### PR TITLE
Use mutable default literals in Pydantic models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,6 +379,7 @@ exclude_github_workflow_status = ["success"]
 - **Import organization**: Use module imports over direct class/function imports
 - **Logging**: Use module-level LOGGER, colored logging for CLI applications
 - **Error handling**: Use specific exception types, include context in log messages
+- **Pydantic defaults**: Use mutable default literals (e.g., `field: list[int] = []`) instead of `Field(default_factory=list)` for Pydantic v2 models
 
 ## Testing Infrastructure
 

--- a/src/imbi_automations/imc.py
+++ b/src/imbi_automations/imc.py
@@ -23,21 +23,11 @@ class CacheData(pydantic.BaseModel):
     last_updated: datetime.datetime = pydantic.Field(
         default_factory=lambda: datetime.datetime.now(tz=datetime.UTC)
     )
-    environments: list[imbi.ImbiEnvironment] = pydantic.Field(
-        default_factory=list
-    )
-    project_fact_types: list[imbi.ImbiProjectFactType] = pydantic.Field(
-        default_factory=list
-    )
-    project_fact_type_enums: list[imbi.ImbiProjectFactTypeEnum] = (
-        pydantic.Field(default_factory=list)
-    )
-    project_fact_type_ranges: list[imbi.ImbiProjectFactTypeRange] = (
-        pydantic.Field(default_factory=list)
-    )
-    project_types: list[imbi.ImbiProjectType] = pydantic.Field(
-        default_factory=list
-    )
+    environments: list[imbi.ImbiEnvironment] = []
+    project_fact_types: list[imbi.ImbiProjectFactType] = []
+    project_fact_type_enums: list[imbi.ImbiProjectFactTypeEnum] = []
+    project_fact_type_ranges: list[imbi.ImbiProjectFactTypeRange] = []
+    project_types: list[imbi.ImbiProjectType] = []
 
 
 class ImbiMetadataCache:

--- a/src/imbi_automations/models/claude.py
+++ b/src/imbi_automations/models/claude.py
@@ -29,4 +29,4 @@ class AgentRun(pydantic.BaseModel):
 
     result: AgentRunResult
     message: str | None = None
-    errors: list[str] = pydantic.Field(default_factory=list)
+    errors: list[str] = []

--- a/src/imbi_automations/models/git.py
+++ b/src/imbi_automations/models/git.py
@@ -2,8 +2,6 @@
 
 import datetime
 
-import pydantic
-
 from . import base
 
 
@@ -28,8 +26,8 @@ class GitCommit(base.BaseModel):
     commit_date: datetime.datetime
     subject: str
     body: str
-    trailers: dict[str, str] = pydantic.Field(default_factory=dict)
-    files_changed: list[GitFileChange] = pydantic.Field(default_factory=list)
+    trailers: dict[str, str] = {}
+    files_changed: list[GitFileChange] = []
 
 
 class GitCommitSummary(base.BaseModel):

--- a/src/imbi_automations/models/imbi.py
+++ b/src/imbi_automations/models/imbi.py
@@ -7,8 +7,6 @@ workflow targeting and context enrichment.
 
 import typing
 
-import pydantic
-
 from . import base
 
 
@@ -88,12 +86,12 @@ class ImbiProjectFactType(base.BaseModel):
     last_modified_by: str | None = None
     name: str
     description: str | None = None
-    project_type_ids: list[int] = pydantic.Field(default_factory=list)
+    project_type_ids: list[int] = []
     fact_type: typing.Literal['enum', 'range', 'free-form']
     data_type: typing.Literal[
         'boolean', 'date', 'decimal', 'integer', 'string', 'timestamp'
     ]
-    ui_options: list[str] = pydantic.Field(default_factory=list)
+    ui_options: list[str] = []
     weight: float = 0.0
 
 

--- a/src/imbi_automations/models/workflow.py
+++ b/src/imbi_automations/models/workflow.py
@@ -50,14 +50,12 @@ class WorkflowFilter(pydantic.BaseModel):
     (lowercase with underscores) to match OpenSearch data format.
     """
 
-    project_ids: set[int] = pydantic.Field(default_factory=set)
-    project_types: set[str] = pydantic.Field(default_factory=set)
-    project_facts: dict[str, str] = pydantic.Field(default_factory=dict)
-    project_environments: set[str] = pydantic.Field(default_factory=set)
+    project_ids: set[int] = set()
+    project_types: set[str] = set()
+    project_facts: dict[str, str] = {}
+    project_environments: set[str] = set()
     github_identifier_required: bool = False
-    github_workflow_status_exclude: set[str] = pydantic.Field(
-        default_factory=set
-    )
+    github_workflow_status_exclude: set[str] = set()
 
 
 class WorkflowActionTypes(enum.StrEnum):
@@ -103,9 +101,7 @@ class WorkflowAction(pydantic.BaseModel):
     type: WorkflowActionTypes = WorkflowActionTypes.callable
     ai_commit: bool = False
     commit_message: str | None = None
-    conditions: list['WorkflowCondition'] = pydantic.Field(
-        default_factory=list
-    )
+    conditions: list['WorkflowCondition'] = []
     condition_type: WorkflowConditionType = WorkflowConditionType.all
     committable: bool = True
     filter: WorkflowFilter | None = None
@@ -113,7 +109,7 @@ class WorkflowAction(pydantic.BaseModel):
     on_failure: str | None = None
     ignore_errors: bool = False
     timeout: int = 3600
-    data: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+    data: dict[str, typing.Any] = {}
 
     @pydantic.model_validator(mode='after')
     def validate_commit_message(self) -> 'WorkflowAction':
@@ -143,8 +139,8 @@ class WorkflowCallableAction(WorkflowAction):
     type: typing.Literal['callable'] = 'callable'
     import_name: str = pydantic.Field(alias='import')
     callable: typing.Callable
-    args: list[typing.Any] = pydantic.Field(default_factory=list)
-    kwargs: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+    args: list[typing.Any] = []
+    kwargs: dict[str, typing.Any] = {}
     ai_commit: bool = True
 
 
@@ -441,8 +437,8 @@ class WorkflowUtilityAction(WorkflowAction):
     type: typing.Literal['utility'] = 'utility'
     command: WorkflowUtilityCommands
     path: ResourceUrl | None = None
-    args: list[typing.Any] = pydantic.Field(default_factory=list)
-    kwargs: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+    args: list[typing.Any] = []
+    kwargs: dict[str, typing.Any] = {}
 
 
 WorkflowActions = typing.Annotated[
@@ -612,8 +608,8 @@ class WorkflowConfiguration(pydantic.BaseModel):
     use_devcontainers: bool = False
 
     condition_type: WorkflowConditionType = WorkflowConditionType.all
-    conditions: list[WorkflowCondition] = pydantic.Field(default_factory=list)
-    actions: list[WorkflowActions] = pydantic.Field(default_factory=list)
+    conditions: list[WorkflowCondition] = []
+    actions: list[WorkflowActions] = []
 
 
 class WorkflowActionResult(pydantic.BaseModel):


### PR DESCRIPTION
## Summary
- Replace `Field(default_factory=list)` with mutable default literals (`field: list[int] = []`) in Pydantic v2 models
- Simplifies model definitions by using Pydantic v2's native support for mutable defaults
- Updates models in `imc.py`, `claude.py`, `git.py`, `imbi.py`, and `workflow.py`
- Updates AGENTS.md to document the new code style standard

## Test plan
- [ ] Verify all existing tests pass
- [ ] Confirm Pydantic models initialize correctly with empty collections
- [ ] Validate that default values are not shared between instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)