### PR TITLE
Add dry-run mode for safe workflow testing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,8 @@ imbi-automations config.toml workflows/workflow-name --all-projects
 # Global Settings
 ai_commits = false
 commit_author = "Imbi Automations <noreply@example.com>"
+dry_run = false
+dry_run_dir = "./dry-runs"
 error_dir = "./errors"
 preserve_on_error = false
 
@@ -95,6 +97,70 @@ When `true`, temporary directories are not cleaned up after failures, allowing m
 ```toml
 preserve_on_error = true
 ```
+
+### dry_run
+
+Execute workflows without pushing changes or creating pull requests.
+
+**Type:** `boolean`
+**Default:** `false`
+
+When enabled, workflows execute completely (clone, actions, commits) but skip remote operations:
+
+```toml
+dry_run = true
+```
+
+**Behavior:**
+- ✓ Clones repositories
+- ✓ Runs all actions
+- ✓ Makes file changes
+- ✓ Creates commits locally
+- ✗ Skips pushing to remote
+- ✗ Skips creating pull requests
+
+**Use Cases:**
+- Testing new workflows safely
+- Validating changes before production runs
+- Reviewing commit messages and diffs
+- Training and demonstration
+- CI/CD validation pipelines
+
+Working directories are preserved to `dry_run_dir` for inspection.
+
+**Note:** Can be overridden by `--dry-run` CLI flag.
+
+### dry_run_dir
+
+Directory for saving repository state during dry-run executions.
+
+**Type:** `path`
+**Default:** `"./dry-runs"`
+
+```toml
+dry_run_dir = "./review-changes"
+```
+
+**Directory Structure:**
+```
+./review-changes/
+└── workflow-name/
+    └── project-slug-timestamp/
+        ├── repository/    # Full git repository with commits
+        ├── workflow/      # Workflow files and templates
+        └── extracted/     # Docker extracted files (if any)
+```
+
+**Example Inspection:**
+```bash
+# View commits that would have been pushed
+cd ./dry-runs/update-deps/my-project-20250103-143052/repository
+git log -1
+git show HEAD
+git diff HEAD~1
+```
+
+**Note:** Can be overridden by `--dry-run-dir` CLI flag.
 
 ## Anthropic Configuration
 
@@ -540,6 +606,23 @@ api_key = "${GITHUB_TOKEN}"
 api_key = "${IMBI_API_KEY}"
 hostname = "imbi.example.com"
 ```
+
+### With Dry Run Mode
+
+```toml
+# Enable dry-run globally for safe testing
+dry_run = true
+dry_run_dir = "./review-changes"
+
+[github]
+api_key = "${GITHUB_TOKEN}"
+
+[imbi]
+api_key = "${IMBI_API_KEY}"
+hostname = "imbi.example.com"
+```
+
+All workflows will execute but skip pushing and PR creation. Review changes in `./review-changes/` before disabling dry-run mode.
 
 ## Troubleshooting
 

--- a/src/imbi_automations/cli.py
+++ b/src/imbi_automations/cli.py
@@ -200,10 +200,22 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         '(saved to error-dir/<workflow>/<project>-<timestamp>)',
     )
     parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Save repository state to dry-run-dir instead of pushing '
+        'changes or creating pull requests',
+    )
+    parser.add_argument(
         '--cache-dir',
         type=pathlib.Path,
         default=pathlib.Path.home() / '.cache' / 'imbi-automations',
         help='Directory for caching Imbi metadata',
+    )
+    parser.add_argument(
+        '--dry-run-dir',
+        type=pathlib.Path,
+        default=pathlib.Path('./dry-runs'),
+        help='Directory to save repository state when --dry-run is used',
     )
     parser.add_argument(
         '--error-dir',
@@ -245,6 +257,10 @@ def main() -> None:
         config.preserve_on_error = True
     if args.error_dir:
         config.error_dir = args.error_dir
+    if args.dry_run:
+        config.dry_run = True
+    if args.dry_run_dir:
+        config.dry_run_dir = args.dry_run_dir
 
     LOGGER.info('Imbi Automations v%s starting', version)
     try:

--- a/src/imbi_automations/models/configuration.py
+++ b/src/imbi_automations/models/configuration.py
@@ -118,6 +118,8 @@ class Configuration(pydantic.BaseModel):
         default_factory=ClaudeCodeConfiguration
     )
     commit_author: str = 'Imbi Automations <noreply@aweber.com>'
+    dry_run: bool = False
+    dry_run_dir: pathlib.Path = pathlib.Path('./dry-runs')
     error_dir: pathlib.Path = pathlib.Path('./errors')
     git: GitConfiguration = pydantic.Field(default_factory=GitConfiguration)
     github: GitHubConfiguration | None = None


### PR DESCRIPTION
## Summary

Adds dry-run mode that executes workflows completely but skips remote operations (push and PR creation). This enables safe testing and validation of workflows without affecting remote repositories.

## Changes

- Add `dry_run` and `dry_run_dir` configuration fields
- Add `--dry-run` and `--dry-run-dir` CLI arguments
- Implement dry-run execution that preserves working directory for inspection
- Refactor working directory preservation logic for reuse
- Add comprehensive documentation for dry-run mode

## Configuration

Dry-run can be enabled via TOML configuration:

```toml
dry_run = true
dry_run_dir = "./review-changes"
```

Or via CLI arguments (which override config):

```bash
imbi-automations config.toml workflows/update --all-projects --dry-run
```

## Behavior

When dry-run mode is enabled:
- ✓ Clones repositories
- ✓ Runs all workflow actions
- ✓ Makes file changes
- ✓ Creates commits locally
- ✗ Skips pushing to remote
- ✗ Skips creating pull requests

Working directories are preserved to `dry_run_dir` for inspection.

## Use Cases

- Testing new workflows before production deployment
- Validating changes and reviewing commits/diffs
- Training and demonstration purposes
- CI/CD validation pipelines
- Debugging workflow logic safely

## Inspection

After a dry-run, inspect the results:

```bash
cd ./dry-runs/workflow-name/project-slug-timestamp/repository
git log -1
git show HEAD
git diff HEAD~1
```

## Test Plan

- [x] Configuration model accepts dry_run fields
- [x] CLI arguments parse correctly
- [x] Workflow engine skips push/PR when dry_run enabled
- [x] Working directory preserved to correct location
- [x] Documentation updated with examples

Co-authored-by: Claude <noreply@anthropic.com>