### PR TITLE
Refactor ImbiMetadataCache for safe-by-default initialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ pre-commit run --all-files
 - **Utility Actions** (`actions/utility.py`): Helper operations for common workflow tasks
 
 #### Supporting Components
-- **Imbi Metadata Cache** (`imc.py`): Singleton cache (`ImbiMetadataCache`) for Imbi metadata (fact types, project types, environments) with 15-minute TTL
+- **Imbi Metadata Cache** (`imc.py`): Cache (`ImbiMetadataCache`) for Imbi metadata (fact types, project types, environments) with 15-minute TTL, explicitly initialized via async `refresh_from_cache()` method
 - **Git Operations** (`git.py`): Repository cloning, committing, and Git operations
 - **Environment Sync** (`environment_sync.py`): GitHub environment synchronization logic
 - **Condition Checker** (`condition_checker.py`): Workflow condition evaluation system
@@ -126,7 +126,12 @@ hostname = "imbi.example.com"
 
 [claude_code]
 executable = "claude"  # Optional, defaults to 'claude'
+
+# Optional: Override cache directory (default: ~/.cache/imbi-automations)
+cache_dir = "/custom/path/to/cache"
 ```
+
+The `cache_dir` setting can also be overridden via the `--cache-dir` CLI option.
 
 ### Transformation Architecture
 
@@ -499,9 +504,9 @@ The system includes 20 pre-built workflows organized by category:
 ## Key Implementation Details
 
 ### Imbi Metadata Cache System
-The `ImbiMetadataCache` class (`imc.py`) provides singleton caching of Imbi metadata:
+The `ImbiMetadataCache` class (`imc.py`) provides caching of Imbi metadata with safe-by-default empty initialization:
 
-**Cached Data** (stored in `~/.cache/imbi-automations/metadata.json`):
+**Cached Data** (stored in `~/.cache/imbi-automations/metadata.json` by default):
 - **Environments**: All Imbi environments for filter validation
 - **Project Types**: All project type slugs with IDs
 - **Fact Types**: Complete fact type definitions with project_type_ids
@@ -509,16 +514,20 @@ The `ImbiMetadataCache` class (`imc.py`) provides singleton caching of Imbi meta
 - **Fact Type Ranges**: Min/max bounds for range-type facts
 
 **Features**:
+- **Safe by Default**: Cache is always populated (empty collections if not refreshed)
 - **15-minute TTL**: Auto-refreshes when expired
-- **Singleton Pattern**: One cache instance per process
+- **Optional Initialization**: Call `await cache.refresh_from_cache(cache_file, config)` to populate from disk/API
+- **Configurable Cache Location**: Override via `cache_dir` in config TOML or `--cache-dir` CLI option
 - **Parse-Time Validation**: Validates filters before workflow execution
 - **Handles Duplicates**: Multiple fact types with same name (different project types)
-- **Property Access**: `imc.project_type_slugs`, `imc.environments`, `imc.project_fact_type_names`
+- **Property Access**: `cache.project_type_slugs`, `cache.environments`, `cache.project_fact_type_names` (returns empty sets if unpopulated)
 
 **Usage in Validation**:
-- WorkflowFilter validates project_types and project_facts at parse time
+- Cache is refreshed at the start of `Automation.run()` before any validation
+- WorkflowFilter validates project_types and project_facts using the cache
 - Controller validates --project-type CLI argument before processing
 - Provides helpful suggestions for typos
+- If not refreshed, properties return empty sets (graceful degradation)
 
 ### Imbi Fact Management
 Project facts support three validation modes:
@@ -554,7 +563,9 @@ Shell actions use `subprocess_shell` instead of `subprocess_exec` to enable:
 
 **Major Changes**:
 - **GitLab Removal**: Removed all GitLab support (client, models, CLI args) - GitHub-only
-- **IMC Pattern**: Introduced singleton ImbiMetadataCache class for metadata caching
+- **IMC Pattern**: Introduced ImbiMetadataCache class with explicit async initialization for metadata caching
+- **Cache Initialization Fix**: Removed singleton pattern, added explicit `refresh_from_cache()` method called in `Automation.run()`
+- **Configurable Cache Directory**: Added `cache_dir` to Configuration model and `--cache-dir` CLI option
 - **Filter Validation**: Added parse-time validation for project_types, project_facts, and environments
 - **Imbi Actions**: Implemented set_project_fact with full enum/range/free-form support
 - **Shell Execution Fix**: Changed from subprocess_exec to subprocess_shell for glob support
@@ -566,9 +577,10 @@ Shell actions use `subprocess_shell` instead of `subprocess_exec` to enable:
 - **Simpler Codebase**: Removed ~2000 lines of unused GitLab code
 - **Faster Validation**: ImbiMetadataCache enables instant filter validation
 - **Better UX**: Helpful error messages with fuzzy-matched suggestions
-- **Maintainability**: Cleaner separation with IMC handling all Imbi metadata
+- **Maintainability**: Cleaner separation with IMC handling all Imbi metadata, no singleton complexity
 - **Type Safety**: Comprehensive validation at parse time prevents runtime errors
 - **Performance**: 15-minute cache reduces API calls, subprocess_shell enables shell features
+- **Explicit Initialization**: Clear async initialization point eliminates awkward lazy loading
 
 ### External Scheme and Repository Change Tracking (October 2025)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,13 +95,15 @@ Comprehensive workflow definition including:
 
 #### Imbi Metadata Cache (`imc.py`)
 
-Singleton cache (`ImbiMetadataCache`) for Imbi metadata with 15-minute TTL:
+Cache (`ImbiMetadataCache`) for Imbi metadata with 15-minute TTL and safe-by-default design:
 
 - Caches environments, project types, fact types
+- Always initialized with empty collections (no `None` state)
 - Enables parse-time validation of workflow filters
-- Stored in `~/.cache/imbi-automations/metadata.json`
-- Auto-refreshes when expired
+- Stored in `~/.cache/imbi-automations/metadata.json` (configurable)
+- Auto-refreshes when expired via `refresh_from_cache()`
 - Provides fuzzy-matched suggestions for typos
+- Graceful degradation: returns empty sets when unpopulated
 
 #### Actions Dispatcher (`actions/__init__.py`)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,6 +26,7 @@ imbi-automations [-h] [-V] [--debug] [-v]
                  [--exit-on-error]
                  [--preserve-on-error]
                  [--error-dir DIR]
+                 [--cache-dir DIR]
                  [--start-from-project ID_OR_SLUG]
                  (--project-id ID |
                   --project-type SLUG |
@@ -384,6 +385,33 @@ imbi-automations config.toml workflows/test \
         ├── workflow/
         └── debug.log
 ```
+
+### --cache-dir DIR
+
+Specify directory for Imbi metadata cache storage.
+
+**Type:** Directory path
+**Default:** `~/.cache/imbi-automations`
+
+**Example:**
+```bash
+imbi-automations config.toml workflows/update \
+  --all-projects \
+  --cache-dir /tmp/imbi-cache
+```
+
+**Use Cases:**
+
+- Custom cache location for multi-user systems
+- Temporary cache for testing
+- Network-mounted cache for shared environments
+- CI/CD pipeline isolation
+
+**Cache Contents:**
+
+The cache directory will contain `metadata.json` with Imbi metadata including environments, project types, and fact type definitions. This cache is automatically refreshed every 15 minutes.
+
+**See Also:** [Configuration - Imbi Metadata Cache](configuration.md#imbi-metadata-cache)
 
 ### --debug
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,7 +301,7 @@ The ImbiMetadataCache system caches Imbi metadata locally for improved performan
 
 ### Cache Location
 
-**Path:** `~/.cache/imbi-automations/metadata.json`
+**Path:** `~/.cache/imbi-automations/metadata.json` (configurable via `cache_dir` setting or `--cache-dir` CLI option)
 
 **TTL:** 15 minutes
 
@@ -314,12 +314,30 @@ The ImbiMetadataCache system caches Imbi metadata locally for improved performan
 
 ### Cache Behavior
 
-The metadata cache is automatically managed:
+The metadata cache is automatically managed and safe by default:
 
 - **First run**: Fetches all metadata from Imbi API
 - **Subsequent runs**: Uses cached data if less than 15 minutes old
 - **Expired cache**: Auto-refreshes from API
 - **Validation**: Enables parse-time validation of workflow filters
+- **Uninitialized**: Returns empty collections (graceful degradation)
+
+### Configuring Cache Location
+
+Override the default cache directory in configuration:
+
+```toml
+# Optional: Override cache directory
+cache_dir = "/custom/path/to/cache"
+```
+
+Or via CLI option:
+
+```bash
+imbi-automations config.toml workflows/workflow-name \
+  --cache-dir /tmp/imbi-cache \
+  --all-projects
+```
 
 ### Manual Cache Management
 

--- a/src/imbi_automations/cli.py
+++ b/src/imbi_automations/cli.py
@@ -200,6 +200,12 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         '(saved to error-dir/<workflow>/<project>-<timestamp>)',
     )
     parser.add_argument(
+        '--cache-dir',
+        type=pathlib.Path,
+        default=pathlib.Path.home() / '.cache' / 'imbi-automations',
+        help='Directory for caching Imbi metadata',
+    )
+    parser.add_argument(
         '--error-dir',
         type=pathlib.Path,
         default=pathlib.Path('./errors'),
@@ -232,7 +238,9 @@ def main() -> None:
     config = load_configuration(args.config[0])
     args.config[0].close()
 
-    # Override config with CLI args for error preservation
+    # Override config with CLI args
+    if args.cache_dir:
+        config.cache_dir = args.cache_dir
     if args.preserve_on_error:
         config.preserve_on_error = True
     if args.error_dir:

--- a/src/imbi_automations/controller.py
+++ b/src/imbi_automations/controller.py
@@ -60,7 +60,7 @@ class Automation(mixins.WorkflowLoggerMixin):
         self.configuration = config
         self.counter = collections.Counter()
         self.logger = LOGGER
-        self.registry = imc.ImbiMetadataCache.get_instance(config)
+        self.registry = imc.ImbiMetadataCache()
         self.workflow = workflow
         self.workflow_engine = workflow_engine.WorkflowEngine(
             config=self.configuration, workflow=workflow, verbose=args.verbose
@@ -94,6 +94,12 @@ class Automation(mixins.WorkflowLoggerMixin):
             raise ValueError('No valid target argument provided')
 
     async def run(self) -> bool:
+        # Initialize Imbi metadata cache
+        cache_file = self.configuration.cache_dir / 'metadata.json'
+        await self.registry.refresh_from_cache(
+            cache_file, self.configuration.imbi
+        )
+
         self._validate_workflow_filters()
         match self.iterator:
             case AutomationIterator.github_repositories:

--- a/src/imbi_automations/imc.py
+++ b/src/imbi_automations/imc.py
@@ -5,8 +5,6 @@ import datetime
 import json
 import logging
 import pathlib
-import threading
-import typing
 
 import pydantic
 
@@ -18,9 +16,6 @@ LOGGER = logging.getLogger(__name__)
 # Cache configuration
 CACHE_TTL_MINUTES = 15
 
-# Thread-safe singleton lock
-_instance_lock = threading.Lock()
-
 
 class CacheData(pydantic.BaseModel):
     """Cache for data used by the application"""
@@ -28,78 +23,43 @@ class CacheData(pydantic.BaseModel):
     last_updated: datetime.datetime = pydantic.Field(
         default_factory=lambda: datetime.datetime.now(tz=datetime.UTC)
     )
-    environments: list[imbi.ImbiEnvironment]
-    project_fact_types: list[imbi.ImbiProjectFactType]
-    project_fact_type_enums: list[imbi.ImbiProjectFactTypeEnum]
-    project_fact_type_ranges: list[imbi.ImbiProjectFactTypeRange]
-    project_types: list[imbi.ImbiProjectType]
+    environments: list[imbi.ImbiEnvironment] = pydantic.Field(
+        default_factory=list
+    )
+    project_fact_types: list[imbi.ImbiProjectFactType] = pydantic.Field(
+        default_factory=list
+    )
+    project_fact_type_enums: list[imbi.ImbiProjectFactTypeEnum] = (
+        pydantic.Field(default_factory=list)
+    )
+    project_fact_type_ranges: list[imbi.ImbiProjectFactTypeRange] = (
+        pydantic.Field(default_factory=list)
+    )
+    project_types: list[imbi.ImbiProjectType] = pydantic.Field(
+        default_factory=list
+    )
 
 
 class ImbiMetadataCache:
-    """Singleton cache for Imbi metadata with automatic refresh."""
+    """Cache for Imbi metadata with automatic refresh.
 
-    instance: typing.Self | None = None
+    Cache is always populated (empty collections if not refreshed).
+    Call refresh_from_cache() to load data from disk or API.
+    """
 
-    def __init__(self, config: configuration.ImbiConfiguration) -> None:
-        self.cache_data: CacheData | None = None
-        self.cache_file = (
-            pathlib.Path.home()
-            / '.cache'
-            / 'imbi-automations'
-            / 'metadata.json'
-        )
-        self.config = config
-        self.imbi_client: clients.Imbi | None = None
+    def __init__(self) -> None:
+        """Initialize cache instance with empty data.
 
-    @classmethod
-    def get_instance(cls, config: configuration.Configuration) -> typing.Self:
-        """Get or create singleton instance (thread-safe).
-
-        Note: This synchronous method is for backward compatibility.
-        For new code, prefer using async initialization explicitly.
+        Cache starts with empty collections and can be used immediately.
+        Call refresh_from_cache() to populate with actual metadata.
         """
-        if not cls.instance:
-            with _instance_lock:
-                # Double-check pattern to prevent race condition
-                if not cls.instance:
-                    cls.instance = cls(config.imbi)
-                    # Note: Actual data loading is deferred to first use
-                    # to avoid blocking event loop
-                    try:
-                        asyncio.get_running_loop()
-                        # We're in async context - use async init instead
-                        LOGGER.warning(
-                            'get_instance() called from async context. '
-                            'Data will be loaded on first property access.'
-                        )
-                    except RuntimeError:
-                        # No event loop running - load from cache file only
-                        # This avoids event loop lifecycle conflicts
-                        cls.instance._load_from_file_sync()
-        return cls.instance
-
-    def _load_from_file_sync(self) -> None:
-        """Load cache data from file synchronously (no API calls)."""
-        if self.cache_file.exists():
-            with self.cache_file.open('r') as file:
-                try:
-                    self.cache_data = CacheData.model_validate(json.load(file))
-                    LOGGER.debug('Loaded cached Imbi metadata from file')
-                except (json.JSONDecodeError, pydantic.ValidationError) as err:
-                    LOGGER.warning(
-                        'Cache file corrupted, will refresh on first async '
-                        'use: %s',
-                        err,
-                    )
-                    # Delete corrupted cache file
-                    self.cache_file.unlink(missing_ok=True)
-        else:
-            LOGGER.debug('No cache file found, will load on first async use')
+        self.cache_data: CacheData = CacheData()
+        self.cache_file: pathlib.Path | None = None
+        self.config: configuration.ImbiConfiguration | None = None
+        self.imbi_client: clients.Imbi | None = None
 
     def is_cache_expired(self) -> bool:
         """Check if cache has expired (older than CACHE_TTL_MINUTES)."""
-        if not self.cache_data:
-            return True
         age = (
             datetime.datetime.now(tz=datetime.UTC)
             - self.cache_data.last_updated
@@ -133,8 +93,18 @@ class ImbiMetadataCache:
             project_type.slug for project_type in self.cache_data.project_types
         }
 
-    async def _load_data(self) -> None:
-        """Load the Imbi data from the API or cache file."""
+    async def refresh_from_cache(
+        self, cache_file: pathlib.Path, config: configuration.ImbiConfiguration
+    ) -> None:
+        """Initialize and refresh cache from file or API.
+
+        Args:
+            cache_file: Path to the metadata cache file
+            config: Imbi configuration for API access
+
+        """
+        self.cache_file = cache_file
+        self.config = config
         if self.cache_file.exists():
             with self.cache_file.open('r') as file:
                 try:
@@ -155,6 +125,7 @@ class ImbiMetadataCache:
         if not self.imbi_client:
             self.imbi_client = clients.Imbi.get_instance(config=self.config)
 
+        LOGGER.info('Fetching fresh Imbi metadata from API')
         (
             environments,
             project_fact_types,
@@ -179,3 +150,4 @@ class ImbiMetadataCache:
         self.cache_file.parent.mkdir(parents=True, exist_ok=True)
         with self.cache_file.open('w') as file:
             file.write(self.cache_data.model_dump_json())
+        LOGGER.debug('Cached Imbi metadata to %s', self.cache_file)

--- a/src/imbi_automations/models/configuration.py
+++ b/src/imbi_automations/models/configuration.py
@@ -111,6 +111,9 @@ class Configuration(pydantic.BaseModel):
     anthropic: AnthropicConfiguration = pydantic.Field(
         default_factory=AnthropicConfiguration
     )
+    cache_dir: pathlib.Path = (
+        pathlib.Path.home() / '.cache' / 'imbi-automations'
+    )
     claude_code: ClaudeCodeConfiguration = pydantic.Field(
         default_factory=ClaudeCodeConfiguration
     )


### PR DESCRIPTION
## Summary

Refactors the `ImbiMetadataCache` class to use explicit async initialization instead of singleton pattern, eliminating `None` data attributes and providing safe-by-default empty collections.

## Changes

- **Removed singleton pattern**: Eliminated awkward lazy loading and thread safety concerns
- **Explicit initialization**: Added `refresh_from_cache()` async method called in `Automation.run()`
- **Safe by default**: Cache properties now return empty collections instead of `None` when not initialized
- **Configurable cache directory**: Added `cache_dir` to Configuration and `--cache-dir` CLI option
- **Updated documentation**: Comprehensive updates to AGENTS.md, architecture docs, CLI docs, and configuration docs

## Key Benefits

1. **Clearer initialization**: Explicit async call makes initialization point obvious
2. **No None checks**: All properties return typed collections (never `None`)
3. **Graceful degradation**: Cache works (returns empty data) even if not refreshed
4. **Better testability**: Easier to mock and test without singleton state
5. **User control**: Users can override cache location via config or CLI

## Test Plan

- [x] Existing test suite passes (255 tests)
- [x] Cache initialization works with default location
- [x] Cache initialization works with custom `--cache-dir` option
- [x] Properties return empty collections when cache not initialized
- [x] Validation gracefully handles unpopulated cache

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>