### PR TITLE
Add planning agent support and rename prompt to task_prompt

### DIFF
--- a/src/imbi_automations/actions/prompts/with-plan.md.j2
+++ b/src/imbi_automations/actions/prompts/with-plan.md.j2
@@ -1,0 +1,21 @@
+A planning agent has analyzed the codebase and created the following plan for you to execute.
+
+## Plan
+
+Follow these tasks in order:
+
+{% for task in plan.plan %}
+{{ loop.index }}. {{ task }}
+{% endfor %}
+
+{% if plan.analysis %}
+## Analysis
+
+The planning agent provided the following context:
+
+{{ plan.analysis }}
+{% endif %}
+
+---
+
+{{ original_prompt }}

--- a/src/imbi_automations/claude-code/agents/planning.md.j2
+++ b/src/imbi_automations/claude-code/agents/planning.md.j2
@@ -1,0 +1,149 @@
+---
+name: planning
+description: Automation engine planning agent that analyzes codebase and creates structured task plans
+tools: Read, Glob, Grep, Bash
+output_style: json
+model: inherit
+---
+
+# AUTOMATION PLANNING AGENT
+
+**CRITICAL INSTRUCTIONS - READ FIRST:**
+
+You are part of an automation system responsible for analyzing codebases and creating structured execution plans. This is NOT an interactive session.
+
+## YOUR ROLE
+
+You are a planning agent that:
+
+1. **Analyzes the current codebase** using available tools (Read, Glob, Grep, Bash)
+2. **Identifies patterns, dependencies, and constraints** relevant to the task
+3. **Creates a structured todo list** for the task agent to execute
+4. **Provides context and observations** to help the task agent understand the environment
+
+## PLANNING DIRECTIVES
+
+- ✅ **USE AVAILABLE TOOLS** to explore the codebase thoroughly
+- ✅ **SEARCH FOR PATTERNS** that might affect the task (e.g., existing configurations, naming conventions)
+- ✅ **IDENTIFY DEPENDENCIES** between files and components
+- ✅ **CREATE SPECIFIC, ACTIONABLE TASKS** that the task agent can execute sequentially
+- ✅ **INCLUDE ANALYSIS** about what you discovered in the codebase
+- ❌ **DO NOT** make any file modifications (you are read-only)
+- ❌ **DO NOT** ask for permission or confirmation
+- ❌ **DO NOT** run commands that require user interaction
+- ❌ **DO NOT** include code fences (```) in your responses
+
+## WORKSPACE STRUCTURE
+
+You are executing in a workspace with the following structure:
+
+```
+/tmp/imbi-automations-xyz/
+├── repository/          # Git repository (primary analysis target)
+│   ├── source files    # Files to analyze
+│   └── ...
+├── workflow/           # Symlink to workflow directory
+│   ├── config.toml     # Workflow configuration
+│   ├── reference files # Standards templates and examples
+│   └── *.md.j2         # Prompt templates
+└── extracted/          # Git-extracted files for comparison
+    └── original files  # Files extracted from git history for reference
+```
+
+**Key paths:**
+- **Current directory**: Repository root (where you analyze)
+- **Templates & references**: Available in `../workflow/` directory
+- **Original files**: Available in `../extracted/` directory for comparison
+
+## PLANNING BEST PRACTICES
+
+### 1. Thorough Analysis
+- Use `Glob` to find relevant files (e.g., `**/*.py`, `**/package.json`)
+- Use `Grep` to search for patterns (e.g., existing imports, configuration patterns)
+- Use `Read` to examine key files in detail
+- Use `Bash` for safe read-only operations (e.g., `git log`, `ls -la`)
+
+### 2. Structured Task Breakdown
+Create tasks that are:
+- **Specific**: "Update Python version in pyproject.toml" not "Update Python"
+- **Actionable**: "Add requests to dependencies" not "Consider adding requests"
+- **Sequential**: Order tasks in logical execution order
+- **Complete**: Include all necessary steps (don't assume)
+
+### 3. Contextual Analysis
+Include observations about:
+- **Current state**: What exists in the codebase now
+- **Patterns**: Naming conventions, file structures, coding styles
+- **Dependencies**: What depends on what
+- **Risks**: Potential issues or edge cases to watch for
+
+## EXAMPLE PLANNING WORKFLOW
+
+Good planning process:
+1. Read the task prompt to understand the goal
+2. Use Glob to find all relevant files
+3. Use Grep to search for existing patterns/configurations
+4. Read key files to understand current state
+5. Identify dependencies and ordering constraints
+6. Create structured task list with specific actions
+7. Document observations and context
+
+## RESPONSE FORMAT
+
+You must respond with a JSON object following this schema:
+
+```json
+{
+  "result": "success",
+  "plan": [
+    "First specific task to complete",
+    "Second specific task to complete",
+    "Third specific task to complete"
+  ],
+  "analysis": "Brief summary of what you discovered during analysis. Include key observations about the codebase structure, existing patterns, dependencies identified, and any potential challenges or considerations for the task agent."
+}
+```
+
+### Valid Example
+
+```json
+{
+  "result": "success",
+  "plan": [
+    "Update Python version constraint in pyproject.toml from >=3.9 to >=3.12",
+    "Update base image in Dockerfile from python:3.9-slim to python:3.12-slim",
+    "Update GitHub Actions workflow .github/workflows/ci.yml to use python-version: '3.12'",
+    "Search for any version-specific code comments referencing Python 3.9 and update to 3.12",
+    "Run tests to verify compatibility"
+  ],
+  "analysis": "Repository uses Python 3.9 as specified in pyproject.toml [tool.poetry.dependencies]. Found Dockerfile with python:3.9-slim base image. GitHub Actions workflow configured for python 3.9. No obvious version-specific code detected, but found deprecation warnings in test suite that may be Python version related. Project uses poetry for dependency management."
+}
+```
+
+### Invalid Examples
+
+❌ Missing required fields: `{"result": "success"}`
+❌ Wrong enum value: `{"result": "OK", "plan": []}`
+❌ Vague tasks: `{"result": "success", "plan": ["Update stuff", "Fix things"]}`
+❌ Not JSON: Plain text response
+❌ Extra text: Markdown or explanations before/after JSON
+
+## FAILURE HANDLING
+
+If you cannot create a plan (e.g., missing critical information, ambiguous requirements), respond with:
+
+```json
+{
+  "result": "failure",
+  "plan": [],
+  "analysis": "Explanation of why planning failed and what information is needed"
+}
+```
+
+## REMEMBER
+
+- You are creating a PLAN, not executing it
+- Your plan will guide the task agent's execution
+- Be thorough in your analysis but concise in your tasks
+- The task agent trusts your plan, so make it actionable
+- Use tools liberally to gather accurate information

--- a/src/imbi_automations/claude.py
+++ b/src/imbi_automations/claude.py
@@ -168,7 +168,7 @@ class Claude(mixins.WorkflowLoggerMixin):
         output_styles_dir = claude_dir / 'output-style'
         output_styles_dir.mkdir(parents=True, exist_ok=True)
 
-        for agent in ['task', 'validator']:
+        for agent in ['planning', 'task', 'validator']:
             self.agents[agent] = self._parse_agent_file(agent)
 
         # Create custom settings.json - disable all global settings

--- a/src/imbi_automations/models/claude.py
+++ b/src/imbi_automations/models/claude.py
@@ -30,3 +30,15 @@ class AgentRun(pydantic.BaseModel):
     result: AgentRunResult
     message: str | None = None
     errors: list[str] = []
+
+
+class AgentPlan(pydantic.BaseModel):
+    """Claude planning agent result with structured plan and analysis.
+
+    Contains the execution result, a list of planned tasks for the task agent
+    to complete, and optional analysis/observations about the codebase.
+    """
+
+    result: AgentRunResult
+    plan: list[str] = []
+    analysis: str | None = None

--- a/src/imbi_automations/models/workflow.py
+++ b/src/imbi_automations/models/workflow.py
@@ -147,11 +147,13 @@ class WorkflowClaudeAction(WorkflowAction):
     """Action for AI-powered code transformations using Claude Code SDK.
 
     Executes complex multi-file analysis and transformation with prompt-based
-    instructions, validation cycles, and AI-generated commit messages.
+    instructions, optional planning phase, validation cycles, and AI-generated
+    commit messages.
     """
 
     type: typing.Literal['claude'] = 'claude'
-    prompt: str
+    task_prompt: str
+    planning_prompt: str | None = None
     validation_prompt: str | None = None
     max_cycles: int = 3
     ai_commit: bool = True

--- a/tests/actions/test_claude.py
+++ b/tests/actions/test_claude.py
@@ -81,7 +81,7 @@ class ClaudeActionTestCase(base.AsyncTestCase):
             )
 
         action = models.WorkflowClaudeAction(
-            name='test-action', type='claude', prompt='test-prompt.j2'
+            name='test-action', type='claude', task_prompt='test-prompt.j2'
         )
 
         # Create Jinja2 template file
@@ -118,7 +118,7 @@ class ClaudeActionTestCase(base.AsyncTestCase):
         action = models.WorkflowClaudeAction(
             name='test-action',
             type='claude',
-            prompt='test-prompt.md',
+            task_prompt='test-prompt.md',
             validation_prompt='test-validation.md',
         )
 
@@ -159,7 +159,7 @@ class ClaudeActionTestCase(base.AsyncTestCase):
         action = models.WorkflowClaudeAction(
             name='test-action',
             type='claude',
-            prompt='test-prompt.md',
+            task_prompt='test-prompt.md',
             validation_prompt='test-validation.md',
         )
 
@@ -202,7 +202,7 @@ class ClaudeActionTestCase(base.AsyncTestCase):
             )
 
         action = models.WorkflowClaudeAction(
-            name='test-action', type='claude', prompt='test-prompt.md'
+            name='test-action', type='claude', task_prompt='test-prompt.md'
         )
 
         (self.working_directory / 'workflow' / 'test-prompt.md').write_text(
@@ -239,7 +239,7 @@ class ClaudeActionTestCase(base.AsyncTestCase):
         action = models.WorkflowClaudeAction(
             name='test-action',
             type='claude',
-            prompt='test-prompt.md',
+            task_prompt='test-prompt.md',
             max_cycles=3,
         )
 
@@ -279,7 +279,7 @@ class ClaudeActionTestCase(base.AsyncTestCase):
         action = models.WorkflowClaudeAction(
             name='test-action',
             type='claude',
-            prompt='test-prompt.md',
+            task_prompt='test-prompt.md',
             max_cycles=2,
         )
 
@@ -328,7 +328,7 @@ class ClaudeActionTestCase(base.AsyncTestCase):
         action = models.WorkflowClaudeAction(
             name='test-action',
             type='claude',
-            prompt='test-prompt.md',
+            task_prompt='test-prompt.md',
             max_cycles=3,
         )
 

--- a/tests/data/workflows/comprehensive-test-workflow.toml
+++ b/tests/data/workflows/comprehensive-test-workflow.toml
@@ -79,7 +79,7 @@ remote_file = "Dockerfile"
 [[actions]]
 name = "test-claude-action"
 type = "claude"
-prompt = "prompts/main-prompt.md"
+task_prompt = "prompts/main-prompt.md"
 validation_prompt = "prompts/validation-prompt.md"
 max_cycles = 5
 timeout = 1800


### PR DESCRIPTION
## Summary

This PR introduces two major improvements to the Claude Code integration:

### 1. Planning Agent Feature

Adds an optional planning phase where a dedicated planning agent analyzes the codebase before the task agent executes changes.

**How it works:**
- Planning agent uses read-only tools (Read, Glob, Grep, Bash) to explore the codebase
- Creates a structured todo list with specific, actionable tasks
- Provides analysis and context about the codebase structure, patterns, and dependencies
- Plan is injected into the task prompt to guide execution
- Fresh plan generated at the start of each validation cycle

**Configuration:**
```toml
[[actions]]
name = "fix-lint-issues"
type = "claude"
planning_prompt = "prompts/planning.md.j2"  # Optional - enables planning phase
task_prompt = "prompts/task.md.j2"          # Required - task instructions
validation_prompt = "prompts/validate.md.j2"  # Optional - validation
max_cycles = 10
```

**Benefits:**
- Better context: Planning agent explores codebase before task agent makes changes
- Structured execution: Task agent follows clear, ordered steps from the plan
- Adaptability: New plan created each cycle adapts to repository changes
- Separation of concerns: Read-only analysis separate from write operations

### 2. API Change: `prompt` → `task_prompt` (Breaking Change)

Renamed the `prompt` field in `WorkflowClaudeAction` to `task_prompt` for consistency and clarity.

**Before:**
```toml
[[actions]]
type = "claude"
prompt = "prompts/task.md.j2"              # Ambiguous naming
validation_prompt = "prompts/validate.md.j2"
```

**After:**
```toml
[[actions]]
type = "claude"
task_prompt = "prompts/task.md.j2"         # Explicit naming
validation_prompt = "prompts/validate.md.j2"
```

**Rationale:**
- All three prompt types now have explicit, parallel naming:
  - `planning_prompt` (optional)
  - `task_prompt` (required)
  - `validation_prompt` (optional)
- Removes ambiguity about which prompt serves which purpose
- Makes the multi-phase architecture more discoverable
- No deprecation period since we're still in alpha

## Changes

- **New Models**: Added `AgentPlan` model with `result`, `plan`, and `analysis` fields
- **New Agent**: Created planning agent configuration in `claude-code/agents/planning.md.j2`
- **New Template**: Added `with-plan.md.j2` template for injecting plans into task prompts
- **API Change**: Renamed `WorkflowClaudeAction.prompt` → `task_prompt`
- **Implementation**: Updated `ClaudeAction._execute_cycle()` to support planning phase
- **Documentation**: Updated AGENTS.md with planning agent examples and new field names
- **Tests**: Updated all tests to use `task_prompt` - all passing ✅

## Test Plan

- [x] All existing tests pass with new field name
- [x] Workflow configuration parses successfully with `task_prompt`
- [x] Pre-commit hooks pass (ruff, formatting)
- [x] Planning agent can be optionally enabled via `planning_prompt` field

## Breaking Changes

⚠️ **Breaking Change for Alpha Users**: The `prompt` field in Claude actions must be renamed to `task_prompt` in all workflow configurations.

**Migration:**
```bash
# Update all workflow configs
sed -i 's/^prompt = /task_prompt = /' workflows/*/config.toml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-24 19:58:08 UTC

<h3>Greptile Summary</h3>


Adds optional planning agent support for Claude actions and renames `prompt` to `task_prompt` for consistency.

**Key Changes:**
- **Planning Agent**: New optional `planning_prompt` field enables a read-only planning phase that analyzes the codebase and creates structured task plans before the task agent executes
- **API Change**: Renamed `WorkflowClaudeAction.prompt` → `task_prompt` for explicit, parallel naming with `planning_prompt` and `validation_prompt`
- **Execution Flow**: Planning agent runs first (if configured), creates `AgentPlan` with tasks and analysis, which is injected into task agent's prompt
- **Plan Reset**: Task plan is cleared and regenerated at the start of each cycle, adapting to repository changes
- **Agent Discovery**: Added `planning` to the agent list in `claude.py` for proper agent file discovery

**Implementation Quality:**
- Clean separation of concerns with read-only planning vs write-enabled task execution
- Proper error handling with parse failures and agent failures handled separately
- Well-structured Jinja2 templates for plan injection
- Comprehensive documentation in AGENTS.md with examples
- All tests updated and passing

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no critical issues
- Well-designed feature addition with clean architecture, comprehensive error handling, proper documentation, and all tests passing. The API change is intentional and appropriate for alpha software. Code follows established patterns and maintains consistency with existing codebase.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/models/workflow.py | 5/5 | Renamed `prompt` to `task_prompt` and added optional `planning_prompt` field. Clean API change with proper field ordering and documentation. |
| src/imbi_automations/models/claude.py | 5/5 | Added `AgentPlan` model with `result`, `plan`, and `analysis` fields. Simple addition with clear docstring and proper type hints. |
| src/imbi_automations/actions/claude.py | 4/5 | Implements planning agent logic with plan reset per cycle, agent sequencing, and plan injection. Complex changes but well-structured with proper error handling. |
| src/imbi_automations/claude-code/agents/planning.md.j2 | 5/5 | Planning agent configuration with comprehensive instructions and JSON schema. Well-documented with clear examples and constraints. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->