### PR TITLE
Fix github_identifier_required references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,7 +283,7 @@ project_facts = {
 }
 
 # Require GitHub identifier to be present
-requires_github_identifier = true
+github_identifier_required = true
 
 # Exclude projects with specific GitHub workflow statuses
 exclude_github_workflow_status = ["success"]
@@ -599,7 +599,7 @@ The GitHub Actions module syncs repository environments with Imbi project defini
 # Extract configuration files for analysis
 [filter]
 project_types = ["apis", "consumers"]
-requires_github_identifier = true
+github_identifier_required = true
 
 [[conditions]]
 remote_file_exists = "config.yaml"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,7 +167,7 @@ Workflows are defined in TOML configuration files with three main sections:
 [filter]
 project_ids = [123, 456]
 project_types = ["apis", "consumers"]
-requires_github_identifier = true
+github_identifier_required = true
 
 # Execution conditions
 [[conditions]]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -779,7 +779,7 @@ Reduce scope with workflow filters in `config.toml`:
 ```toml
 [filter]
 project_types = ["api", "consumer"]
-requires_github_identifier = true
+github_identifier_required = true
 ```
 
 ### Batch Smartly

--- a/src/imbi_automations/controller.py
+++ b/src/imbi_automations/controller.py
@@ -242,7 +242,7 @@ class Automation(mixins.WorkflowLoggerMixin):
         project_types: set[str] = pydantic.Field(default_factory=set)
         project_facts: dict[str, str] = pydantic.Field(default_factory=dict)
         project_environments: set[str] = pydantic.Field(default_factory=set)
-        requires_github_identifier: bool = False
+        github_identifier_required: bool = False
         exclude_github_workflow_status: set[str] = pydantic.Field(
             default_factory=set
         )

--- a/src/imbi_automations/workflow_filter.py
+++ b/src/imbi_automations/workflow_filter.py
@@ -36,7 +36,7 @@ class Filter(mixins.WorkflowLoggerMixin):
         project_types: set[str] = pydantic.Field(default_factory=set)
         project_facts: dict[str, str] = pydantic.Field(default_factory=dict)
         project_environments: set[str] = pydantic.Field(default_factory=set)
-        requires_github_identifier: bool = False
+        github_identifier_required: bool = False
         exclude_github_workflow_status: set[str] = pydantic.Field(
             default_factory=set
         )


### PR DESCRIPTION
`requires_github_identifier` is a typo. The actual key needs to be `github_identifier_required`. I'm not sure if it was introduced by accident somewhere or an old name that didn't get cleaned up. It only appears in docs, never actually in code.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Renamed field from `requires_github_identifier` to `github_identifier_required` across documentation and code for consistency
- Updated Pydantic model definitions in `controller.py` and `workflow_filter.py` to use the new field name

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- Simple field rename applied consistently across all files - no logic changes, no security implications, and grep confirms no remaining references to old field name
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->