### PR TITLE
Use last modified date of cache file

### DIFF
--- a/src/imbi_automations/imc.py
+++ b/src/imbi_automations/imc.py
@@ -107,8 +107,15 @@ class ImbiMetadataCache:
         self.config = config
         if self.cache_file.exists():
             with self.cache_file.open('r') as file:
+                st = self.cache_file.stat()
+                last_mod = datetime.datetime.fromtimestamp(
+                    st.st_mtime, tz=datetime.UTC
+                )
+
                 try:
-                    self.cache_data = CacheData.model_validate(json.load(file))
+                    data = json.load(file)
+                    data['last_updated'] = last_mod
+                    self.cache_data = CacheData.model_validate(data)
                 except (json.JSONDecodeError, pydantic.ValidationError) as err:
                     LOGGER.warning(
                         'Cache file corrupted, regenerating: %s', err


### PR DESCRIPTION
## Summary

- Fixes cache validation logic to use the cache file's last modified timestamp instead of relying on potentially missing or corrupted `last_updated` field in the cached JSON data
- Ensures that cached metadata is properly validated against the 15-minute TTL even when the JSON payload doesn't include a timestamp

## Implementation Details

When reading cached metadata from disk, the system now:
1. Retrieves the file's `st_mtime` (last modification time) via `stat()`
2. Converts it to a timezone-aware datetime in UTC
3. Overrides the `last_updated` field in the loaded JSON data before validation

This approach is more robust because:
- File modification time is always available from the filesystem
- Eliminates dependency on correctly serialized timestamp in JSON
- Prevents cache validation failures due to missing/corrupted timestamp fields

## Test plan

- [ ] Verify cache is properly validated with 15-minute TTL
- [ ] Test with existing cache files that may have missing `last_updated` fields
- [ ] Confirm cache regeneration works correctly when expired
- [ ] Run test suite to ensure no regressions

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)