### PR TITLE
Add git commit signing configuration for Claude Code actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,11 +128,25 @@ hostname = "imbi.example.com"
 [claude_code]
 executable = "claude"  # Optional, defaults to 'claude'
 
+[git]
+# Optional: Configure commit signing for Claude Code actions
+# When enabled, git commits made by Claude Code will be signed
+gpg_sign = true                    # Enable commit signing (default: false)
+gpg_format = "ssh"                 # Format: 'gpg', 'ssh', 'x509', 'openpgp' (required for SSH signing)
+signing_key = "ssh-ed25519 AAAA..."  # Your SSH public key or GPG key ID
+ssh_program = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign"  # SSH signing program (for SSH format)
+# gpg_program = "gpg"              # GPG program path (for GPG format)
+
 # Optional: Override cache directory (default: ~/.cache/imbi-automations)
 cache_dir = "/custom/path/to/cache"
 ```
 
 The `cache_dir` setting can also be overridden via the `--cache-dir` CLI option.
+
+**Git Signing Configuration:**
+- **SSH Signing** (1Password, ssh-agent): Set `gpg_sign=true`, `gpg_format="ssh"`, provide your SSH public key in `signing_key`, and optionally specify `ssh_program` for custom signing programs like 1Password's op-ssh-sign.
+- **GPG Signing**: Set `gpg_sign=true`, `gpg_format="gpg"` (or omit, as GPG is the default), provide your GPG key ID in `signing_key`, and optionally specify `gpg_program` path.
+- **Note**: Git signing configuration only applies to commits made by Claude Code actions. Manual git operations and commits made through other actions use the standard git configuration.
 
 ### Transformation Architecture
 

--- a/src/imbi_automations/models/configuration.py
+++ b/src/imbi_automations/models/configuration.py
@@ -30,10 +30,16 @@ class AnthropicConfiguration(pydantic.BaseModel):
 class GitConfiguration(pydantic.BaseModel):
     """Git configuration for repository operations.
 
-    Controls git commit behavior including additional arguments for signing.
+    Controls git commit behavior including signing with GPG or SSH keys.
+    Supports multiple signing formats: 'gpg', 'ssh', 'x509', 'openpgp'.
     """
 
     commit_args: str = ''
+    gpg_sign: bool = False
+    gpg_format: str | None = None
+    signing_key: str | None = None
+    ssh_program: str | None = None
+    gpg_program: str | None = None
 
 
 class GitHubConfiguration(pydantic.BaseModel):


### PR DESCRIPTION
## Summary

This PR enables commit signing for Claude Code actions by adding git configuration options to the Configuration model and passing them to the Claude Agent SDK via the settings.json file.

## Problem

Claude Code actions were not signing commits because the SDK was configured with `setting_sources=['local']`, which excludes global git configuration. This was intentional to isolate automated workflows from user environment, but prevented commit signing.

## Solution

Add explicit git signing configuration to the Configuration model and inject it into the Claude Code settings.json file when enabled. This maintains workflow isolation while enabling commit signing.

## Changes

- **GitConfiguration model** (`src/imbi_automations/models/configuration.py`):
  - `gpg_sign`: Enable/disable commit signing
  - `gpg_format`: Signing format (gpg, ssh, x509, openpgp)
  - `signing_key`: SSH public key or GPG key ID
  - `ssh_program`: Path to SSH signing program (e.g., 1Password op-ssh-sign)
  - `gpg_program`: Path to GPG program (optional)

- **Claude.py** (`src/imbi_automations/claude.py`):
  - Updated `_initialize_working_directory()` to generate git configuration in settings.json when `gpg_sign=true`
  - Maintains isolation from global git config while enabling signing

- **Documentation** (`AGENTS.md`):
  - Added configuration examples for both SSH signing (1Password, ssh-agent) and GPG signing
  - Documented all new configuration fields

## Configuration Example

```toml
[git]
# Optional: Configure commit signing for Claude Code actions
gpg_sign = true                    # Enable commit signing (default: false)
gpg_format = "ssh"                 # Format: 'gpg', 'ssh', 'x509', 'openpgp' (required for SSH signing)
signing_key = "ssh-ed25519 AAAA..."  # Your SSH public key or GPG key ID
ssh_program = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign"  # SSH signing program (for SSH format)
```

## Testing

- All 374 tests pass
- Linting checks pass
- No breaking changes to existing functionality

## Technical Details

**For SSH Signing (1Password, ssh-agent):**
- Requires `gpg_format="ssh"` (critical - without this git tries GPG and fails)
- Public key in `signing_key`
- Optional `ssh_program` for custom signing programs

**For GPG Signing:**
- `gpg_format="gpg"` (or omit, as GPG is default)
- GPG key ID in `signing_key`
- Optional `gpg_program` path

**Settings.json structure:**
```json
{
  "git": {
    "commit": {"gpgsign": true},
    "gpg": {
      "format": "ssh",
      "ssh": {"program": "/path/to/op-ssh-sign"}
    },
    "user": {"signingkey": "ssh-ed25519 AAAA..."}
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-24 16:50:58 UTC

<h3>Greptile Summary</h3>


This PR adds git commit signing configuration for Claude Code actions by introducing new optional fields to the `GitConfiguration` model and injecting them into Claude Code's `settings.json` when enabled.

**Key Changes:**
- Added 5 optional fields to `GitConfiguration`: `gpg_sign`, `gpg_format`, `signing_key`, `ssh_program`, and `gpg_program`
- Modified `claude.py` to generate git configuration in `settings.json` when `gpg_sign=true`
- Updated documentation with comprehensive examples for both SSH signing (1Password, ssh-agent) and GPG signing

**Implementation:**
The code properly constructs the nested git configuration structure with conditional checks to avoid overwriting the `gpg` dict. The configuration only applies to Claude Code actions, maintaining isolation from global git config while enabling signing.

**Testing:**
All 374 tests pass with no breaking changes.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with low risk - adds optional configuration without breaking existing functionality
- Score reflects well-structured implementation with proper defaults and documentation. One minor consideration: no validation ensures required fields are set together (e.g., SSH signing needs both gpg_format and signing_key), but this is acceptable as git will fail gracefully with clear error messages
- No files require special attention - implementation is straightforward and well-documented

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/models/configuration.py | 5/5 | Added 5 optional git signing fields to GitConfiguration model - all properly typed with defaults |
| src/imbi_automations/claude.py | 4/5 | Added git config injection logic to settings.json generation - handles SSH and GPG signing with proper nested dict construction |
| AGENTS.md | 5/5 | Added comprehensive documentation for git signing configuration with examples for SSH and GPG signing |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->