### PR TITLE
Add planning agent skip_task feature to skip unnecessary work

### DIFF
--- a/src/imbi_automations/actions/callablea.py
+++ b/src/imbi_automations/actions/callablea.py
@@ -52,7 +52,7 @@ class CallableAction(mixins.WorkflowLoggerMixin):
         except Exception as exc:
             self.logger.exception('Error invoking callable: %s', exc)
             raise RuntimeError(str(exc)) from exc
-        self._log_verbose_info(
+        self.logger.info(
             '%s [%s/%s] %s completed callable %s',
             self.context.imbi_project.slug,
             self.context.current_action_index,

--- a/src/imbi_automations/actions/claude.py
+++ b/src/imbi_automations/actions/claude.py
@@ -137,7 +137,7 @@ class ClaudeAction(mixins.WorkflowLoggerMixin):
             )
 
             run = await self.claude.agent_query(prompt)
-            self._log_verbose_info(
+            self.logger.info(
                 '%s [%s/%s] %s executedClaude Code %s agent in cycle %d',
                 self.context.imbi_project.slug,
                 self.context.current_action_index,

--- a/src/imbi_automations/actions/claude.py
+++ b/src/imbi_automations/actions/claude.py
@@ -157,6 +157,16 @@ class ClaudeAction(mixins.WorkflowLoggerMixin):
 
             if isinstance(run, models.ClaudeAgentPlanningResult):
                 self.task_plan = run
+                if run.skip_task:
+                    self.logger.info(
+                        '%s [%s/%s] %s planning agent determined no work '
+                        'needed - skipping task and validation',
+                        self.context.imbi_project.slug,
+                        self.context.current_action_index,
+                        self.context.total_actions,
+                        action.name,
+                    )
+                    return True  # Success - no work needed
                 self.logger.debug(
                     '%s %s planning agent created plan with %d tasks',
                     self.context.imbi_project.slug,

--- a/src/imbi_automations/actions/claude.py
+++ b/src/imbi_automations/actions/claude.py
@@ -146,7 +146,7 @@ class ClaudeAction(mixins.WorkflowLoggerMixin):
                 agent,
                 cycle,
             )
-            self.logger.debug(
+            self._log_verbose_info(
                 '%s [%s/%s] %s claude response: %s',
                 self.context.imbi_project.slug,
                 self.context.current_action_index,

--- a/src/imbi_automations/actions/docker.py
+++ b/src/imbi_automations/actions/docker.py
@@ -76,7 +76,7 @@ class DockerActions(mixins.WorkflowLoggerMixin):
         dest_path = utils.resolve_path(
             self.context, dest_url, default_scheme='extracted'
         )
-        self._log_verbose_info(
+        self.logger.info(
             '%s [%s/%s] %s extracting %s from container %s to %s',
             self.context.imbi_project.slug,
             self.context.current_action_index,
@@ -105,7 +105,7 @@ class DockerActions(mixins.WorkflowLoggerMixin):
                 ],
                 action=action,
             )
-            self._log_verbose_info(
+            self.logger.info(
                 '%s [%s/%s] %s extracted %s to %s',
                 self.context.imbi_project.slug,
                 self.context.current_action_index,

--- a/src/imbi_automations/actions/filea.py
+++ b/src/imbi_automations/actions/filea.py
@@ -78,7 +78,7 @@ class FileActions(mixins.WorkflowLoggerMixin):
             else:
                 f.write(action.content)
 
-        self._log_verbose_info(
+        self.logger.info(
             '%s [%s/%s] %s appended to %s',
             self.context.imbi_project.slug,
             self.context.current_action_index,
@@ -110,7 +110,7 @@ class FileActions(mixins.WorkflowLoggerMixin):
             await self._execute_copy_glob(source_path, dest_path)
         else:
             await self._execute_copy_single(source_path, dest_path)
-        self._log_verbose_info(
+        self.logger.info(
             '%s [%s/%s] %s copied from %s to %s',
             self.context.imbi_project.slug,
             self.context.current_action_index,
@@ -200,7 +200,7 @@ class FileActions(mixins.WorkflowLoggerMixin):
                 file_path.unlink()
             elif file_path.is_dir():
                 shutil.rmtree(file_path)
-            self._log_verbose_info(
+            self.logger.info(
                 '%s %s deleted %s',
                 self.context.imbi_project.slug,
                 action.name,
@@ -249,7 +249,7 @@ class FileActions(mixins.WorkflowLoggerMixin):
                     file_path.unlink()
                     deleted_count += 1
 
-        self._log_verbose_info(
+        self.logger.info(
             '%s %s deleted %d files matching pattern',
             self.context.imbi_project.slug,
             action.name,
@@ -282,7 +282,7 @@ class FileActions(mixins.WorkflowLoggerMixin):
 
         shutil.move(str(source_path), str(dest_path))
 
-        self._log_verbose_info(
+        self.logger.info(
             '%s [%s/%s] %s moved %s to %s',
             self.context.imbi_project.slug,
             self.context.current_action_index,
@@ -318,7 +318,7 @@ class FileActions(mixins.WorkflowLoggerMixin):
 
         source_path.rename(dest_path)
 
-        self._log_verbose_info(
+        self.logger.info(
             '%s [%s/%s] %s renamed %s to %s',
             self.context.imbi_project.slug,
             self.context.current_action_index,
@@ -353,7 +353,7 @@ class FileActions(mixins.WorkflowLoggerMixin):
             with file_path.open('w', encoding=action.encoding) as f:
                 f.write(action.content)
 
-        self._log_verbose_info(
+        self.logger.info(
             '%s [%s/%s] %s wrote to %s',
             self.context.imbi_project.slug,
             self.context.current_action_index,

--- a/src/imbi_automations/actions/git.py
+++ b/src/imbi_automations/actions/git.py
@@ -55,7 +55,7 @@ class GitActions(mixins.WorkflowLoggerMixin):
                     raise RuntimeError(
                         f'Git extraction failed for {action.source}'
                     )
-                self._log_verbose_info(
+                self.logger.info(
                     '%s [%s/%s] %s extracted %s to %s',
                     self.context.imbi_project.slug,
                     self.context.current_action_index,
@@ -84,7 +84,7 @@ class GitActions(mixins.WorkflowLoggerMixin):
                     branch=action.branch,
                     depth=action.depth,
                 )
-                self._log_verbose_info(
+                self.logger.info(
                     '%s [%s/%s] %s cloned repository to %s',
                     self.context.imbi_project.slug,
                     self.context.current_action_index,

--- a/src/imbi_automations/actions/github.py
+++ b/src/imbi_automations/actions/github.py
@@ -89,7 +89,7 @@ class GitHubActions(mixins.WorkflowLoggerMixin):
 
         # Log results
         if result['success']:
-            self._log_verbose_info(
+            self.logger.info(
                 '%s [%s/%s] %s successfully synced environments: '
                 'created %d, deleted %d',
                 self.context.imbi_project.slug,
@@ -223,7 +223,7 @@ class GitHubActions(mixins.WorkflowLoggerMixin):
                 try:
                     await github_client.delete_environment(org, repo, env_name)
                     result['deleted'].append(env_name)
-                    self._log_verbose_info(
+                    self.logger.info(
                         'Deleted environment "%s" from %s/%s',
                         env_name,
                         org,
@@ -242,7 +242,7 @@ class GitHubActions(mixins.WorkflowLoggerMixin):
                 try:
                     await github_client.create_environment(org, repo, env_name)
                     result['created'].append(env_name)
-                    self._log_verbose_info(
+                    self.logger.info(
                         'Created environment "%s" in %s/%s',
                         env_name,
                         org,

--- a/src/imbi_automations/actions/imbi.py
+++ b/src/imbi_automations/actions/imbi.py
@@ -106,7 +106,7 @@ class ImbiActions(mixins.WorkflowLoggerMixin):
             )
             raise
         else:
-            self._log_verbose_info(
+            self.logger.info(
                 '%s [%s/%s] %s successfully updated environments for '
                 'project %d',
                 self.context.imbi_project.slug,
@@ -168,7 +168,7 @@ class ImbiActions(mixins.WorkflowLoggerMixin):
             )
             raise
         else:
-            self._log_verbose_info(
+            self.logger.info(
                 '%s [%s/%s] %s successfully updated fact "%s" for project %d',
                 self.context.imbi_project.slug,
                 self.context.current_action_index,

--- a/src/imbi_automations/actions/shell.py
+++ b/src/imbi_automations/actions/shell.py
@@ -110,7 +110,7 @@ class ShellAction(mixins.WorkflowLoggerMixin):
             stdout_str = stdout.decode('utf-8') if stdout else ''
             stderr_str = stderr.decode('utf-8') if stderr else ''
 
-            self._log_verbose_info(
+            self.logger.info(
                 '%s [%s/%s] %s shell command completed with exit code %d',
                 self.context.imbi_project.slug,
                 self.context.current_action_index,

--- a/src/imbi_automations/actions/template.py
+++ b/src/imbi_automations/actions/template.py
@@ -53,7 +53,7 @@ class TemplateAction(mixins.WorkflowLoggerMixin):
             )
             with destination_path.open('w', encoding='utf-8') as fh:
                 fh.write(prompts.render(self.context, source_path))
-            self._log_verbose_info(
+            self.logger.info(
                 '%s [%s/%s] %s rendered template from %s to %s',
                 self.context.imbi_project.slug,
                 self.context.current_action_index,
@@ -88,7 +88,7 @@ class TemplateAction(mixins.WorkflowLoggerMixin):
                     fh.write(prompts.render(self.context, template_file))
                 file_count += 1
 
-        self._log_verbose_info(
+        self.logger.info(
             '%s [%s/%s] %s rendered %d templates from %s to %s',
             self.context.imbi_project.slug,
             self.context.current_action_index,

--- a/src/imbi_automations/claude-code/CLAUDE.md
+++ b/src/imbi_automations/claude-code/CLAUDE.md
@@ -58,7 +58,7 @@ mcp__agent_tools__submit_validation_response(
 
 Use this tool to submit planning results with structured arguments.
 
-Example:
+Example (with work to do):
 ```
 mcp__agent_tools__submit_planning_response(
     plan=[
@@ -66,13 +66,24 @@ mcp__agent_tools__submit_planning_response(
         "Update base image in Dockerfile to python:3.12",
         "Modify dependency constraints for Python 3.12 compatibility"
     ],
-    analysis="Repository uses Python 3.9 in multiple locations. Found dependencies that need updating for 3.12 compatibility."
+    analysis="Repository uses Python 3.9 in multiple locations. Found dependencies that need updating for 3.12 compatibility.",
+    skip_task=False
+)
+```
+
+Example (no work needed):
+```
+mcp__agent_tools__submit_planning_response(
+    plan=[],
+    analysis="Repository already uses Python 3.12 in all locations. No changes needed.",
+    skip_task=True
 )
 ```
 
 **Parameters:**
 - `plan` (required): Array of task strings (simple strings, not objects)
 - `analysis` (required): Summary of findings and context
+- `skip_task` (optional, default False): Set to True if analysis determines no work is needed. Skips task and validation agents entirely.
 
 ## Important Notes
 

--- a/src/imbi_automations/claude-code/agents/planning.md.j2
+++ b/src/imbi_automations/claude-code/agents/planning.md.j2
@@ -17,14 +17,39 @@ When done analyzing, call this tool:
 ```
 mcp__agent_tools__submit_planning_response(
     plan=["First task to do", "Second task to do", "Third task to do"],
-    analysis="What you found and observed"
+    analysis="What you found and observed",
+    skip_task=False
 )
 ```
 
 **IMPORTANT:**
 - `plan` = list of strings (tasks for the task agent)
 - `analysis` = string (your findings)
+- `skip_task` = boolean (optional, default False) - set to True if no work is needed
 - Call the tool - do NOT output text
+
+### When to Skip Task Execution
+
+If your analysis determines that **no changes are needed**, set `skip_task=True`:
+
+```
+mcp__agent_tools__submit_planning_response(
+    plan=[],
+    analysis="Analysis complete. The repository already matches requirements - no changes needed.",
+    skip_task=True
+)
+```
+
+**Use skip_task=True when:**
+- Repository already in desired state
+- Required changes already implemented
+- Action not applicable to this project
+- Configuration already correct
+
+**Benefits of skipping:**
+- Saves execution time (no task/validation agents run)
+- Prevents unnecessary commits
+- Clearly documents "no work needed" decision
 
 ## KEY DIRECTIVES
 

--- a/src/imbi_automations/committer.py
+++ b/src/imbi_automations/committer.py
@@ -55,7 +55,7 @@ class Committer(mixins.WorkflowLoggerMixin):
         Returns:
             True if a commit was made, False if no changes to commit
         """
-        self._log_verbose_info(
+        self.logger.info(
             '%s [%s/%s] %s using Claude Code to commit changes',
             context.imbi_project.slug,
             context.current_action_index,
@@ -126,7 +126,7 @@ class Committer(mixins.WorkflowLoggerMixin):
             raise
         else:
             if commit_sha:
-                self._log_verbose_info(
+                self.logger.info(
                     '%s [%s/%s] %s committed changes: %s',
                     context.imbi_project.slug,
                     context.current_action_index,
@@ -136,7 +136,7 @@ class Committer(mixins.WorkflowLoggerMixin):
                 )
                 return True
             else:
-                self._log_verbose_info(
+                self.logger.info(
                     '%s [%s/%s] %s no changes to commit',
                     context.imbi_project.slug,
                     context.current_action_index,

--- a/src/imbi_automations/controller.py
+++ b/src/imbi_automations/controller.py
@@ -341,7 +341,7 @@ class Automation(mixins.WorkflowLoggerMixin):
     async def _process_workflow_from_imbi_project(
         self, project: models.ImbiProject
     ) -> bool:
-        self._log_verbose_info(
+        self.logger.info(
             'Processing Project %i - %s', project.id, project.slug
         )
         github_repository = await self._get_github_repository(project)
@@ -363,7 +363,7 @@ class Automation(mixins.WorkflowLoggerMixin):
                     )
                 return False
 
-            self._log_verbose_info(
+            self.logger.info(
                 'Completed processing %s (%i)', project.name, project.id
             )
             return True

--- a/src/imbi_automations/mixins.py
+++ b/src/imbi_automations/mixins.py
@@ -20,6 +20,13 @@ class WorkflowLoggerMixin:
         self.verbose = verbose
         super().__init__(*args, **kwargs)
 
+    def _log_verbose_info(
+        self, message: str, *args: typing.Any, **kwargs: typing.Any
+    ) -> None:
+        """Log a verbose message if enabled."""
+        if self.verbose:
+            self.logger.info(message, *args, **kwargs)
+
     def _set_workflow_logger(self, workflow: models.Workflow) -> None:
         """Set logger name to workflow directory name so it's slugified"""
         self.logger = logging.getLogger(workflow.path.name)

--- a/src/imbi_automations/mixins.py
+++ b/src/imbi_automations/mixins.py
@@ -20,13 +20,6 @@ class WorkflowLoggerMixin:
         self.verbose = verbose
         super().__init__(*args, **kwargs)
 
-    def _log_verbose_info(
-        self, message: str, *args: typing.Any, **kwargs: typing.Any
-    ) -> None:
-        """Log a verbose message if enabled."""
-        if self.verbose:
-            self.logger.info(message, *args, **kwargs)
-
     def _set_workflow_logger(self, workflow: models.Workflow) -> None:
         """Set logger name to workflow directory name so it's slugified"""
         self.logger = logging.getLogger(workflow.path.name)

--- a/src/imbi_automations/models/claude.py
+++ b/src/imbi_automations/models/claude.py
@@ -30,10 +30,15 @@ class ClaudeAgentPlanningResult(pydantic.BaseModel):
 
     The plan field accepts structured objects (dicts with task/description/
     details fields) and flattens them to simple strings for compatibility.
+
+    If skip_task is True, the task and validation agents will be skipped
+    entirely, treating the action as successfully completed with no changes
+    needed.
     """
 
     plan: list[str]
     analysis: str
+    skip_task: bool = False
 
 
 class ClaudeAgentTaskResult(pydantic.BaseModel):

--- a/src/imbi_automations/workflow_engine.py
+++ b/src/imbi_automations/workflow_engine.py
@@ -255,7 +255,7 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
 
         # Delete remote branch if replace_branch is enabled
         if context.workflow.configuration.github.replace_branch:
-            self._log_verbose_info(
+            self.logger.info(
                 'Deleting remote branch %s if exists for %s '
                 '(replace_branch=True)',
                 branch_name,
@@ -265,7 +265,7 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
                 working_directory=repository_dir, branch_name=branch_name
             )
 
-        self._log_verbose_info(
+        self.logger.info(
             'Creating pull request branch: %s for %s',
             branch_name,
             context.imbi_project.slug,
@@ -286,7 +286,7 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
             set_upstream=True,
         )
 
-        self._log_verbose_info(
+        self.logger.info(
             'Successfully pushed branch %s for pull request for %s',
             branch_name,
             context.imbi_project.slug,
@@ -318,7 +318,7 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
             body=body,
             head_branch=branch_name,
         )
-        self._log_verbose_info(
+        self.logger.info(
             'Created pull request for %s: %s',
             context.imbi_project.slug,
             pr_url,
@@ -379,7 +379,7 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
             self.tracker.incr(
                 f'actions_remote_condition_skipped_{action.type}'
             )
-            self._log_verbose_info(
+            self.logger.info(
                 'Skipping action %s due to failed condition check', action.name
             )
             return False


### PR DESCRIPTION
## Summary

Planning agents can now signal when no work is needed by setting `skip_task=True` in their response, causing the workflow engine to skip task and validation agents entirely.

## Changes

### Model (`models/claude.py`)
- Added `skip_task: bool = False` to `ClaudeAgentPlanningResult`
- Documents that `skip_task` skips task/validation when True

### Execution (`actions/claude.py`)
- Check `skip_task` flag in `_execute_cycle` after planning
- Return True (success) immediately when `skip_task=True`
- Log informational message about skipping

### Documentation
- Updated `planning.md.j2` agent template with skip_task usage
- Added examples for when to use skip_task (no work needed)
- Updated `CLAUDE.md` with skip_task in planning response examples
- Updated `AGENTS.md` with skip_task in execution flow and behaviors

## Use Cases

Set `skip_task=True` when:
- Repository already in desired state
- Required changes already implemented
- Action not applicable to project
- Configuration already correct

## Benefits

- ✅ Saves execution time (no task/validation cycles)
- ✅ Reduces Claude API costs for no-op actions
- ✅ Prevents unnecessary commits
- ✅ Clearly documents "no work needed" decisions in logs

## Example

\`\`\`python
mcp__agent_tools__submit_planning_response(
    plan=[],
    analysis="Repository already uses Python 3.12. No changes needed.",
    skip_task=True  # Skips task and validation
)
\`\`\`

## Testing

- [ ] Verify planning agent can set skip_task=True
- [ ] Verify task and validation agents are skipped
- [ ] Verify proper logging when skipped
- [ ] Verify backward compatibility (default False)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds a `skip_task` feature to the planning agent, allowing it to signal when no work is needed and skip task/validation execution entirely. The implementation is clean and well-documented across code, templates, and documentation files.

**Key Changes:**
- Added `skip_task: bool = False` field to `ClaudeAgentPlanningResult` model
- Implemented early return in `_execute_cycle` when `skip_task=True` (line 160-169 in `claude.py:160`)
- Updated agent template (`planning.md.j2`) with skip_task usage guidance and examples
- Documented skip_task behavior in `CLAUDE.md` and `AGENTS.md` with clear use cases

**Implementation Quality:**
- Proper default value (`False`) ensures backward compatibility
- Early return pattern correctly prevents task/validation agent execution
- Comprehensive documentation with usage examples and benefits

**Note:**
- No automated tests were added for the skip_task functionality, though the PR description includes a testing checklist

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is straightforward, properly handles backward compatibility with a default value, and follows existing patterns. The early return logic is sound, and documentation is thorough. While automated tests would strengthen confidence, the simple nature of the change (adding an optional boolean field and checking it) makes this low-risk.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/models/claude.py | 5/5 | Added `skip_task` field with default False to `ClaudeAgentPlanningResult` model and comprehensive docstring |
| src/imbi_automations/actions/claude.py | 5/5 | Implemented skip_task logic in `_execute_cycle` to return early when planning agent sets skip_task=True |
| src/imbi_automations/claude-code/agents/planning.md.j2 | 5/5 | Updated planning agent template with skip_task parameter documentation and usage examples |
| src/imbi_automations/claude-code/CLAUDE.md | 5/5 | Added skip_task parameter to planning response examples with clear use cases |
| AGENTS.md | 5/5 | Documented skip_task behavior in execution flow and key behaviors sections |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->