### PR TITLE
Fix hash contract violation in BaseModel

### DIFF
--- a/src/imbi_automations/models/base.py
+++ b/src/imbi_automations/models/base.py
@@ -4,6 +4,8 @@ Provides base Pydantic model class with hashability and equality comparison
 based on model content, used across all API response models.
 """
 
+import json
+
 import pydantic
 
 
@@ -11,11 +13,13 @@ class BaseModel(pydantic.BaseModel):
     """Base model with hash and equality support.
 
     Enables models to be used in sets and as dict keys by implementing
-    __hash__ based on JSON serialization and __eq__ based on field values.
+    __hash__ based on JSON serialization with sorted keys and __eq__ based
+    on field values. Sorting keys ensures that two instances with identical
+    content produce the same hash regardless of dict key insertion order.
     """
 
     def __hash__(self) -> int:
-        return hash(self.model_dump_json())
+        return hash(json.dumps(self.model_dump(), sort_keys=True))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -548,6 +548,70 @@ packages = ["my.package"]
             utils.python_init_file_path(self.context)
         self.assertIn('Could not find __init__.py', str(ctx.exception))
 
+    def test_imbi_project_hash_contract(self) -> None:
+        # Two ImbiProject instances with identical content but different
+        # dict key ordering should have equal hashes since they compare
+        # as equal. This verifies the hash invariant: a == b implies
+        # hash(a) == hash(b).
+        #
+        # Create two projects with same data but different dict key order
+        project1 = models.ImbiProject(
+            id=123,
+            dependencies=None,
+            description='Test project',
+            environments=None,
+            facts={'language': 'Python', 'framework': 'FastAPI'},
+            identifiers={'github': 'org/repo', 'jira': 'PROJ'},
+            links={'docs': 'https://example.com', 'wiki': 'https://wiki.com'},
+            name='test-project',
+            namespace='test-namespace',
+            namespace_slug='test-namespace',
+            project_score=None,
+            project_type='API',
+            project_type_slug='api',
+            slug='test-project',
+            urls={
+                'prod': 'https://prod.com',
+                'staging': 'https://staging.com',
+            },
+            imbi_url='https://imbi.example.com/projects/123',
+        )
+
+        # Same data, but dict keys in different order
+        project2 = models.ImbiProject(
+            id=123,
+            dependencies=None,
+            description='Test project',
+            environments=None,
+            facts={'framework': 'FastAPI', 'language': 'Python'},
+            identifiers={'jira': 'PROJ', 'github': 'org/repo'},
+            links={'wiki': 'https://wiki.com', 'docs': 'https://example.com'},
+            name='test-project',
+            namespace='test-namespace',
+            namespace_slug='test-namespace',
+            project_score=None,
+            project_type='API',
+            project_type_slug='api',
+            slug='test-project',
+            urls={
+                'staging': 'https://staging.com',
+                'prod': 'https://prod.com',
+            },
+            imbi_url='https://imbi.example.com/projects/123',
+        )
+
+        # Verify equality works correctly (should be True)
+        self.assertEqual(
+            project1, project2, 'Projects with same data should be equal'
+        )
+
+        # Hash contract: a == b must imply hash(a) == hash(b)
+        self.assertEqual(
+            hash(project1),
+            hash(project2),
+            'Equal projects must have equal hashes (hash invariant)',
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes a critical hash contract violation in `BaseModel` where models containing dict fields could violate Python's hash invariant: if `a == b`, then `hash(a)` must equal `hash(b)`.

## Problem

The previous implementation used `model_dump_json()` for hashing, which preserves Python 3.7+ dict insertion order. This caused two `ImbiProject` instances with identical content but different dict key ordering to:
- Compare as **equal** (`project1 == project2` → `True`)
- Have **different hashes** (`hash(project1) != hash(project2)`)

This made models unsafe for use in sets or as dict keys.

## Solution

Changed `__hash__` to use `json.dumps(self.model_dump(), sort_keys=True)` to ensure deterministic key ordering regardless of dict insertion order.

## Impact

This fixes the hash contract for all models inheriting from the custom `BaseModel`:
- `ImbiProject` (with `facts`, `identifiers`, `links`, `urls` dicts)
- `GitHubRepository` (with `custom_properties` dict)
- `GitHubPullRequest` (with `head`, `base` dicts)
- `GitCommit` (with `trailers` dict)
- All other GitHub, Imbi, and Git models

## Test Plan

- ✅ Added `test_imbi_project_hash_contract()` to verify the fix
- ✅ All 292 existing tests pass
- ✅ Pre-commit hooks pass