### PR TITLE
Implement callable action, minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !/.pre-commit-config.yaml
 /build
 /dist
+/dry-runs
 /env
 /errors
 /.venv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ pre-commit run --all-files
 - **Validators** (`models/validators.py`): Pydantic field validators
 
 #### Actions Layer (under `actions/`)
-- **Callable Actions** (`actions/callablea.py`): Direct method calls on client instances with dynamic kwargs
+- **Callable Actions** (`actions/callablea.py`): Direct Python function/method invocation with async support, template rendering, and dynamic args/kwargs
 - **Claude Actions** (`actions/claude.py`): AI-powered transformations using Claude Code SDK
 - **Docker Actions** (`actions/docker.py`): Docker container operations and file extractions
 - **File Actions** (`actions/filea.py`): File manipulation (copy with glob support, move, delete, regex replacement)
@@ -137,7 +137,7 @@ The `cache_dir` setting can also be overridden via the `--cache-dir` CLI option.
 
 The system supports multiple transformation types through the workflow action system:
 
-1. **Callable Actions** (`actions/callablea.py`): Direct method calls on client instances with dynamic kwargs
+1. **Callable Actions** (`actions/callablea.py`): Direct Python function/method invocation with async support, template rendering, and dynamic args/kwargs
 2. **Claude Actions** (`actions/claude.py`): Complex multi-file analysis and transformation using Claude Code SDK
 3. **Docker Actions** (`actions/docker.py`): Container-based file extraction and manipulation
 4. **File Actions** (`actions/filea.py`): Direct file manipulation (copy with glob patterns, move, delete, regex replacement)

--- a/docs/actions/callable.md
+++ b/docs/actions/callable.md
@@ -169,9 +169,9 @@ args = [42, "hello"]
 [[actions]]
 name = "create-directory"
 type = "callable"
-callable = "pathlib:Path.mkdir"
+callable = "os:makedirs"
 args = ["{{ working_directory }}/output"]
-kwargs = {parents = true, exist_ok = true}
+kwargs = {exist_ok = true}
 committable = false
 ```
 
@@ -213,7 +213,7 @@ kwargs = {
 [[actions]]
 name = "update-project-fact"
 type = "callable"
-callable = "imbi_automations.clients.imbi:Imbi.set_fact"
+callable = "imbi_automations.clients.imbi:Imbi.set_project_fact"
 args = [
     123,                             # project_id (literal)
     "{{ workflow.slug }}",           # fact_name (template)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,7 @@ Workflow condition evaluation:
 
 Specialized action handlers:
 
-- **Callable** (`actions/callablea.py`): Direct method calls on clients
+- **Callable** (`actions/callablea.py`): Direct Python function/method invocation with async support and template rendering
 - **Claude** (`actions/claude.py`): AI-powered transformations via Claude Code SDK
 - **Docker** (`actions/docker.py`): Container operations and file extraction
 - **File** (`actions/filea.py`): Copy (with globs), move, delete, regex replacement
@@ -187,16 +187,15 @@ type = "claude"
 ### Action Types
 
 #### 1. Callable Actions
-Direct method calls on client instances:
+Direct Python function/method invocation with async support:
 ```toml
 [[actions]]
+name = "update-fact"
 type = "callable"
-[actions.value]
-client = "github"
-method = "create_pull_request"
-[actions.value.kwargs]
-title = "{{ workflow_name }}"
-body = "Automated update"
+callable = "imbi_automations.clients.imbi:Imbi.set_fact"
+args = [123, "deployment_status", "completed"]
+kwargs = {notes = "{{ workflow.name }} finished"}
+ai_commit = true
 ```
 
 #### 2. Claude Code Integration

--- a/src/imbi_automations/actions/callablea.py
+++ b/src/imbi_automations/actions/callablea.py
@@ -1,6 +1,9 @@
 """Callable operations for workflow execution."""
 
-from imbi_automations import mixins, models
+import asyncio
+import typing
+
+from imbi_automations import mixins, models, prompts, utils
 
 
 class CallableAction(mixins.WorkflowLoggerMixin):
@@ -22,4 +25,28 @@ class CallableAction(mixins.WorkflowLoggerMixin):
         self.context = context
 
     async def execute(self, action: models.WorkflowCallableAction) -> None:
-        raise NotImplementedError('Callable actions not yet supported')
+        """Execute a callable action based on provided configuration."""
+        args = [self._process_arg(arg) for arg in action.args]
+        kwargs = {
+            key: self._process_arg(value)
+            for key, value in action.kwargs.items()
+        }
+        self.logger.debug(
+            'Executing %s(%r, %r)', action.callable, args, kwargs
+        )
+        try:
+            if asyncio.iscoroutinefunction(action.callable):
+                await action.callable(*args, **kwargs)
+            else:
+                action.callable(*args, **kwargs)
+        except Exception as exc:
+            self.logger.exception('Error invoking callable: %s', exc)
+            raise RuntimeError(str(exc)) from exc
+
+    def _process_arg(self, arg: typing.Any) -> typing.Any:
+        """Process an argument for use in a callable."""
+        if isinstance(arg, str) and prompts.has_template_syntax(arg):
+            arg = prompts.render(self.context, template=arg)
+        if utils.has_path_scheme(arg):
+            return utils.resolve_path(self.context, arg)
+        return arg

--- a/src/imbi_automations/claude.py
+++ b/src/imbi_automations/claude.py
@@ -127,6 +127,7 @@ class Claude(mixins.WorkflowLoggerMixin):
             ],
             cwd=self.context.working_directory,
             mcp_servers={'agent_tools': agent_tools},
+            model=self.configuration.claude_code.model,
             settings=str(settings),
             setting_sources=['local'],
             system_prompt=types.SystemPromptPreset(

--- a/src/imbi_automations/models/configuration.py
+++ b/src/imbi_automations/models/configuration.py
@@ -24,7 +24,7 @@ class AnthropicConfiguration(pydantic.BaseModel):
         default=os.environ.get('ANTHROPIC_API_KEY')
     )
     bedrock: bool = False
-    model: str = pydantic.Field(default='claude-4-5-haiku')
+    model: str = 'claude-4-5-haiku'
 
 
 class GitConfiguration(pydantic.BaseModel):

--- a/src/imbi_automations/models/configuration.py
+++ b/src/imbi_automations/models/configuration.py
@@ -24,7 +24,7 @@ class AnthropicConfiguration(pydantic.BaseModel):
         default=os.environ.get('ANTHROPIC_API_KEY')
     )
     bedrock: bool = False
-    model: str = pydantic.Field(default='claude-3-5-haiku-latest')
+    model: str = pydantic.Field(default='claude-4-5-haiku')
 
 
 class GitConfiguration(pydantic.BaseModel):
@@ -82,13 +82,14 @@ class ImbiConfiguration(pydantic.BaseModel):
 class ClaudeCodeConfiguration(pydantic.BaseModel):
     """Claude Code SDK configuration.
 
-    Configures the Claude Code executable path, base prompt file, and
-    whether AI-powered transformations are enabled for workflows.
+    Configures the Claude Code executable path, base prompt file, model
+    selection, and whether AI-powered transformations are enabled.
     """
 
     executable: str = 'claude'  # Claude Code executable path
     base_prompt: pathlib.Path | None = None
     enabled: bool = True
+    model: str = pydantic.Field(default='claude-sonnet-4-5')
 
     def __init__(self, **kwargs: typing.Any) -> None:
         super().__init__(**kwargs)

--- a/src/imbi_automations/models/workflow.py
+++ b/src/imbi_automations/models/workflow.py
@@ -137,8 +137,7 @@ class WorkflowCallableAction(WorkflowAction):
     """
 
     type: typing.Literal['callable'] = 'callable'
-    import_name: str = pydantic.Field(alias='import')
-    callable: typing.Callable
+    callable: pydantic.ImportString  # Expects "module.path:function_name"
     args: list[typing.Any] = []
     kwargs: dict[str, typing.Any] = {}
     ai_commit: bool = True

--- a/src/imbi_automations/models/workflow.py
+++ b/src/imbi_automations/models/workflow.py
@@ -182,7 +182,7 @@ class WorkflowDockerAction(validators.CommandRulesMixin, WorkflowAction):
     image: str
     tag: str = 'latest'
     path: ResourceUrl | None = None
-    source: pathlib.Path | None = None
+    source: str | pathlib.Path | None = None
     destination: ResourceUrl | None = None
     committable: bool = False
 
@@ -473,11 +473,11 @@ class WorkflowCondition(validators.ExclusiveGroupsMixin, pydantic.BaseModel):
     absence, and content matching with glob patterns and regex support.
     """
 
-    file_exists: ResourceUrl | None = None
-    file_not_exists: ResourceUrl | None = None
+    file_exists: ResourceUrl | str | None = None
+    file_not_exists: ResourceUrl | str | None = None
     file_contains: str | None = None
     file_doesnt_contain: str | None = None
-    file: ResourceUrl | None = None
+    file: ResourceUrl | str | None = None
 
     remote_client: WorkflowConditionRemoteClient = (
         WorkflowConditionRemoteClient.github

--- a/src/imbi_automations/prompts.py
+++ b/src/imbi_automations/prompts.py
@@ -90,8 +90,8 @@ def render_file(
 
 
 def render_path(
-    context: models.WorkflowContext, path: pydantic.AnyUrl
-) -> pydantic.AnyUrl:
+    context: models.WorkflowContext, path: pydantic.AnyUrl | str
+) -> pydantic.AnyUrl | str:
     if isinstance(path, pydantic.AnyUrl):
         path_str = parse.unquote(path.path)
     elif isinstance(path, str):

--- a/src/imbi_automations/prompts.py
+++ b/src/imbi_automations/prompts.py
@@ -92,11 +92,19 @@ def render_file(
 def render_path(
     context: models.WorkflowContext, path: pydantic.AnyUrl
 ) -> pydantic.AnyUrl:
-    path_str = parse.unquote(path.path)
+    if isinstance(path, pydantic.AnyUrl):
+        path_str = parse.unquote(path.path)
+    elif isinstance(path, str):
+        path_str = path
+    else:
+        raise TypeError(f'Invalid path type: {type(path)}')
     if has_template_syntax(path_str):
         value = render(context, template=path_str)
         LOGGER.debug('Rendered path: %s', value)
-        return models.ResourceUrl(f'{path.scheme}://{value}')
+        if isinstance(path, pydantic.AnyUrl):
+            return models.ResourceUrl(f'{path.scheme}://{value}')
+        else:
+            return value
     return path
 
 

--- a/src/imbi_automations/utils.py
+++ b/src/imbi_automations/utils.py
@@ -216,10 +216,15 @@ def extract_package_name_from_pyproject(
 
 def has_path_scheme(path: models.ResourceUrl | pathlib.Path | str) -> bool:
     """Check if a path has a scheme."""
-    for scheme in {'external', 'extracted', 'file', 'repository', 'workflow'}:
-        if str(path).startswith(f'{scheme}://'):
-            return True
-    return False
+    return str(path).startswith(
+        (
+            'external://',
+            'extracted://',
+            'file://',
+            'repository://',
+            'workflow://',
+        )
+    )
 
 
 def load_toml(toml_file: typing.TextIO) -> dict:

--- a/src/imbi_automations/utils.py
+++ b/src/imbi_automations/utils.py
@@ -207,6 +207,14 @@ def extract_package_name_from_pyproject(
         raise RuntimeError(f'Failed to extract package name: {err}') from err
 
 
+def has_path_scheme(path: models.ResourceUrl | pathlib.Path | str) -> bool:
+    """Check if a path has a scheme."""
+    for scheme in {'external', 'extracted', 'file', 'repository', 'workflow'}:
+        if str(path).startswith(f'{scheme}://'):
+            return True
+    return False
+
+
 def load_toml(toml_file: typing.TextIO) -> dict:
     """Load TOML data from a file-like object
 

--- a/tests/actions/test_callable.py
+++ b/tests/actions/test_callable.py
@@ -1,0 +1,656 @@
+"""Comprehensive tests for the callablea module."""
+
+import asyncio
+import pathlib
+import tempfile
+import typing
+import unittest
+from unittest import mock
+
+from imbi_automations import models
+from imbi_automations.actions import callablea
+from tests import base
+
+
+# Test fixtures - sample callables
+def sync_function(arg1: int, arg2: str, keyword_arg: str = 'default') -> str:
+    """Sample synchronous function for testing."""
+    return f'{arg1}-{arg2}-{keyword_arg}'
+
+
+async def async_function(
+    arg1: int, arg2: str, keyword_arg: str = 'default'
+) -> str:
+    """Sample asynchronous function for testing."""
+    await asyncio.sleep(0.001)  # Simulate async work
+    return f'{arg1}-{arg2}-{keyword_arg}'
+
+
+def failing_function() -> None:
+    """Function that always raises an exception."""
+    raise ValueError('Intentional test failure')
+
+
+async def async_failing_function() -> None:
+    """Async function that always raises an exception."""
+    await asyncio.sleep(0.001)
+    raise ValueError('Intentional async test failure')
+
+
+def type_sensitive_function(
+    int_arg: int, str_arg: str, bool_arg: bool, float_arg: float
+) -> dict:
+    """Function that requires specific types."""
+    return {
+        'int': (int_arg, type(int_arg).__name__),
+        'str': (str_arg, type(str_arg).__name__),
+        'bool': (bool_arg, type(bool_arg).__name__),
+        'float': (float_arg, type(float_arg).__name__),
+    }
+
+
+class CallableActionTestCase(base.AsyncTestCase):
+    """Test cases for CallableAction functionality."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.working_directory = pathlib.Path(self.temp_dir.name)
+
+        # Create mock workflow and context
+        self.workflow = models.Workflow(
+            path=pathlib.Path('/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow', actions=[]
+            ),
+        )
+
+        self.context = models.WorkflowContext(
+            workflow=self.workflow,
+            imbi_project=models.ImbiProject(
+                id=123,
+                dependencies=None,
+                description='Test project',
+                environments=None,
+                facts=None,
+                identifiers=None,
+                links=None,
+                name='test-project',
+                namespace='test-namespace',
+                namespace_slug='test-namespace',
+                project_score=None,
+                project_type='API',
+                project_type_slug='api',
+                slug='test-project',
+                urls=None,
+                imbi_url='https://imbi.example.com/projects/123',
+            ),
+            working_directory=self.working_directory,
+        )
+
+        self.configuration = models.Configuration(
+            github=models.GitHubConfiguration(api_key='test-key'),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+
+        self.callable_executor = callablea.CallableAction(
+            self.configuration, self.context, verbose=True
+        )
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self.temp_dir.cleanup()
+
+    async def test_execute_sync_callable_no_args(self) -> None:
+        """Test execution of synchronous callable with no arguments."""
+        mock_callable = mock.Mock(return_value='success')
+
+        action = models.WorkflowCallableAction(
+            name='test-sync-no-args', type='callable', callable=mock_callable
+        )
+
+        await self.callable_executor.execute(action)
+
+        mock_callable.assert_called_once_with()
+
+    async def test_execute_sync_callable_with_args(self) -> None:
+        """Test execution of synchronous callable with positional args."""
+        mock_callable = mock.Mock(return_value='result')
+
+        action = models.WorkflowCallableAction(
+            name='test-sync-args',
+            type='callable',
+            callable=mock_callable,
+            args=[42, 'hello', True],
+        )
+
+        await self.callable_executor.execute(action)
+
+        mock_callable.assert_called_once_with(42, 'hello', True)
+
+    async def test_execute_sync_callable_with_kwargs(self) -> None:
+        """Test execution of synchronous callable with keyword arguments."""
+        mock_callable = mock.Mock(return_value='result')
+
+        action = models.WorkflowCallableAction(
+            name='test-sync-kwargs',
+            type='callable',
+            callable=mock_callable,
+            kwargs={'name': 'test', 'count': 5, 'enabled': True},
+        )
+
+        await self.callable_executor.execute(action)
+
+        mock_callable.assert_called_once_with(
+            name='test', count=5, enabled=True
+        )
+
+    async def test_execute_sync_callable_with_args_and_kwargs(self) -> None:
+        """Test execution of synchronous callable with both args and kwargs."""
+        mock_callable = mock.Mock(return_value='result')
+
+        action = models.WorkflowCallableAction(
+            name='test-sync-mixed',
+            type='callable',
+            callable=mock_callable,
+            args=[1, 2, 3],
+            kwargs={'multiplier': 10, 'offset': 5},
+        )
+
+        await self.callable_executor.execute(action)
+
+        mock_callable.assert_called_once_with(1, 2, 3, multiplier=10, offset=5)
+
+    async def test_execute_async_callable_no_args(self) -> None:
+        """Test execution of asynchronous callable with no arguments."""
+        mock_callable = mock.AsyncMock(return_value='async_success')
+
+        action = models.WorkflowCallableAction(
+            name='test-async-no-args', type='callable', callable=mock_callable
+        )
+
+        await self.callable_executor.execute(action)
+
+        mock_callable.assert_awaited_once_with()
+
+    async def test_execute_async_callable_with_args(self) -> None:
+        """Test execution of asynchronous callable with arguments."""
+        mock_callable = mock.AsyncMock(return_value='async_result')
+
+        action = models.WorkflowCallableAction(
+            name='test-async-args',
+            type='callable',
+            callable=mock_callable,
+            args=[99, 'async', False],
+        )
+
+        await self.callable_executor.execute(action)
+
+        mock_callable.assert_awaited_once_with(99, 'async', False)
+
+    async def test_execute_templated_args(self) -> None:
+        """Test execution with Jinja2-templated positional arguments."""
+        mock_callable = mock.Mock(return_value='success')
+
+        action = models.WorkflowCallableAction(
+            name='test-templated-args',
+            type='callable',
+            callable=mock_callable,
+            args=[
+                '{{ imbi_project.name }}',
+                '{{ imbi_project.id }}',
+                '{{ workflow.slug }}',
+            ],
+        )
+
+        await self.callable_executor.execute(action)
+
+        # Template rendering converts to strings
+        mock_callable.assert_called_once_with('test-project', '123', 'test')
+
+    async def test_execute_templated_kwargs(self) -> None:
+        """Test execution with Jinja2-templated keyword arguments."""
+        mock_callable = mock.Mock(return_value='success')
+
+        action = models.WorkflowCallableAction(
+            name='test-templated-kwargs',
+            type='callable',
+            callable=mock_callable,
+            kwargs={
+                'project_name': '{{ imbi_project.name }}',
+                'project_slug': '{{ imbi_project.slug }}',
+                'project_type': '{{ imbi_project.project_type }}',
+            },
+        )
+
+        await self.callable_executor.execute(action)
+
+        mock_callable.assert_called_once_with(
+            project_name='test-project',
+            project_slug='test-project',
+            project_type='API',
+        )
+
+    async def test_execute_mixed_templated_and_literal_args(self) -> None:
+        """Test execution with mix of templated and literal arguments."""
+        mock_callable = mock.Mock(return_value='success')
+
+        action = models.WorkflowCallableAction(
+            name='test-mixed',
+            type='callable',
+            callable=mock_callable,
+            args=[
+                42,  # Literal int
+                '{{ imbi_project.name }}',  # Templated string
+                True,  # Literal bool
+                'literal-string',  # Literal string
+            ],
+            kwargs={
+                'count': 10,  # Literal int
+                'name': '{{ imbi_project.slug }}',  # Templated
+                'enabled': False,  # Literal bool
+            },
+        )
+
+        await self.callable_executor.execute(action)
+
+        mock_callable.assert_called_once_with(
+            42,
+            'test-project',
+            True,
+            'literal-string',
+            count=10,
+            name='test-project',
+            enabled=False,
+        )
+
+    async def test_execute_preserves_arg_order(self) -> None:
+        """Test that positional argument order is preserved."""
+        result_list: list = []
+
+        def order_sensitive_function(*args: typing.Any) -> None:
+            result_list.extend(args)
+
+        action = models.WorkflowCallableAction(
+            name='test-order',
+            type='callable',
+            callable=order_sensitive_function,
+            args=['first', 'second', 'third', 'fourth', 'fifth'],
+        )
+
+        await self.callable_executor.execute(action)
+
+        # Verify order is preserved
+        self.assertEqual(
+            result_list, ['first', 'second', 'third', 'fourth', 'fifth']
+        )
+
+    async def test_execute_sync_callable_raises_exception(self) -> None:
+        """Test exception handling for synchronous callable failures."""
+        action = models.WorkflowCallableAction(
+            name='test-sync-fail', type='callable', callable=failing_function
+        )
+
+        with self.assertRaises(RuntimeError) as exc_context:
+            await self.callable_executor.execute(action)
+
+        # Verify the RuntimeError wraps the original exception
+        self.assertEqual(
+            str(exc_context.exception), 'Intentional test failure'
+        )
+        self.assertIsInstance(exc_context.exception.__cause__, ValueError)
+
+    async def test_execute_async_callable_raises_exception(self) -> None:
+        """Test exception handling for asynchronous callable failures."""
+        action = models.WorkflowCallableAction(
+            name='test-async-fail',
+            type='callable',
+            callable=async_failing_function,
+        )
+
+        with self.assertRaises(RuntimeError) as exc_context:
+            await self.callable_executor.execute(action)
+
+        # Verify the RuntimeError wraps the original exception
+        self.assertEqual(
+            str(exc_context.exception), 'Intentional async test failure'
+        )
+        self.assertIsInstance(exc_context.exception.__cause__, ValueError)
+
+    async def test_execute_with_non_string_types(self) -> None:
+        """Test that non-string types are not template-rendered."""
+        mock_callable = mock.Mock(return_value='success')
+
+        action = models.WorkflowCallableAction(
+            name='test-types',
+            type='callable',
+            callable=mock_callable,
+            args=[
+                123,  # int
+                45.67,  # float
+                True,  # bool
+                None,  # None
+                ['list', 'of', 'items'],  # list
+                {'key': 'value'},  # dict
+            ],
+        )
+
+        await self.callable_executor.execute(action)
+
+        # Verify non-string types are passed as-is
+        mock_callable.assert_called_once_with(
+            123, 45.67, True, None, ['list', 'of', 'items'], {'key': 'value'}
+        )
+
+    async def test_execute_empty_args_and_kwargs(self) -> None:
+        """Test execution with empty args and kwargs (defaults)."""
+        mock_callable = mock.Mock(return_value='success')
+
+        action = models.WorkflowCallableAction(
+            name='test-empty',
+            type='callable',
+            callable=mock_callable,
+            args=[],
+            kwargs={},
+        )
+
+        await self.callable_executor.execute(action)
+
+        mock_callable.assert_called_once_with()
+
+    async def test_execute_string_without_template_syntax(self) -> None:
+        """Test that strings without template syntax are not rendered."""
+        mock_callable = mock.Mock(return_value='success')
+
+        action = models.WorkflowCallableAction(
+            name='test-no-template',
+            type='callable',
+            callable=mock_callable,
+            args=['plain string', 'another plain string'],
+            kwargs={
+                'key1': 'value without templates',
+                'key2': 'just a normal string',
+            },
+        )
+
+        await self.callable_executor.execute(action)
+
+        # Strings without template syntax should pass through unchanged
+        mock_callable.assert_called_once_with(
+            'plain string',
+            'another plain string',
+            key1='value without templates',
+            key2='just a normal string',
+        )
+
+    async def test_execute_callable_with_complex_template_expression(
+        self,
+    ) -> None:
+        """Test execution with complex Jinja2 expressions."""
+        mock_callable = mock.Mock(return_value='success')
+
+        action = models.WorkflowCallableAction(
+            name='test-complex-template',
+            type='callable',
+            callable=mock_callable,
+            args=[
+                '{{ imbi_project.namespace }}/{{ imbi_project.name }}',
+                '{{ imbi_project.id | int }}',
+                (
+                    '{% if imbi_project.id > 100 %}'
+                    'large{% else %}small{% endif %}'
+                ),
+            ],
+        )
+
+        await self.callable_executor.execute(action)
+
+        mock_callable.assert_called_once_with(
+            'test-namespace/test-project', '123', 'large'
+        )
+
+    async def test_execute_logs_debug_message(self) -> None:
+        """Test that execution logs debug message with callable and args."""
+        mock_callable = mock.Mock(return_value='success')
+
+        action = models.WorkflowCallableAction(
+            name='test-logging',
+            type='callable',
+            callable=mock_callable,
+            args=[1, 2],
+            kwargs={'key': 'value'},
+        )
+
+        with mock.patch.object(
+            self.callable_executor, 'logger'
+        ) as mock_logger:
+            await self.callable_executor.execute(action)
+
+            # Verify debug logging occurred
+            mock_logger.debug.assert_called_once()
+            call_args = mock_logger.debug.call_args[0]
+            self.assertIn('Executing', call_args[0])
+
+    async def test_execute_logs_exception_on_failure(self) -> None:
+        """Test that exceptions are logged before re-raising."""
+        action = models.WorkflowCallableAction(
+            name='test-logging-exception',
+            type='callable',
+            callable=failing_function,
+        )
+
+        with mock.patch.object(
+            self.callable_executor, 'logger'
+        ) as mock_logger:
+            with self.assertRaises(RuntimeError):
+                await self.callable_executor.execute(action)
+
+            # Verify exception logging occurred
+            mock_logger.exception.assert_called_once()
+            call_args = mock_logger.exception.call_args[0]
+            self.assertIn('Error invoking callable', call_args[0])
+
+    async def test_callable_return_value_not_captured(self) -> None:
+        """Test that return values from callables are not captured.
+
+        This is by design - CallableAction executes for side effects,
+        not return values.
+        """
+
+        def callable_with_return() -> str:
+            return 'important_result'
+
+        action = models.WorkflowCallableAction(
+            name='test-return', type='callable', callable=callable_with_return
+        )
+
+        # Execute and verify it doesn't raise, but return value is lost
+        result = await self.callable_executor.execute(action)
+
+        # Execute returns None by design
+        self.assertIsNone(result)
+
+    async def test_execute_real_async_function(self) -> None:
+        """Test execution with real async function (not mocked)."""
+        action = models.WorkflowCallableAction(
+            name='test-real-async',
+            type='callable',
+            callable=async_function,
+            args=[42, 'test'],
+            kwargs={'keyword_arg': 'custom'},
+        )
+
+        # Should complete without raising
+        await self.callable_executor.execute(action)
+
+    async def test_execute_real_sync_function(self) -> None:
+        """Test execution with real sync function (not mocked)."""
+        action = models.WorkflowCallableAction(
+            name='test-real-sync',
+            type='callable',
+            callable=sync_function,
+            args=[99, 'hello'],
+            kwargs={'keyword_arg': 'world'},
+        )
+
+        # Should complete without raising
+        await self.callable_executor.execute(action)
+
+    async def test_asyncio_detection_for_sync_function(self) -> None:
+        """Test that sync functions are correctly identified."""
+        # Test with real sync function
+        self.assertFalse(asyncio.iscoroutinefunction(sync_function))
+
+        # Create action and execute
+        action = models.WorkflowCallableAction(
+            name='test-sync-detection',
+            type='callable',
+            callable=sync_function,
+            args=[1, 'test'],
+        )
+
+        # Should execute without trying to await
+        await self.callable_executor.execute(action)
+
+    async def test_asyncio_detection_for_async_function(self) -> None:
+        """Test that async functions are correctly identified."""
+        # Test with real async function
+        self.assertTrue(asyncio.iscoroutinefunction(async_function))
+
+        # Create action and execute
+        action = models.WorkflowCallableAction(
+            name='test-async-detection',
+            type='callable',
+            callable=async_function,
+            args=[1, 'test'],
+        )
+
+        # Should await properly
+        await self.callable_executor.execute(action)
+
+    async def test_execute_with_resourceurl_args(self) -> None:
+        """Test execution with ResourceUrl arguments that get resolved."""
+        mock_callable = mock.Mock(return_value='success')
+
+        # Create repository directory
+        repo_dir = self.working_directory / 'repository'
+        repo_dir.mkdir()
+        test_file = repo_dir / 'config.yaml'
+        test_file.write_text('config: test')
+
+        action = models.WorkflowCallableAction(
+            name='test-resourceurl',
+            type='callable',
+            callable=mock_callable,
+            args=[
+                models.ResourceUrl('repository:///config.yaml'),
+                'literal-string',
+            ],
+        )
+
+        await self.callable_executor.execute(action)
+
+        # Verify ResourceUrl was resolved to pathlib.Path
+        call_args = mock_callable.call_args[0]
+        self.assertIsInstance(call_args[0], pathlib.Path)
+        self.assertEqual(call_args[0], repo_dir / 'config.yaml')
+        self.assertEqual(call_args[1], 'literal-string')
+
+    async def test_execute_with_resourceurl_kwargs(self) -> None:
+        """Test execution with ResourceUrl in keyword arguments."""
+        mock_callable = mock.Mock(return_value='success')
+
+        # Create extracted directory for testing
+        extracted_dir = self.working_directory / 'extracted'
+        extracted_dir.mkdir(exist_ok=True)
+        extracted_file = extracted_dir / 'data.csv'
+        extracted_file.write_text('col1,col2\nval1,val2')
+
+        action = models.WorkflowCallableAction(
+            name='test-resourceurl-kwargs',
+            type='callable',
+            callable=mock_callable,
+            kwargs={
+                'data_path': models.ResourceUrl('extracted:///data.csv'),
+                'count': 42,
+            },
+        )
+
+        await self.callable_executor.execute(action)
+
+        # Verify ResourceUrl was resolved in kwargs
+        call_kwargs = mock_callable.call_args[1]
+        self.assertIsInstance(call_kwargs['data_path'], pathlib.Path)
+        self.assertEqual(call_kwargs['data_path'], extracted_file)
+        self.assertEqual(call_kwargs['count'], 42)
+
+    async def test_execute_with_mixed_resourceurl_and_templates(self) -> None:
+        """Test execution with both ResourceUrl and template strings."""
+        mock_callable = mock.Mock(return_value='success')
+
+        # Create test files
+        repo_dir = self.working_directory / 'repository'
+        repo_dir.mkdir(exist_ok=True)
+        (repo_dir / 'data.json').write_text('{}')
+
+        action = models.WorkflowCallableAction(
+            name='test-mixed',
+            type='callable',
+            callable=mock_callable,
+            args=[
+                models.ResourceUrl('repository:///data.json'),
+                '{{ imbi_project.name }}',  # Template
+                42,  # Literal
+            ],
+        )
+
+        await self.callable_executor.execute(action)
+
+        call_args = mock_callable.call_args[0]
+        # ResourceUrl resolved to Path
+        self.assertIsInstance(call_args[0], pathlib.Path)
+        # Template rendered to string
+        self.assertEqual(call_args[1], 'test-project')
+        # Literal preserved
+        self.assertEqual(call_args[2], 42)
+
+    async def test_execute_with_multiple_resourceurl_schemes(self) -> None:
+        """Test execution with different ResourceUrl schemes."""
+        mock_callable = mock.Mock(return_value='success')
+
+        # Create directories for different schemes
+        (self.working_directory / 'repository').mkdir(exist_ok=True)
+        (self.working_directory / 'extracted').mkdir(exist_ok=True)
+
+        (self.working_directory / 'repository' / 'input.txt').write_text(
+            'input'
+        )
+        (self.working_directory / 'extracted' / 'output.txt').write_text(
+            'output'
+        )
+
+        action = models.WorkflowCallableAction(
+            name='test-multiple-schemes',
+            type='callable',
+            callable=mock_callable,
+            args=[
+                models.ResourceUrl('repository:///input.txt'),
+                models.ResourceUrl('extracted:///output.txt'),
+            ],
+        )
+
+        await self.callable_executor.execute(action)
+
+        call_args = mock_callable.call_args[0]
+        self.assertEqual(
+            call_args[0], self.working_directory / 'repository' / 'input.txt'
+        )
+        self.assertEqual(
+            call_args[1], self.working_directory / 'extracted' / 'output.txt'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,293 @@
+"""Tests for prompts module."""
+
+import pathlib
+import tempfile
+import unittest
+
+import pydantic
+
+from imbi_automations import models, prompts
+
+
+class RenderPathTestCase(unittest.TestCase):
+    """Tests for render_path function."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.working_dir = pathlib.Path(self.temp_dir.name)
+        self.workflow = models.Workflow(
+            path=pathlib.Path('/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow', actions=[]
+            ),
+        )
+        self.context = models.WorkflowContext(
+            workflow=self.workflow,
+            imbi_project=models.ImbiProject(
+                id=123,
+                dependencies=None,
+                description='Test project',
+                environments=None,
+                facts=None,
+                identifiers=None,
+                links=None,
+                name='test-project',
+                namespace='test-namespace',
+                namespace_slug='test-namespace',
+                project_score=None,
+                project_type='API',
+                project_type_slug='api',
+                slug='test-project',
+                urls=None,
+                imbi_url='https://imbi.example.com/projects/123',
+            ),
+            working_directory=self.working_dir,
+        )
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures."""
+        self.temp_dir.cleanup()
+
+    def test_render_path_with_string_without_templates(self) -> None:
+        """Test render_path with plain string (no templates)."""
+        path = 'simple/path.txt'
+        result = prompts.render_path(self.context, path)
+        self.assertEqual(result, 'simple/path.txt')
+        self.assertIsInstance(result, str)
+
+    def test_render_path_with_string_with_templates(self) -> None:
+        """Test render_path with string containing template syntax."""
+        path = 'path/{{ workflow.configuration.name }}/file.txt'
+        result = prompts.render_path(self.context, path)
+        self.assertEqual(result, 'path/test-workflow/file.txt')
+        self.assertIsInstance(result, str)
+
+    def test_render_path_with_anyurl_without_templates(self) -> None:
+        """Test render_path with AnyUrl (no templates)."""
+        path = models.ResourceUrl('repository:///simple/path.txt')
+        result = prompts.render_path(self.context, path)
+        self.assertEqual(result, path)
+        self.assertIsInstance(result, pydantic.AnyUrl)
+
+    def test_render_path_with_anyurl_with_templates(self) -> None:
+        """Test render_path with AnyUrl containing templates."""
+        path = models.ResourceUrl(
+            'repository:///path/'
+            '%7B%7B%20workflow.configuration.name%20%7D%7D/file.txt'
+        )
+        result = prompts.render_path(self.context, path)
+        self.assertEqual(
+            str(result), 'repository:///path/test-workflow/file.txt'
+        )
+        self.assertIsInstance(result, pydantic.AnyUrl)
+
+    def test_render_path_with_invalid_type(self) -> None:
+        """Test render_path raises TypeError for invalid types."""
+        with self.assertRaises(TypeError) as cm:
+            prompts.render_path(self.context, 123)  # type: ignore
+        self.assertIn('Invalid path type', str(cm.exception))
+
+    def test_render_path_string_with_conditional_template(self) -> None:
+        """Test render_path with string containing conditional template."""
+        path = (
+            'path/{% if workflow.configuration.name %}'
+            '{{ workflow.configuration.name }}{% endif %}'
+        )
+        result = prompts.render_path(self.context, path)
+        self.assertEqual(result, 'path/test-workflow')
+
+    def test_render_path_string_with_comment_template(self) -> None:
+        """Test render_path with string containing comment template."""
+        path = 'path/{# comment #}file.txt'
+        result = prompts.render_path(self.context, path)
+        self.assertEqual(result, 'path/file.txt')
+
+
+class HasTemplateSyntaxTestCase(unittest.TestCase):
+    """Tests for has_template_syntax function."""
+
+    def test_has_template_syntax_with_variable(self) -> None:
+        """Test detection of variable syntax."""
+        self.assertTrue(prompts.has_template_syntax('{{ variable }}'))
+
+    def test_has_template_syntax_with_control_structure(self) -> None:
+        """Test detection of control structure syntax."""
+        self.assertTrue(prompts.has_template_syntax('{% if condition %}'))
+
+    def test_has_template_syntax_with_comment(self) -> None:
+        """Test detection of comment syntax."""
+        self.assertTrue(prompts.has_template_syntax('{# comment #}'))
+
+    def test_has_template_syntax_without_templates(self) -> None:
+        """Test no false positives on plain text."""
+        self.assertFalse(prompts.has_template_syntax('plain text'))
+
+    def test_has_template_syntax_with_partial_syntax(self) -> None:
+        """Test no false positives on partial syntax."""
+        self.assertFalse(prompts.has_template_syntax('single { brace'))
+        self.assertFalse(prompts.has_template_syntax('text with % sign'))
+
+
+class RenderTestCase(unittest.TestCase):
+    """Tests for render function."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.working_dir = pathlib.Path(self.temp_dir.name)
+        self.workflow = models.Workflow(
+            path=pathlib.Path('/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow', actions=[]
+            ),
+        )
+        self.context = models.WorkflowContext(
+            workflow=self.workflow,
+            imbi_project=models.ImbiProject(
+                id=123,
+                dependencies=None,
+                description='Test project',
+                environments=None,
+                facts=None,
+                identifiers=None,
+                links=None,
+                name='test-project',
+                namespace='test-namespace',
+                namespace_slug='test-namespace',
+                project_score=None,
+                project_type='API',
+                project_type_slug='api',
+                slug='test-project',
+                urls=None,
+                imbi_url='https://imbi.example.com/projects/123',
+            ),
+            working_directory=self.working_dir,
+        )
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures."""
+        self.temp_dir.cleanup()
+
+    def test_render_with_template_string(self) -> None:
+        """Test render with template string."""
+        result = prompts.render(
+            self.context, template='Hello {{ workflow.configuration.name }}'
+        )
+        self.assertEqual(result, 'Hello test-workflow')
+
+    def test_render_with_source_path(self) -> None:
+        """Test render with source path."""
+        template_file = self.working_dir / 'template.txt'
+        template_file.write_text(
+            'Name: {{ workflow.configuration.name }}', encoding='utf-8'
+        )
+        result = prompts.render(self.context, source=template_file)
+        self.assertEqual(result, 'Name: test-workflow')
+
+    def test_render_without_source_or_template_raises(self) -> None:
+        """Test render raises ValueError without source or template."""
+        with self.assertRaises(ValueError) as cm:
+            prompts.render(self.context)
+        self.assertIn('source or template is required', str(cm.exception))
+
+    def test_render_with_both_source_and_template_raises(self) -> None:
+        """Test render raises ValueError with both source and template."""
+        with self.assertRaises(ValueError) as cm:
+            prompts.render(
+                self.context, source='path', template='{{ variable }}'
+            )
+        self.assertIn(
+            'You can not specify both source and template', str(cm.exception)
+        )
+
+    def test_render_with_kwargs(self) -> None:
+        """Test render with additional kwargs."""
+        result = prompts.render(
+            self.context,
+            template='{{ custom_var }}',
+            custom_var='custom_value',
+        )
+        self.assertEqual(result, 'custom_value')
+
+    def test_render_without_context(self) -> None:
+        """Test render without context."""
+        result = prompts.render(template='Static template')
+        self.assertEqual(result, 'Static template')
+
+    def test_render_with_anyurl_source(self) -> None:
+        """Test render with AnyUrl source."""
+        # Create a template file
+        template_file = self.working_dir / 'template.txt'
+        template_file.write_text(
+            'URL: {{ workflow.configuration.name }}', encoding='utf-8'
+        )
+
+        # Create ResourceUrl pointing to the template
+        source_url = models.ResourceUrl(
+            f'file:///{template_file.relative_to(self.working_dir)}'
+        )
+        result = prompts.render(self.context, source=source_url)
+        self.assertEqual(result, 'URL: test-workflow')
+
+    def test_render_with_string_source_raises_runtime_error(self) -> None:
+        """Test render with string source raises RuntimeError."""
+        with self.assertRaises(RuntimeError) as cm:
+            prompts.render(self.context, source='invalid-string')
+        self.assertIn('source is not a Path object', str(cm.exception))
+
+
+class RenderFileTestCase(unittest.TestCase):
+    """Tests for render_file function."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.working_dir = pathlib.Path(self.temp_dir.name)
+        self.workflow = models.Workflow(
+            path=pathlib.Path('/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow', actions=[]
+            ),
+        )
+        self.context = models.WorkflowContext(
+            workflow=self.workflow,
+            imbi_project=models.ImbiProject(
+                id=123,
+                dependencies=None,
+                description='Test project',
+                environments=None,
+                facts=None,
+                identifiers=None,
+                links=None,
+                name='test-project',
+                namespace='test-namespace',
+                namespace_slug='test-namespace',
+                project_score=None,
+                project_type='API',
+                project_type_slug='api',
+                slug='test-project',
+                urls=None,
+                imbi_url='https://imbi.example.com/projects/123',
+            ),
+            working_directory=self.working_dir,
+        )
+
+    def tearDown(self) -> None:
+        """Clean up test fixtures."""
+        self.temp_dir.cleanup()
+
+    def test_render_file(self) -> None:
+        """Test render_file creates output file with rendered content."""
+        source = self.working_dir / 'source.txt'
+        source.write_text(
+            'Hello {{ workflow.configuration.name }}', encoding='utf-8'
+        )
+        destination = self.working_dir / 'output.txt'
+
+        prompts.render_file(self.context, source, destination)
+
+        self.assertTrue(destination.exists())
+        self.assertEqual(
+            destination.read_text(encoding='utf-8'), 'Hello test-workflow'
+        )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -14,8 +14,8 @@ class PromptsTestBase(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.temp_dir_name = self.enterContext(tempfile.TemporaryDirectory())
-        self.working_dir = pathlib.Path(self.temp_dir.name)
+        self.temp_dir = self.enterContext(tempfile.TemporaryDirectory())
+        self.working_dir = pathlib.Path(self.temp_dir)
         self.workflow = models.Workflow(
             path=pathlib.Path('/workflows/test'),
             configuration=models.WorkflowConfiguration(
@@ -44,10 +44,6 @@ class PromptsTestBase(unittest.TestCase):
             ),
             working_directory=self.working_dir,
         )
-
-    def tearDown(self) -> None:
-        """Clean up test fixtures."""
-        self.temp_dir.cleanup()
 
 
 class RenderPathTestCase(PromptsTestBase):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -14,7 +14,7 @@ class PromptsTestBase(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir_name = self.enterContext(tempfile.TemporaryDirectory())
         self.working_dir = pathlib.Path(self.temp_dir.name)
         self.workflow = models.Workflow(
             path=pathlib.Path('/workflows/test'),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 
 import pathlib
 import tempfile
+import textwrap
 import unittest
 
 from imbi_automations import models, utils

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -222,9 +222,10 @@ WORKDIR /app
 
     def test_extract_image_from_dockerfile_with_resource_url(self) -> None:
         """Test extracting Docker image using ResourceUrl scheme."""
-        dockerfile_content = """FROM alpine:3.18
-RUN apk add --no-cache python3
-"""
+        dockerfile_content = textwrap.dedent("""
+           FROM alpine:3.18
+           RUN apk add --no-cache python3
+        """)
         # Create in repository subdirectory
         repo_dir = self.temp_path / 'repository'
         repo_dir.mkdir()


### PR DESCRIPTION
## Summary

  This PR implements the callable action type, enabling workflows to invoke Python functions/methods directly with advanced template rendering and path resolution capabilities. The implementation
  includes comprehensive test coverage, improved ResourceUrl handling, and configurable Claude Code model selection.

  ## Key Features

  ### Callable Action Implementation
  - Direct Python function/method invocation using Pydantic ImportString format (`module.path:function_name`)
  - Automatic async/sync detection and execution
  - Jinja2 template rendering for args and kwargs with full workflow context
  - ResourceUrl path resolution for file arguments (supports `repository:///`, `workflow:///`, `extracted:///`, `file:///`, `external:///`)
  - Proper exception wrapping with original exceptions preserved as `__cause__`

  ### Enhanced Path Handling
  - Added `has_path_scheme()` utility to detect ResourceUrl schemes
  - Extended `resolve_path()` to support ResourceUrl objects with default_scheme parameter
  - Updated `extract_image_from_dockerfile()` to accept ResourceUrl, Path, and str types
  - Simplified Docker extract action path handling using direct ResourceUrl extraction

  ### Prompts Module Improvements
  - Added string path support to `render_path()` function alongside AnyUrl
  - Returns rendered strings for string paths with templates
  - Returns ResourceUrl objects for AnyUrl paths with templates
  - Added comprehensive test coverage (21 tests, 100% branch coverage)

  ### Model Enhancements
  - Extended WorkflowCondition fields (`source`, `file_exists`, `file_not_exists`, `file`) to accept `str | pathlib.Path | ResourceUrl`
  - Added configurable Claude Code model selection in ClaudeCodeConfiguration (default: claude-sonnet-4-5)
  - Updated AnthropicConfiguration default model to claude-4-5-haiku

  ### Documentation
  - Complete rewrite of `docs/actions/callable.md` (511 lines) with examples, best practices, and migration guide
  - Updated `docs/architecture.md` with callable action implementation details
  - Updated `AGENTS.md` with accurate callable action descriptions

  ## Test Coverage

  - **27 new callable action tests** covering sync/async execution, template rendering, ResourceUrl resolution, error handling
  - **21 new prompts module tests** achieving 100% branch coverage
  - **5 new utils tests** for ResourceUrl path handling
  - All existing tests passing

  ## Changes Summary

  14 files changed, 1516 insertions(+), 121 deletions(-)

  ### Modified Files
  - `src/imbi_automations/actions/callablea.py` - Full callable action implementation
  - `src/imbi_automations/actions/docker.py` - Simplified path handling
  - `src/imbi_automations/claude.py` - Configurable model support
  - `src/imbi_automations/models/configuration.py` - Added model field to ClaudeCodeConfiguration
  - `src/imbi_automations/models/workflow.py` - Extended WorkflowCondition field types
  - `src/imbi_automations/prompts.py` - Added string path support
  - `src/imbi_automations/utils.py` - Enhanced ResourceUrl handling

  ### Test Files
  - `tests/actions/test_callable.py` - 656 lines of comprehensive callable tests
  - `tests/test_prompts.py` - 293 lines of prompts module tests
  - `tests/test_utils.py` - 64 lines added for ResourceUrl tests

  ### Documentation
  - `docs/actions/callable.md` - Complete rewrite (492 lines)
  - `docs/architecture.md` - Updated with implementation details
  - `AGENTS.md` - Accurate callable action descriptions

  ### Configuration
  - `.gitignore` - Exclude /dry-runs directory

  ## Usage Example

  ```toml
  [[actions]]
  name = "extract-docker-image"
  type = "callable"
  callable = "imbi_automations.utils:extract_image_from_dockerfile"
  args = ["repository:///Dockerfile"]

  [[actions]]
  name = "custom-processing"
  type = "callable"
  callable = "my_module:process_project"
  kwargs = {
      project_name = "{{ imbi_project.name }}",
      config_file = "repository:///config.yaml"
  }
  ```