### PR TITLE
Fix debug logs and add action progress tracking

### DIFF
--- a/src/imbi_automations/actions/claude.py
+++ b/src/imbi_automations/actions/claude.py
@@ -50,8 +50,10 @@ class ClaudeAction(mixins.WorkflowLoggerMixin):
 
         for cycle in range(1, action.max_cycles + 1):
             self._log_verbose_info(
-                '%s %s Claude Code cycle %d/%d',
+                '%s [%s/%s] %s Claude Code cycle %d/%d',
                 self.context.imbi_project.slug,
+                self.context.current_action_index,
+                self.context.total_actions,
                 action.name,
                 cycle,
                 action.max_cycles,
@@ -63,8 +65,10 @@ class ClaudeAction(mixins.WorkflowLoggerMixin):
                 and action.max_cycles > 5
             ):
                 self.logger.warning(
-                    '%s %s has used %d/%d cycles - approaching limit',
+                    '%s [%s/%s] %s has used %d/%d cycles - approaching limit',
                     self.context.imbi_project.slug,
+                    self.context.current_action_index,
+                    self.context.total_actions,
                     action.name,
                     cycle,
                     action.max_cycles,
@@ -115,8 +119,10 @@ class ClaudeAction(mixins.WorkflowLoggerMixin):
 
         for agent in agents:
             self._log_verbose_info(
-                '%s %s executing Claude Code %s agent in cycle %d',
+                '%s [%s/%s] %s executing Claude Code %s agent in cycle %d',
                 self.context.imbi_project.slug,
+                self.context.current_action_index,
+                self.context.total_actions,
                 action.name,
                 agent,
                 cycle,

--- a/src/imbi_automations/actions/prompts/last-error.md.j2
+++ b/src/imbi_automations/actions/prompts/last-error.md.j2
@@ -1,6 +1,6 @@
 A validation agent that audited your previous task has identified issues that must be resolved. Review these errors and correct them before continuing.
 
-The results from the validaiton phase of the last run are:
+The results from the validation phase of the last run are:
 
 {{ last_error }}
 

--- a/src/imbi_automations/actions/prompts/with-plan.md.j2
+++ b/src/imbi_automations/actions/prompts/with-plan.md.j2
@@ -3,7 +3,8 @@
 # Plan
 The planning agent created the following plan for you to follow in order:
 
-{% for task in plan.plan %}{{ loop.index }}. {{ task }}
+{% for task in plan.plan %}
+{{ loop.index }}. {{ task }}
 {% endfor %}
 {% if plan.analysis %}
 # Analysis

--- a/src/imbi_automations/controller.py
+++ b/src/imbi_automations/controller.py
@@ -369,7 +369,7 @@ class Automation(mixins.WorkflowLoggerMixin):
             return True
         finally:
             # Write debug logs if error occurred (error_path set by engine)
-            if log_capture:
+            if log_capture and token:
                 error_path = self.workflow_engine.get_last_error_path()
                 if error_path:
                     log_capture.write_to_file(error_path / 'debug.log')

--- a/src/imbi_automations/models/workflow.py
+++ b/src/imbi_automations/models/workflow.py
@@ -640,3 +640,5 @@ class WorkflowContext(pydantic.BaseModel):
     starting_commit: str | None = None
     has_repository_changes: bool = False
     registry: typing.Any = None  # ImbiMetadataCache (avoid circular import)
+    current_action_index: int | None = None  # 1-indexed position in workflow
+    total_actions: int | None = None  # Total actions in workflow

--- a/src/imbi_automations/workflow_engine.py
+++ b/src/imbi_automations/workflow_engine.py
@@ -149,8 +149,14 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
             )
             return False
 
+        # Set total actions for progress tracking
+        context.total_actions = len(self.workflow.configuration.actions)
+
         # Execute actions (all actions for normal mode, remaining for resume)
         for idx, action in actions_to_run:
+            # Update current action index for progress tracking
+            context.current_action_index = idx + 1
+
             try:
                 await self._execute_action(context, action)
 


### PR DESCRIPTION
## Summary

This PR includes two main improvements to workflow execution debugging and visibility:

1. **Fix debug logs not being written on exceptions** - Debug logs are now properly written to error directories when workflow actions fail with exceptions
2. **Add action progress tracking** - Claude Code action logs now show [current/total] progress indicators

## Changes

### Debug Log Fix (`controller.py:370-379`)
- Moved debug log writing logic from try block to finally block
- Now checks if `error_path` was set by workflow engine to detect failures
- Catches both exception failures and return-False failures without requiring specific exception handling
- Ensures per-project debug logs are always preserved in error directories for diagnosis

**Before:** Exception bypassed log writing code, only cleanup ran
**After:** Finally block writes logs if error occurred, then cleans up

### Progress Tracking (`workflow.py`, `workflow_engine.py`, `actions/claude.py`)
- Added `current_action_index` and `total_actions` fields to `WorkflowContext` model
- Set `total_actions` once before action loop (not on every iteration)
- Update `current_action_index` on each iteration
- Updated Claude action log statements to include `[current/total]` format

**Example log output:**
```
Before: facebook-canvas update-readme Claude Code cycle 1/3
After:  facebook-canvas [12/35] update-readme Claude Code cycle 1/3
```

**Note:** Progress shows position in workflow, not execution count (skipped actions due to filters/conditions still count toward total).

### Bonus: Prompt Template Fixes (`actions/prompts/*.md.j2`)
- Fixed typo: "validaiton" → "validation"
- Improved task list formatting

## Testing
- Debug logs now appear in error directories when Claude Code actions fail
- Progress indicators show correct action position throughout workflow execution
- Works correctly in resume mode (shows overall workflow position)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixed debug logs not being written on exceptions by moving log writing to finally block with error_path check
- Added action progress tracking with [current/total] indicators in Claude Code logs
- Fixed typo in prompt template ("validaiton" → "validation")

<h3>Confidence Score: 4/5</h3>


- This PR is mostly safe to merge with one logical issue requiring fix
- The PR implements two straightforward improvements (debug logging and progress tracking) with clean changes across multiple files. However, there's a critical bug in `controller.py:379` where `cleanup(token)` is called without verifying `token` is not None, which will cause a runtime error if an exception occurs before `token` is set
- Pay close attention to `controller.py:379` - the cleanup logic needs to verify both `log_capture` and `token` exist

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/imbi_automations/controller.py | Moved debug log writing from try block to finally block to ensure logs are written on exceptions; added conditional check for error_path before writing logs. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->