### PR TITLE
Fix Claude Code commit response handling causing false-negative failures

### DIFF
--- a/src/imbi_automations/prompts/commit.md.j2
+++ b/src/imbi_automations/prompts/commit.md.j2
@@ -83,14 +83,11 @@ rm {{ working_directory }}/do-commit.sh
 
 # RESPONSE FORMAT
 
-You should response with the following if do-commit succeeds:
+After successfully creating commits (or determining there are no changes), you MUST call the `submit_task_response` tool with a message summarizing what was done.
 
-```json
-{"result": "success", "message": "<do-commit.sh response output>"}
-```
+Examples:
+- If commits were created: `submit_task_response(message="Created 2 commits: fix-auth-bug (a1b2c3d) and update-docs (e4f5g6h)")`
+- If no changes: `submit_task_response(message="No changes to commit - working tree is clean")`
+- If commit failed: `submit_task_response(message="Commit failed: <error details>")`
 
-And the following if it fails
-
-```json
-{"result": "failure", "message": "Commit failed", "errors": ["<do-commit.sh response output>"]}
-```
+IMPORTANT: You MUST call submit_task_response - simply outputting JSON is not sufficient.


### PR DESCRIPTION
## Problem

When using AI-powered commits (`ai_commit = true`), workflows were incorrectly failing with "No response received from Claude Code" even though Claude successfully created commits. This resulted in unnecessary error state preservation and prevented workflows from completing despite successful execution.

Example: The facebook-canvas workflow in `errors/fbcanvas/facebook-canvas-20251119-211003/` shows all lint fixes applied successfully and commit `d157461` created, but the system incorrectly preserved error state.

## Root Cause

Two related bugs in the commit handling code:

1. **Missing Tool Call Instruction** (`commit.md.j2`): The prompt instructed Claude to output JSON like `{"result": "success", ...}` but never told it to call the `submit_task_response` MCP tool. Without the tool call, `_submitted_response` remained `None`, triggering the "No response received" error in `claude.py:91-92`.

2. **Invalid Result Field Reference** (`committer.py`): Code referenced `run.result == models.AgentRunResult.failure`, but:
   - `AgentRunResult` doesn't exist in the codebase  
   - `ClaudeAgentTaskResult` only has a `message: str` field, not a `result` field
   - This code was unreachable due to bug #1 but would have failed if executed

## What Was Done

### commit.md.j2
Rewrote the response format section to explicitly require calling the `submit_task_response` tool:
- Success case: `submit_task_response(message="Created N commits: ...")`
- No changes case: `submit_task_response(message="No changes to commit...")`
- Failure case: `submit_task_response(message="Commit failed: ...")`

### committer.py  
Rewrote `_claude_commit()` to properly handle `ClaudeAgentTaskResult`:
- Check message content for "no changes to commit" or "working tree is clean" → return `False`
- Check message content for "commit failed" → raise `RuntimeError`
- Otherwise assume success → return `True`

## Impact

- ✅ Prevents false-negative failures where commits succeed but are incorrectly reported as failures
- ✅ Eliminates unnecessary error state preservation
- ✅ Allows workflows to complete successfully when commits are created
- ✅ All 390 tests pass

## Testing

Verified with existing test suite - all 390 tests pass without modification, confirming the fix doesn't break existing behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes false-negative commit failures by ensuring Claude calls `submit_task_response` tool instead of outputting plain JSON
- Replaces non-existent `AgentRunResult` check with correct message parsing for `ClaudeAgentTaskResult.message` field

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it fixes critical bugs causing false-negative failures with no side effects
- The fix correctly addresses both root causes: missing tool call instruction in the prompt and invalid field reference in the response handler. The solution uses proper string matching on the `ClaudeAgentTaskResult.message` field, which is the correct data structure. All 390 tests pass, confirming no regressions.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/imbi_automations/prompts/commit.md.j2 | Fixed missing tool call instruction by explicitly requiring `submit_task_response` tool invocation instead of plain JSON output |
| src/imbi_automations/committer.py | Replaced invalid `AgentRunResult.failure` check with correct message parsing logic for `ClaudeAgentTaskResult` |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->