### PR TITLE
Add regex support for remote_file_contains

### DIFF
--- a/src/imbi_automations/condition_checker.py
+++ b/src/imbi_automations/condition_checker.py
@@ -205,7 +205,7 @@ class ConditionChecker(mixins.WorkflowLoggerMixin):
     def _check_file_doesnt_contain(
         self, file_path: pathlib.Path, condition: models.WorkflowCondition
     ) -> bool:
-        """Check that a file exists & does not contain string or regex pattern"""
+        """Check file exists & does not contain string or regex pattern"""
         if not file_path.is_file():
             self.logger.debug(
                 'file %s does not exist for negative contains check',

--- a/src/imbi_automations/condition_checker.py
+++ b/src/imbi_automations/condition_checker.py
@@ -123,46 +123,22 @@ class ConditionChecker(mixins.WorkflowLoggerMixin):
                 content = await client.get_file_contents(context, file_path)
 
                 if condition.remote_file_contains and condition.remote_file:
-                    if content is None:
-                        results.append(False)
-                    else:
-                        # Try exact string match first (fast)
-                        if condition.remote_file_contains in content:
-                            results.append(True)
-                        else:
-                            # Fall back to regex pattern matching
-                            try:
-                                pattern = re.compile(
-                                    condition.remote_file_contains
-                                )
-                                results.append(
-                                    pattern.search(content) is not None
-                                )
-                            except re.error:
-                                # Invalid regex, treat as failed match
-                                results.append(False)
+                    results.append(
+                        content is not None
+                        and self._match_string_or_regex(
+                            condition.remote_file_contains, content
+                        )
+                    )
                 elif (
                     condition.remote_file_doesnt_contain
                     and condition.remote_file
                 ):
-                    if content is None:
-                        results.append(False)
-                    else:
-                        # Try exact string match first (fast)
-                        if condition.remote_file_doesnt_contain in content:
-                            results.append(False)
-                        else:
-                            # Fall back to regex pattern matching
-                            try:
-                                pattern = re.compile(
-                                    condition.remote_file_doesnt_contain
-                                )
-                                results.append(
-                                    pattern.search(content) is None
-                                )
-                            except re.error:
-                                # Invalid regex, treat as no match (passes)
-                                results.append(True)
+                    results.append(
+                        content is not None
+                        and not self._match_string_or_regex(
+                            condition.remote_file_doesnt_contain, content
+                        )
+                    )
                 elif condition.remote_file_exists:
                     results.append(content is not None)
                 elif condition.remote_file_not_exists:
@@ -176,10 +152,37 @@ class ConditionChecker(mixins.WorkflowLoggerMixin):
             return any(results)
         return all(results)
 
+    @staticmethod
+    def _match_string_or_regex(pattern: str, content: str) -> bool:
+        """Check if content matches pattern via exact string or regex.
+
+        Tries exact string matching first for performance, then falls back
+        to regex pattern matching if no exact match is found.
+
+        Args:
+            pattern: String to match (literal or regex pattern)
+            content: Content to search within
+
+        Returns:
+            True if exact string match or regex match found, False otherwise
+
+        """
+        # Try exact string match first (fast)
+        if pattern in content:
+            return True
+
+        # Fall back to regex pattern matching
+        try:
+            compiled = re.compile(pattern)
+            return compiled.search(content) is not None
+        except re.error:
+            # Invalid regex, treat as failed match
+            return False
+
     def _check_file_contains(
         self, file_path: pathlib.Path, condition: models.WorkflowCondition
     ) -> bool:
-        """Check if a file contains the specified string"""
+        """Check if a file contains the specified string or regex pattern"""
         if not file_path.is_file():
             self.logger.debug(
                 'file %s does not exist for contains check', condition.file
@@ -194,12 +197,15 @@ class ConditionChecker(mixins.WorkflowLoggerMixin):
                 exc,
             )
             return False
-        return condition.file_contains in file_content
+
+        return self._match_string_or_regex(
+            condition.file_contains, file_content
+        )
 
     def _check_file_doesnt_contain(
         self, file_path: pathlib.Path, condition: models.WorkflowCondition
     ) -> bool:
-        """Check that a file exists & does not contain the specified string"""
+        """Check that a file exists & does not contain string or regex pattern"""
         if not file_path.is_file():
             self.logger.debug(
                 'file %s does not exist for negative contains check',
@@ -215,7 +221,10 @@ class ConditionChecker(mixins.WorkflowLoggerMixin):
                 exc,
             )
             return False
-        return condition.file_doesnt_contain not in file_content
+
+        return not self._match_string_or_regex(
+            condition.file_doesnt_contain, file_content
+        )
 
     @staticmethod
     def _check_file_pattern_exists(

--- a/tests/test_condition_checker.py
+++ b/tests/test_condition_checker.py
@@ -454,6 +454,96 @@ class ConditionCheckerTestCase(base.AsyncTestCase):
         self.assertFalse(result)
 
     @mock.patch('imbi_automations.clients.GitHub.get_file_contents')
+    async def test_check_remote_file_contains_regex_success(
+        self, mock_get_file: mock.AsyncMock
+    ) -> None:
+        """Test remote_file_contains with regex pattern that matches."""
+        mock_get_file.return_value = 'FROM python:3.9-slim'
+
+        condition = models.WorkflowCondition(
+            remote_file_contains=r'python:[3-4]\.\d+',
+            remote_file=pathlib.Path('Dockerfile'),
+        )
+
+        result = await self.checker.check_remote(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertTrue(result)
+
+    @mock.patch('imbi_automations.clients.GitHub.get_file_contents')
+    async def test_check_remote_file_contains_regex_failure(
+        self, mock_get_file: mock.AsyncMock
+    ) -> None:
+        """Test remote_file_contains with regex pattern that doesn't match."""
+        mock_get_file.return_value = 'FROM python:2.7-slim'
+
+        condition = models.WorkflowCondition(
+            remote_file_contains=r'python:[3-4]\.\d+',
+            remote_file=pathlib.Path('Dockerfile'),
+        )
+
+        result = await self.checker.check_remote(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertFalse(result)
+
+    @mock.patch('imbi_automations.clients.GitHub.get_file_contents')
+    async def test_check_remote_file_contains_invalid_regex(
+        self, mock_get_file: mock.AsyncMock
+    ) -> None:
+        """Test remote_file_contains with invalid regex pattern."""
+        mock_get_file.return_value = 'some content'
+
+        condition = models.WorkflowCondition(
+            remote_file_contains=r'[invalid(regex',
+            remote_file=pathlib.Path('test.txt'),
+        )
+
+        result = await self.checker.check_remote(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertFalse(result)
+
+    @mock.patch('imbi_automations.clients.GitHub.get_file_contents')
+    async def test_check_remote_file_doesnt_contain_regex_success(
+        self, mock_get_file: mock.AsyncMock
+    ) -> None:
+        """Test remote_file_doesnt_contain with regex that doesn't match."""
+        mock_get_file.return_value = 'FROM python:2.7-slim'
+
+        condition = models.WorkflowCondition(
+            remote_file_doesnt_contain=r'python:[3-4]\.\d+',
+            remote_file=pathlib.Path('Dockerfile'),
+        )
+
+        result = await self.checker.check_remote(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertTrue(result)
+
+    @mock.patch('imbi_automations.clients.GitHub.get_file_contents')
+    async def test_check_remote_file_doesnt_contain_regex_failure(
+        self, mock_get_file: mock.AsyncMock
+    ) -> None:
+        """Test remote_file_doesnt_contain with regex that matches."""
+        mock_get_file.return_value = 'FROM python:3.9-slim'
+
+        condition = models.WorkflowCondition(
+            remote_file_doesnt_contain=r'python:[3-4]\.\d+',
+            remote_file=pathlib.Path('Dockerfile'),
+        )
+
+        result = await self.checker.check_remote(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertFalse(result)
+
+    @mock.patch('imbi_automations.clients.GitHub.get_file_contents')
     async def test_check_remote_condition_type_any(
         self, mock_get_file: mock.AsyncMock
     ) -> None:

--- a/tests/test_condition_checker.py
+++ b/tests/test_condition_checker.py
@@ -637,6 +637,71 @@ class ConditionCheckerTestCase(base.AsyncTestCase):
 
         self.assertFalse(result)
 
+    def test_check_file_contains_regex_success(self) -> None:
+        """Test file_contains with regex pattern that matches."""
+        condition = models.WorkflowCondition(
+            file_contains=r'fastapi==0\.\d+\.\d+',
+            file='repository://requirements.txt',
+        )
+
+        result = self.checker.check(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertTrue(result)
+
+    def test_check_file_contains_regex_failure(self) -> None:
+        """Test file_contains with regex pattern that doesn't match."""
+        condition = models.WorkflowCondition(
+            file_contains=r'django==\d+\.\d+\.\d+',
+            file='repository://requirements.txt',
+        )
+
+        result = self.checker.check(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertFalse(result)
+
+    def test_check_file_contains_invalid_regex(self) -> None:
+        """Test file_contains with invalid regex pattern."""
+        condition = models.WorkflowCondition(
+            file_contains=r'[invalid(regex',
+            file='repository://requirements.txt',
+        )
+
+        result = self.checker.check(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertFalse(result)
+
+    def test_check_file_doesnt_contain_regex_success(self) -> None:
+        """Test file_doesnt_contain with regex that doesn't match."""
+        condition = models.WorkflowCondition(
+            file_doesnt_contain=r'django==\d+\.\d+\.\d+',
+            file='repository://requirements.txt',
+        )
+
+        result = self.checker.check(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertTrue(result)
+
+    def test_check_file_doesnt_contain_regex_failure(self) -> None:
+        """Test file_doesnt_contain with regex that matches."""
+        condition = models.WorkflowCondition(
+            file_doesnt_contain=r'fastapi==0\.\d+\.\d+',
+            file='repository://requirements.txt',
+        )
+
+        result = self.checker.check(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertFalse(result)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds regex support for `remote_file_contains` (and `reomte_file_doesnt_contain`), which was documented but not previously implemented.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-29 19:05:24 UTC

<h3>Greptile Summary</h3>


Implements regex support for `remote_file_contains` and `remote_file_doesnt_contain` conditions as documented in AGENTS.md. The implementation uses a smart fallback approach: tries exact string matching first for performance, then falls back to regex pattern matching if the string match fails.

Key improvements:
- Maintains backward compatibility with existing string-based matches
- Gracefully handles invalid regex patterns
- Adds comprehensive test coverage for regex success, failure, and invalid patterns
- Proper error handling for `None` content

Minor observations:
- Local `file_contains` and `file_doesnt_contain` methods don't have regex support yet, despite documentation claiming they do (AGENTS.md:245)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is solid with smart fallback logic (string match first, regex second), proper error handling for invalid regex patterns, and comprehensive test coverage including edge cases. The changes are backward compatible and well-tested.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/condition_checker.py | 5/5 | Added regex support to `remote_file_contains` and `remote_file_doesnt_contain` with fallback logic and proper error handling |
| tests/test_condition_checker.py | 5/5 | Added comprehensive test coverage for regex patterns, including success, failure, and invalid regex cases for both contains and doesnt_contain |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->