### PR TITLE
Add MCP server configuration support for workflows

### DIFF
--- a/docs/actions/claude.md
+++ b/docs/actions/claude.md
@@ -642,6 +642,66 @@ command = "git log -1 --pretty=%B"
 working_directory = "repository:///"
 ```
 
+## MCP Servers
+
+Claude actions automatically have access to MCP (Model Context Protocol) servers configured at the workflow level. These servers provide Claude with tools to access external data sources and APIs during task execution.
+
+### Configuration
+
+MCP servers are configured in the workflow's `config.toml` file under the `[mcp_servers]` section. See [MCP Server Configuration](../workflow-configuration.md#mcp-server-configuration) for full documentation.
+
+### Available Servers
+
+During Claude action execution, the following MCP servers are available:
+
+1. **`agent_tools`** (built-in): Provides workflow submission functions:
+   - `mcp__agent_tools__submit_planning_response()` - For planning agents
+   - `mcp__agent_tools__submit_task_response()` - For task agents
+   - `mcp__agent_tools__submit_validation_response()` - For validation agents
+
+2. **Workflow-configured servers**: Any MCP servers defined in `[mcp_servers.*]` sections
+
+### Example: Database Access
+
+```toml
+# Workflow config.toml
+[mcp_servers.postgres]
+type = "stdio"
+command = "uvx"
+args = ["mcp-server-postgres", "${DATABASE_URL}"]
+
+[[actions]]
+name = "analyze-schema"
+type = "claude"
+task_prompt = "prompts/analyze-schema.md"
+```
+
+**Prompt (`prompts/analyze-schema.md`):**
+```markdown
+# Analyze Database Schema
+
+Use the postgres MCP server to analyze the database schema.
+
+1. List all tables in the database
+2. Identify relationships between tables
+3. Generate a summary of the schema structure
+
+Use the `mcp__postgres__*` tools to query the database.
+```
+
+### Environment Variables in MCP Configs
+
+MCP server configurations support shell-style environment variable expansion (`$VAR` or `${VAR}`) for secure credential injection. Variables are expanded at runtime when the Claude client is created.
+
+```toml
+[mcp_servers.secure-api]
+type = "http"
+url = "https://api.example.com/mcp"
+headers = { Authorization = "Bearer ${API_TOKEN}" }
+```
+
+If a referenced environment variable is not set, a clear error is raised before execution begins.
+
 ## Performance Considerations
 
 - **API Costs**: Each cycle makes Claude API calls

--- a/src/imbi_automations/models/__init__.py
+++ b/src/imbi_automations/models/__init__.py
@@ -4,7 +4,7 @@ Centralizes imports for configuration, API responses (GitHub, GitLab, Imbi),
 workflow definitions, git operations, and Claude Code integration models.
 """
 
-from . import configuration, imbi
+from . import configuration, imbi, mcp
 from .claude import (
     ClaudeAgentPlanningResult,
     ClaudeAgentTaskResult,
@@ -41,6 +41,7 @@ from .imbi import (
     ImbiProjectLink,
     ImbiProjectType,
 )
+from .mcp import McpHttpServer, McpServerConfig, McpSSEServer, McpStdioServer
 from .resume_state import ResumeState
 from .workflow import (
     ResourceUrl,
@@ -79,6 +80,7 @@ from .workflow import (
 __all__ = [
     'configuration',
     'imbi',
+    'mcp',
     'AnthropicConfiguration',
     'ClaudeAgentPlanningResult',
     'ClaudeAgentTaskResult',
@@ -109,6 +111,10 @@ __all__ = [
     'ImbiProjectFactTypeRange',
     'ImbiProjectType',
     'ImbiProjectLink',
+    'McpHttpServer',
+    'McpServerConfig',
+    'McpSSEServer',
+    'McpStdioServer',
     'ResourceUrl',
     'ResumeState',
     'Workflow',

--- a/src/imbi_automations/models/mcp.py
+++ b/src/imbi_automations/models/mcp.py
@@ -1,0 +1,70 @@
+"""MCP (Model Context Protocol) server configuration models.
+
+Defines Pydantic models for configuring MCP servers in workflows,
+supporting stdio, SSE, and HTTP transport types as supported by
+the Claude Agent SDK.
+"""
+
+import typing
+
+import pydantic
+
+
+class McpStdioServer(pydantic.BaseModel):
+    """stdio MCP server configuration.
+
+    Launches an MCP server as a subprocess communicating via stdin/stdout.
+
+    Example:
+        [mcp_servers.my-postgres]
+        type = "stdio"
+        command = "uvx"
+        args = ["mcp-server-postgres", "postgresql://host/db"]
+        env = { DATABASE_URL = "postgresql://..." }
+    """
+
+    type: typing.Literal['stdio'] = 'stdio'
+    command: str
+    args: list[str] = []
+    env: dict[str, str] = {}
+
+
+class McpSSEServer(pydantic.BaseModel):
+    """SSE (Server-Sent Events) MCP server configuration.
+
+    Connects to an MCP server over HTTP using Server-Sent Events.
+
+    Example:
+        [mcp_servers.my-sse-server]
+        type = "sse"
+        url = "https://api.example.com/mcp/sse"
+        headers = { Authorization = "Bearer token" }
+    """
+
+    type: typing.Literal['sse']
+    url: str
+    headers: dict[str, str] = {}
+
+
+class McpHttpServer(pydantic.BaseModel):
+    """HTTP MCP server configuration.
+
+    Connects to an MCP server over HTTP.
+
+    Example:
+        [mcp_servers.my-http-server]
+        type = "http"
+        url = "https://api.example.com/mcp"
+        headers = { Authorization = "Bearer token" }
+    """
+
+    type: typing.Literal['http']
+    url: str
+    headers: dict[str, str] = {}
+
+
+McpServerConfig = typing.Annotated[
+    McpStdioServer | McpSSEServer | McpHttpServer,
+    pydantic.Field(discriminator='type'),
+]
+"""Union type for MCP server configurations with discriminated union."""

--- a/src/imbi_automations/models/workflow.py
+++ b/src/imbi_automations/models/workflow.py
@@ -14,7 +14,7 @@ import pydantic
 import pydantic_core
 from pydantic import AnyUrl
 
-from . import github, imbi, validators
+from . import github, imbi, mcp, validators
 
 
 def _ensure_file_scheme(v: str | pathlib.Path | pydantic.AnyUrl) -> str:
@@ -642,6 +642,7 @@ class WorkflowConfiguration(pydantic.BaseModel):
     git: WorkflowGit = pydantic.Field(default_factory=WorkflowGit)
     github: WorkflowGitHub = pydantic.Field(default_factory=WorkflowGitHub)
     filter: WorkflowFilter | None = None
+    mcp_servers: dict[str, mcp.McpServerConfig] = {}
     use_devcontainers: bool = False
 
     condition_type: WorkflowConditionType = WorkflowConditionType.all

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,311 @@
+"""Tests for MCP server configuration models."""
+
+import os
+import unittest
+
+import pydantic
+
+from imbi_automations import claude, models
+
+
+class McpStdioServerTestCase(unittest.TestCase):
+    """Test cases for McpStdioServer model."""
+
+    def test_minimal_config(self) -> None:
+        """Test minimal stdio server configuration with just command."""
+        server = models.McpStdioServer(command='uvx')
+        self.assertEqual(server.type, 'stdio')
+        self.assertEqual(server.command, 'uvx')
+        self.assertEqual(server.args, [])
+        self.assertEqual(server.env, {})
+
+    def test_full_config(self) -> None:
+        """Test full stdio server configuration with all fields."""
+        server = models.McpStdioServer(
+            command='uvx',
+            args=['mcp-server-postgres', 'postgresql://host/db'],
+            env={'DATABASE_URL': 'postgresql://host/db'},
+        )
+        self.assertEqual(server.type, 'stdio')
+        self.assertEqual(server.command, 'uvx')
+        self.assertEqual(
+            server.args, ['mcp-server-postgres', 'postgresql://host/db']
+        )
+        self.assertEqual(server.env, {'DATABASE_URL': 'postgresql://host/db'})
+
+    def test_model_dump(self) -> None:
+        """Test model_dump returns SDK-compatible dict."""
+        server = models.McpStdioServer(
+            command='uvx', args=['mcp-server-postgres']
+        )
+        dumped = server.model_dump()
+        self.assertEqual(dumped['type'], 'stdio')
+        self.assertEqual(dumped['command'], 'uvx')
+        self.assertEqual(dumped['args'], ['mcp-server-postgres'])
+        self.assertEqual(dumped['env'], {})
+
+
+class McpSSEServerTestCase(unittest.TestCase):
+    """Test cases for McpSSEServer model."""
+
+    def test_minimal_config(self) -> None:
+        """Test minimal SSE server configuration."""
+        server = models.McpSSEServer(
+            type='sse', url='https://api.example.com/mcp'
+        )
+        self.assertEqual(server.type, 'sse')
+        self.assertEqual(server.url, 'https://api.example.com/mcp')
+        self.assertEqual(server.headers, {})
+
+    def test_with_headers(self) -> None:
+        """Test SSE server configuration with headers."""
+        server = models.McpSSEServer(
+            type='sse',
+            url='https://api.example.com/mcp',
+            headers={'Authorization': 'Bearer token123'},
+        )
+        self.assertEqual(server.url, 'https://api.example.com/mcp')
+        self.assertEqual(server.headers, {'Authorization': 'Bearer token123'})
+
+    def test_model_dump(self) -> None:
+        """Test model_dump returns SDK-compatible dict."""
+        server = models.McpSSEServer(
+            type='sse',
+            url='https://api.example.com/mcp',
+            headers={'X-Api-Key': 'secret'},
+        )
+        dumped = server.model_dump()
+        self.assertEqual(dumped['type'], 'sse')
+        self.assertEqual(dumped['url'], 'https://api.example.com/mcp')
+        self.assertEqual(dumped['headers'], {'X-Api-Key': 'secret'})
+
+
+class McpHttpServerTestCase(unittest.TestCase):
+    """Test cases for McpHttpServer model."""
+
+    def test_minimal_config(self) -> None:
+        """Test minimal HTTP server configuration."""
+        server = models.McpHttpServer(
+            type='http', url='https://api.example.com/mcp'
+        )
+        self.assertEqual(server.type, 'http')
+        self.assertEqual(server.url, 'https://api.example.com/mcp')
+        self.assertEqual(server.headers, {})
+
+    def test_with_headers(self) -> None:
+        """Test HTTP server configuration with headers."""
+        server = models.McpHttpServer(
+            type='http',
+            url='https://api.example.com/mcp',
+            headers={'Authorization': 'Bearer token123'},
+        )
+        self.assertEqual(server.url, 'https://api.example.com/mcp')
+        self.assertEqual(server.headers, {'Authorization': 'Bearer token123'})
+
+
+class McpServerConfigDiscriminatorTestCase(unittest.TestCase):
+    """Test cases for McpServerConfig discriminated union."""
+
+    def test_parse_stdio_config(self) -> None:
+        """Test parsing stdio server from dict."""
+        data = {
+            'type': 'stdio',
+            'command': 'uvx',
+            'args': ['mcp-server-postgres'],
+        }
+        adapter = pydantic.TypeAdapter(models.McpServerConfig)
+        server = adapter.validate_python(data)
+        self.assertIsInstance(server, models.McpStdioServer)
+        self.assertEqual(server.command, 'uvx')
+
+    def test_parse_sse_config(self) -> None:
+        """Test parsing SSE server from dict."""
+        data = {'type': 'sse', 'url': 'https://api.example.com/mcp'}
+        adapter = pydantic.TypeAdapter(models.McpServerConfig)
+        server = adapter.validate_python(data)
+        self.assertIsInstance(server, models.McpSSEServer)
+        self.assertEqual(server.url, 'https://api.example.com/mcp')
+
+    def test_parse_http_config(self) -> None:
+        """Test parsing HTTP server from dict."""
+        data = {'type': 'http', 'url': 'https://api.example.com/mcp'}
+        adapter = pydantic.TypeAdapter(models.McpServerConfig)
+        server = adapter.validate_python(data)
+        self.assertIsInstance(server, models.McpHttpServer)
+        self.assertEqual(server.url, 'https://api.example.com/mcp')
+
+
+class WorkflowConfigurationMcpServersTestCase(unittest.TestCase):
+    """Test cases for mcp_servers field in WorkflowConfiguration."""
+
+    def test_empty_mcp_servers_default(self) -> None:
+        """Test mcp_servers defaults to empty dict."""
+        config = models.WorkflowConfiguration(name='test-workflow', actions=[])
+        self.assertEqual(config.mcp_servers, {})
+
+    def test_parse_mcp_servers_from_dict(self) -> None:
+        """Test parsing mcp_servers from configuration dict."""
+        data = {
+            'name': 'test-workflow',
+            'actions': [],
+            'mcp_servers': {
+                'my-postgres': {
+                    'type': 'stdio',
+                    'command': 'uvx',
+                    'args': ['mcp-server-postgres', 'postgresql://host/db'],
+                },
+                'my-api': {
+                    'type': 'http',
+                    'url': 'https://api.example.com/mcp',
+                    'headers': {'Authorization': 'Bearer token'},
+                },
+            },
+        }
+        config = models.WorkflowConfiguration.model_validate(data)
+        self.assertEqual(len(config.mcp_servers), 2)
+        self.assertIsInstance(
+            config.mcp_servers['my-postgres'], models.McpStdioServer
+        )
+        self.assertIsInstance(
+            config.mcp_servers['my-api'], models.McpHttpServer
+        )
+
+    def test_mcp_server_model_dump_for_sdk(self) -> None:
+        """Test that mcp_servers can be converted to SDK format."""
+        data = {
+            'name': 'test-workflow',
+            'actions': [],
+            'mcp_servers': {
+                'my-server': {
+                    'type': 'stdio',
+                    'command': 'uvx',
+                    'args': ['mcp-server'],
+                }
+            },
+        }
+        config = models.WorkflowConfiguration.model_validate(data)
+        server = config.mcp_servers['my-server']
+        sdk_config = server.model_dump()
+        # Verify SDK-compatible format
+        self.assertEqual(sdk_config['type'], 'stdio')
+        self.assertEqual(sdk_config['command'], 'uvx')
+        self.assertEqual(sdk_config['args'], ['mcp-server'])
+        self.assertIn('env', sdk_config)
+
+
+class ExpandEnvVarsTestCase(unittest.TestCase):
+    """Test cases for _expand_env_vars function."""
+
+    def setUp(self) -> None:
+        """Set up test environment variables."""
+        os.environ['TEST_MCP_VAR'] = 'test_value'
+        os.environ['TEST_MCP_KEY'] = 'key_12345'
+
+    def tearDown(self) -> None:
+        """Clean up test environment variables."""
+        os.environ.pop('TEST_MCP_VAR', None)
+        os.environ.pop('TEST_MCP_KEY', None)
+
+    def test_expand_dollar_var(self) -> None:
+        """Test expansion of $VAR syntax."""
+        result = claude._expand_env_vars('value=$TEST_MCP_VAR')
+        self.assertEqual(result, 'value=test_value')
+
+    def test_expand_braced_var(self) -> None:
+        """Test expansion of ${VAR} syntax."""
+        result = claude._expand_env_vars('value=${TEST_MCP_VAR}')
+        self.assertEqual(result, 'value=test_value')
+
+    def test_expand_multiple_vars(self) -> None:
+        """Test expansion of multiple variables."""
+        result = claude._expand_env_vars('$TEST_MCP_VAR:${TEST_MCP_KEY}')
+        self.assertEqual(result, 'test_value:key_12345')
+
+    def test_no_expansion_needed(self) -> None:
+        """Test string without variables passes through unchanged."""
+        result = claude._expand_env_vars('plain_string')
+        self.assertEqual(result, 'plain_string')
+
+    def test_missing_var_raises(self) -> None:
+        """Test that missing environment variable raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            claude._expand_env_vars('$NONEXISTENT_MCP_VAR')
+        self.assertIn('NONEXISTENT_MCP_VAR', str(ctx.exception))
+
+
+class ExpandMcpConfigTestCase(unittest.TestCase):
+    """Test cases for _expand_mcp_config function."""
+
+    def setUp(self) -> None:
+        """Set up test environment variables."""
+        os.environ['TEST_DB_URL'] = 'postgresql://host/db'
+        os.environ['TEST_API_KEY'] = 'api_key_12345'
+
+    def tearDown(self) -> None:
+        """Clean up test environment variables."""
+        os.environ.pop('TEST_DB_URL', None)
+        os.environ.pop('TEST_API_KEY', None)
+
+    def test_expand_args_list(self) -> None:
+        """Test expansion in args list."""
+        config = {
+            'type': 'stdio',
+            'command': 'uvx',
+            'args': ['mcp-server-postgres', '${TEST_DB_URL}'],
+            'env': {},
+        }
+        result = claude._expand_mcp_config(config)
+        self.assertEqual(
+            result['args'], ['mcp-server-postgres', 'postgresql://host/db']
+        )
+
+    def test_expand_headers_dict(self) -> None:
+        """Test expansion in headers dict."""
+        config = {
+            'type': 'http',
+            'url': 'https://api.example.com/mcp',
+            'headers': {'Authorization': 'Bearer ${TEST_API_KEY}'},
+        }
+        result = claude._expand_mcp_config(config)
+        self.assertEqual(
+            result['headers'], {'Authorization': 'Bearer api_key_12345'}
+        )
+
+    def test_expand_url_string(self) -> None:
+        """Test expansion in url string."""
+        config = {
+            'type': 'sse',
+            'url': 'https://api.example.com/mcp?key=${TEST_API_KEY}',
+            'headers': {},
+        }
+        result = claude._expand_mcp_config(config)
+        self.assertEqual(
+            result['url'], 'https://api.example.com/mcp?key=api_key_12345'
+        )
+
+    def test_expand_env_dict(self) -> None:
+        """Test expansion in env dict."""
+        config = {
+            'type': 'stdio',
+            'command': 'uvx',
+            'args': [],
+            'env': {'DATABASE_URL': '${TEST_DB_URL}'},
+        }
+        result = claude._expand_mcp_config(config)
+        self.assertEqual(
+            result['env'], {'DATABASE_URL': 'postgresql://host/db'}
+        )
+
+    def test_non_string_values_unchanged(self) -> None:
+        """Test that non-string values pass through unchanged."""
+        config = {
+            'type': 'stdio',
+            'command': 'uvx',
+            'args': [],
+            'env': {},
+            'some_number': 42,
+            'some_bool': True,
+        }
+        result = claude._expand_mcp_config(config)
+        self.assertEqual(result['some_number'], 42)
+        self.assertEqual(result['some_bool'], True)


### PR DESCRIPTION
## Summary

- Add MCP (Model Context Protocol) server configuration support at the workflow level
- Support for all Claude Agent SDK transport types: `stdio`, `http`, and `sse`
- Shell-style environment variable expansion (`$VAR` and `${VAR}`) for secure credential injection
- Comprehensive documentation in workflow configuration and Claude actions docs

## Changes

### New Files
- `src/imbi_automations/models/mcp.py` - Pydantic models for MCP server configuration with discriminated union for type-safe parsing
- `tests/test_mcp.py` - 24 unit tests covering MCP models and environment variable expansion

### Modified Files
- `src/imbi_automations/claude.py` - Added `_expand_env_vars()` and `_expand_mcp_config()` functions; updated `_create_client()` to merge workflow MCP servers
- `src/imbi_automations/models/workflow.py` - Added `mcp_servers` field to `WorkflowConfiguration`
- `src/imbi_automations/models/__init__.py` - Export new MCP models
- `docs/workflow-configuration.md` - Added MCP Server Configuration section with examples
- `docs/actions/claude.md` - Added MCP Servers section explaining usage in Claude actions
- `AGENTS.md` - Added MCP configuration documentation for AI assistants

## Example Usage

```toml
name = "data-analysis-workflow"

[mcp_servers.postgres]
type = "stdio"
command = "uvx"
args = ["mcp-server-postgres", "${DATABASE_URL}"]

[mcp_servers.internal-api]
type = "http"
url = "https://api.example.com/mcp"
headers = { Authorization = "Bearer ${API_TOKEN}" }

[[actions]]
name = "analyze-data"
type = "claude"
task_prompt = "prompts/analyze.md"
```

## Test plan

- [x] All 24 new MCP tests pass
- [x] Full test suite passes (421 tests)
- [x] Pre-commit hooks pass
- [ ] Manual verification with actual MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added Model Context Protocol (MCP) server configuration support for Claude actions. MCP servers can now be defined at the workflow level in three transport types (stdio, HTTP, SSE) with shell-style environment variable expansion (`$VAR`, `${VAR}`) for secure credential injection. Implementation includes well-structured Pydantic models with discriminated unions, comprehensive test coverage (24 tests), and clear documentation.

**Key Changes:**
- New `src/imbi_automations/models/mcp.py` with type-safe MCP server models
- Environment variable expansion in `claude.py` with validation for missing vars
- Workflow-level `mcp_servers` field merges with built-in `agent_tools` server
- Comprehensive examples in documentation covering all transport types

**Test Coverage:**
All 24 MCP tests pass according to PR description. Tests cover model validation, discriminated unions, environment variable expansion (including error cases), and workflow configuration parsing.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Well-architected implementation with comprehensive test coverage, clear documentation, and proper error handling. Uses Pydantic discriminated unions for type safety, validates environment variables at runtime, and follows existing code patterns
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/models/mcp.py | 5/5 | New file defining MCP server Pydantic models with discriminated unions for stdio, SSE, and HTTP transport types |
| src/imbi_automations/claude.py | 5/5 | Added env var expansion functions and MCP server merging logic to integrate workflow-defined MCP servers |
| tests/test_mcp.py | 5/5 | Comprehensive test suite with 24 tests covering MCP models, discriminated unions, and environment variable expansion |
| docs/workflow-configuration.md | 5/5 | Added comprehensive MCP Server Configuration section with examples for all transport types and env var expansion |

</details>



<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=f01b7d24-6f7b-4477-a7e0-a2e5f296be47))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a9f846fb-08a8-4371-8974-4fcfa7b639fd))
- Context from `dashboard` - docs/actions/claude.md ([source](https://app.greptile.com/review/custom-context?memory=9549c33a-0b28-48f0-8afb-6f6b64bca557))
</details>


<!-- /greptile_comment -->