### PR TITLE
Fix AttributeError when workflow has no filter section

### DIFF
--- a/src/imbi_automations/workflow_filter.py
+++ b/src/imbi_automations/workflow_filter.py
@@ -28,7 +28,7 @@ class Filter(mixins.WorkflowLoggerMixin):
     async def filter_project(
         self,
         project: models.ImbiProject,
-        workflow_filter: models.WorkflowFilter,
+        workflow_filter: models.WorkflowFilter | None,
     ) -> models.ImbiProject | None:
         """Filter projects based on workflow configuration
 
@@ -42,6 +42,9 @@ class Filter(mixins.WorkflowLoggerMixin):
         )
 
         """
+        if workflow_filter is None:
+            return project
+
         if (
             (
                 workflow_filter.github_identifier_required


### PR DESCRIPTION
When processing multiple projects (via --project-type or --all-projects), workflows without a [filter] section in config.toml would crash with: AttributeError: 'NoneType' object has no attribute 'github_identifier_required'

This occurred because _filter_projects() passes workflow.configuration.filter (which is None when no [filter] section exists) to filter_project(), which tried to access attributes on the None value.

The fix adds an early return when workflow_filter is None, treating no filter configuration as "accept all projects". This matches the expected behavior: workflows without filters should process all provided projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-30 18:00:52 UTC

<h3>Greptile Summary</h3>


Fixed AttributeError when workflows lack a `[filter]` section in their `config.toml` by adding an early return in `filter_project()` when `workflow_filter` is None.

- Updated type annotation to accept `WorkflowFilter | None`
- Added None-check that returns the project unfiltered (accept all)
- Matches existing pattern in `controller.py:_filter_projects()`

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The fix correctly handles the None case with a simple early return, matching the pattern used elsewhere in the codebase. The change is minimal, focused, and directly addresses the reported AttributeError without introducing side effects.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/workflow_filter.py | 5/5 | Added None-check for `workflow_filter` parameter to prevent AttributeError when workflows have no `[filter]` section |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->