### PR TITLE
Add Claude Code marketplace and plugins configuration support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,46 @@ args = ["mcp-server-postgres", "${DATABASE_URL}"]
 
 Supports `stdio`, `sse`, `http` transports. Environment variables expanded at runtime.
 
+### Claude Code Plugins
+
+Plugin configuration can be specified in both the main configuration file and workflow files. Workflow settings merge with main config (workflow values take precedence).
+
+**Main configuration (`config.toml`):**
+```toml
+[claude_code.plugins.enabled_plugins]
+"code-formatter@company-tools" = true
+"linter@company-tools" = true
+
+[claude_code.plugins.marketplaces.company-tools]
+source = "github"
+repo = "company-org/claude-plugins"
+
+[[claude_code.plugins.local_plugins]]
+path = "/path/to/local/plugin"
+```
+
+**Workflow configuration (`workflow.toml`):**
+```toml
+[plugins.enabled_plugins]
+"workflow-specific@marketplace" = true
+
+[plugins.marketplaces.workflow-marketplace]
+source = "git"
+url = "https://git.example.com/plugins.git"
+```
+
+**Marketplace source types:**
+| Type | Required Field | Description |
+|------|----------------|-------------|
+| `github` | `repo` | GitHub repository (e.g., `org/repo`) |
+| `git` | `url` | Any git URL |
+| `directory` | `path` | Local directory (dev only) |
+
+**Merging behavior:**
+- `enabled_plugins`: Merged, workflow overrides main
+- `marketplaces`: Merged, workflow overrides same-key entries
+- `local_plugins`: Concatenated, duplicates removed by path
+
 ## Workflow Resumability
 
 ```bash
@@ -176,7 +216,7 @@ State saved in `.state` file (MessagePack format) with:
 
 - Base class: `AsyncTestCase` (extends `unittest.IsolatedAsyncioTestCase`)
 - HTTP mocking: `httpx.MockTransport` with JSON fixtures in `tests/data/`
-- 459 tests with full async support
+- 475 tests with full async support
 
 ## CI/CD
 

--- a/src/imbi_automations/models/__init__.py
+++ b/src/imbi_automations/models/__init__.py
@@ -10,6 +10,11 @@ from .claude import (
     ClaudeAgentTaskResult,
     ClaudeAgentType,
     ClaudeAgentValidationResult,
+    ClaudeLocalPlugin,
+    ClaudeMarketplace,
+    ClaudeMarketplaceSource,
+    ClaudeMarketplaceSourceType,
+    ClaudePluginConfig,
 )
 from .configuration import (
     AnthropicConfiguration,
@@ -88,6 +93,11 @@ __all__ = [
     'ClaudeAgentType',
     'ClaudeAgentValidationResult',
     'ClaudeCodeConfiguration',
+    'ClaudeLocalPlugin',
+    'ClaudeMarketplace',
+    'ClaudeMarketplaceSource',
+    'ClaudeMarketplaceSourceType',
+    'ClaudePluginConfig',
     'Configuration',
     'GitCommit',
     'GitCommitSummary',

--- a/src/imbi_automations/models/configuration.py
+++ b/src/imbi_automations/models/configuration.py
@@ -12,6 +12,8 @@ import typing
 
 import pydantic
 
+from . import claude as claude_models
+
 
 class AnthropicConfiguration(pydantic.BaseModel):
     """Anthropic API configuration for Claude models.
@@ -84,13 +86,36 @@ class ClaudeCodeConfiguration(pydantic.BaseModel):
     """Claude Code SDK configuration.
 
     Configures the Claude Code executable path, base prompt file, model
-    selection, and whether AI-powered transformations are enabled.
+    selection, whether AI-powered transformations are enabled, and
+    marketplace/plugin settings.
+
+    Plugin configuration supports:
+    - enabled_plugins: Map of "plugin@marketplace" to enabled state
+    - marketplaces: Additional marketplace sources to register
+    - local_plugins: Local plugin directories loaded via SDK
+
+    Example TOML:
+        [claude_code]
+        model = "claude-sonnet-4"
+
+        [claude_code.plugins.enabled_plugins]
+        "code-formatter@team-tools" = true
+
+        [claude_code.plugins.marketplaces.team-tools]
+        source = "github"
+        repo = "company/claude-plugins"
+
+        [[claude_code.plugins.local_plugins]]
+        path = "/path/to/local/plugin"
     """
 
     executable: str = 'claude'  # Claude Code executable path
     base_prompt: pathlib.Path | None = None
     enabled: bool = True
     model: str = pydantic.Field(default='claude-haiku-4-5')
+    plugins: claude_models.ClaudePluginConfig = pydantic.Field(
+        default_factory=claude_models.ClaudePluginConfig
+    )
 
     def __init__(self, **kwargs: typing.Any) -> None:
         super().__init__(**kwargs)

--- a/src/imbi_automations/models/workflow.py
+++ b/src/imbi_automations/models/workflow.py
@@ -14,6 +14,7 @@ import pydantic
 import pydantic_core
 from pydantic import AnyUrl
 
+from . import claude as claude_models
 from . import github, imbi, mcp, validators
 
 
@@ -651,7 +652,21 @@ class WorkflowConfiguration(pydantic.BaseModel):
     """Complete workflow configuration with actions, conditions, and filters.
 
     Defines the full workflow structure including provider configurations,
-    execution conditions, filtering criteria, and action sequences.
+    execution conditions, filtering criteria, action sequences, and
+    Claude Code plugin settings.
+
+    Workflow-level plugin configuration merges with main config settings:
+    - enabled_plugins: Merged with main config (workflow can enable/disable)
+    - marketplaces: Merged with main config (workflow can add more)
+    - local_plugins: Concatenated with main config plugins
+
+    Example TOML:
+        [plugins.enabled_plugins]
+        "workflow-specific-plugin@marketplace" = true
+
+        [plugins.marketplaces.workflow-marketplace]
+        source = "github"
+        repo = "org/workflow-plugins"
     """
 
     name: str
@@ -661,6 +676,9 @@ class WorkflowConfiguration(pydantic.BaseModel):
     github: WorkflowGitHub = pydantic.Field(default_factory=WorkflowGitHub)
     filter: WorkflowFilter | None = None
     mcp_servers: dict[str, mcp.McpServerConfig] = {}
+    plugins: claude_models.ClaudePluginConfig = pydantic.Field(
+        default_factory=claude_models.ClaudePluginConfig
+    )
     use_devcontainers: bool = False
     max_followup_cycles: int = 5
 


### PR DESCRIPTION
## Summary

Enable workflows to leverage Claude Code plugins and marketplaces by adding configuration support at both the main configuration file and workflow levels. This allows teams to:

- Configure marketplace sources (GitHub repos, git URLs, or local directories)
- Enable/disable specific plugins from marketplaces
- Load local plugins directly via the Claude Agent SDK
- Override or extend main config settings at the workflow level

## Changes

- **New Models** (`models/claude.py`): Added `ClaudeMarketplaceSourceType`, `ClaudeMarketplaceSource`, `ClaudeMarketplace`, `ClaudeLocalPlugin`, and `ClaudePluginConfig` models with full validation
- **Configuration** (`models/configuration.py`): Added `plugins` field to `ClaudeCodeConfiguration`
- **Workflow** (`models/workflow.py`): Added `plugins` field to `WorkflowConfiguration`
- **Claude Client** (`claude.py`): Implemented `_merge_plugin_configs()` for merging workflow and main config; writes `enabledPlugins` and `extraKnownMarketplaces` to settings.json; passes local plugins to SDK
- **Tests**: Added 16 new tests covering model validation, merge behavior, and edge cases
- **Documentation**: Updated AGENTS.md with complete plugin configuration examples

## Configuration Examples

**Main configuration (`config.toml`):**
```toml
[claude_code.plugins.enabled_plugins]
"code-formatter@company-tools" = true
"linter@company-tools" = true

[claude_code.plugins.marketplaces.company-tools]
source = "github"
repo = "company-org/claude-plugins"

[[claude_code.plugins.local_plugins]]
path = "/path/to/local/plugin"
```

**Workflow configuration (`workflow.toml`):**
```toml
[plugins.enabled_plugins]
"workflow-specific@marketplace" = true

[plugins.marketplaces.workflow-marketplace]
source = "git"
url = "https://git.example.com/plugins.git"
```

## Merge Behavior

| Config Type | Behavior |
|-------------|----------|
| `enabled_plugins` | Workflow values override main config |
| `marketplaces` | Workflow values override main config for same keys |
| `local_plugins` | Concatenated (duplicates removed by path) |

## Test plan

- [x] All 475 tests pass (16 new tests added)
- [x] Pre-commit hooks pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds comprehensive Claude Code plugin and marketplace configuration support to enable workflows to leverage custom plugins. The implementation is well-structured with proper validation, testing, and documentation.

**Key changes:**
- Added Pydantic models for marketplace sources (GitHub, git, directory) with validation
- Implemented plugin configuration merging between main config and workflow config
- Integrated plugins into Claude SDK via `settings.json` and SDK plugin parameters
- Added 16 new tests with 100% coverage of the new functionality
- Updated `AGENTS.md` with complete configuration examples and merge behavior documentation

**Implementation highlights:**
- Shorthand TOML format support in `ClaudeMarketplace.wrap_source()` for ergonomic configuration
- Proper deduplication of local plugins by path in merge logic
- Settings written to `enabledPlugins` and `extraKnownMarketplaces` in Claude Code's settings.json
- Local plugins passed to SDK via `plugins` parameter with proper type mapping

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is thorough and well-tested with 16 new test cases covering all models, validation logic, and merge behavior. The code follows established patterns in the codebase, uses proper Pydantic validation, and includes comprehensive documentation. No logical errors or security issues were identified.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/models/claude.py | 5/5 | Added comprehensive plugin configuration models with proper validation and TOML shorthand support |
| src/imbi_automations/claude.py | 5/5 | Implemented plugin config merging, settings.json generation, and SDK integration with local plugins |
| tests/test_claude.py | 5/5 | Added 16 comprehensive tests covering model validation, merge behavior, and edge cases |
| AGENTS.md | 5/5 | Added comprehensive plugin configuration documentation with examples and merge behavior details |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->