### PR TITLE
Bump version to 1.0.0a13 with config and Docker improvements

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
+      attestations: write
       contents: read
       id-token: write
       packages: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.26
+    rev: v1.7.9
     hooks:
       - id: actionlint
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.12-trixie
 
-ENV GIT_USER_NAME="Imbi Automations" \
+ENV CLAUDE_CODE_USE_ANTHROPIC_API=1 \
+    GH_HOST=github.com \
+    GIT_USER_NAME="Imbi Automations" \
     GIT_USER_EMAIL="imbi-automations@aweber.com" \
     IMBI_AUTOMATIONS_CONFIG=/opt/config/config.toml
 
@@ -19,7 +21,6 @@ RUN apt-get update \
         ripgrep \
         sudo \
  && rm -rf /var/lib/apt/lists/* \
- && curl -fsSL https://claude.ai/install.sh | bash  \
  && pip install --root-user-action ignore --break-system-packages --no-cache-dir --upgrade pip \
  && pip install --root-user-action ignore --break-system-packages --no-cache-dir /tmp/imbi_automations*.whl \
  && rm /tmp/*.whl \
@@ -28,14 +29,16 @@ RUN apt-get update \
  && useradd --uid 1000 --gid 1000 --shell /bin/bash \
             --home-dir /home/imbi-automations --create-home \
             imbi-automations \
- && echo "imbi-automations ALL=(ALL) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt, /usr/bin/rm" >> /etc/sudoers.d/imbi-automations \
- && chmod 0440 /etc/sudoers.d/imbi-automations \
+ && echo "imbi-automations ALL=(ALL) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt, /usr/bin/rm, /usr/bin/chmod, /usr/bin/chown" >> /etc/sudoers.d/imbi-automations \
+ && chmod 440 /etc/sudoers.d/imbi-automations \
  && mkdir -p /home/imbi-automations/.ssh \
  && chmod 700 /home/imbi-automations/.ssh \
  && chown -R imbi-automations:imbi-automations /opt /docker-entrypoint-init.d \
  && chmod +x /usr/local/bin/docker-entrypoint.sh
 
 USER imbi-automations
+
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 WORKDIR /opt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
  && pip install --root-user-action ignore --break-system-packages --no-cache-dir --upgrade pip \
  && pip install --root-user-action ignore --break-system-packages --no-cache-dir /tmp/imbi_automations*.whl \
  && rm /tmp/*.whl \
- && mkdir -p /opt/config /opt/errors /opt/workflows /docker-entrypoint-init.d \
+ && mkdir -p /opt/config /opt/errors /opt/logs /opt/workflows /docker-entrypoint-init.d \
  && groupadd --gid 1000 imbi-automations \
  && useradd --uid 1000 --gid 1000 --shell /bin/bash \
             --home-dir /home/imbi-automations --create-home \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -62,16 +62,16 @@ if [ -d "$INIT_DIR" ] && [ "$(ls -A $INIT_DIR 2>/dev/null)" ]; then
     # Install apt packages (batch for efficiency)
     if [ -n "$APT_PACKAGES" ]; then
         echo "Installing system packages: $APT_PACKAGES"
-        sudo apt-get update >> /var/log/entrypoint.log 2>&1
-        sudo apt-get install -y --no-install-recommends $APT_PACKAGES >> /var/log/entrypoint.log 2>&1
-        sudo apt-get clean >> /var/log/entrypoint.log 2>&1
+        sudo apt-get update >> /opt/logs/entrypoint.log 2>&1
+        sudo apt-get install -y --no-install-recommends $APT_PACKAGES >> /opt/logs/entrypoint.log 2>&1
+        sudo apt-get clean >> /opt/logs/entrypoint.log 2>&1
         sudo rm -rf /var/lib/apt/lists/*
     fi
 
     # Install pip packages
     for f in $PIP_FILES; do
         echo "Installing pip packages from: $f"
-        pip install --user --no-cache-dir -r "$f" >> /var/log/entrypoint.log 2>&1
+        pip install --user --no-cache-dir -r "$f" >> /opt/logs/entrypoint.log 2>&1
     done
 
     # Run shell scripts

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /home/imbi-automations/.profile
+
 # --- Initialization Directory Processing ---
 # Similar to database images' /docker-entrypoint-initdb.d pattern
 # Supports: .apt (system packages), .pip (pip packages), .sh (scripts)
@@ -112,9 +114,7 @@ Host *
 EOF
 
     # Add GitHub hosts to known_hosts
-    for host in github.com; do
-        ssh-keyscan -t ed25519,rsa "$host" >> "$SSH_DIR/known_hosts" 2>/dev/null || true
-    done
+	ssh-keyscan -t ed25519,rsa "github.com" >> "$SSH_DIR/known_hosts" 2>/dev/null || true
 
     # Scan GHE host if GITHUB_HOSTNAME is set (strip api. prefix if present)
     if [ -n "$GITHUB_HOSTNAME" ]; then
@@ -138,19 +138,6 @@ if [ -n "$SSH_KEY_PATH" ] && [ -f "${SSH_KEY_PATH}.pub" ]; then
     SIGNERS_FILE="$SSH_DIR/allowed_signers"
     echo "${GIT_USER_EMAIL} $(cat "${SSH_KEY_PATH}.pub")" > "$SIGNERS_FILE"
     git config --global gpg.ssh.allowedSignersFile "$SIGNERS_FILE"
-fi
-
-# --- GitHub CLI Authentication ---
-# Option 1: GH_TOKEN environment variable (already works natively)
-# Option 2: Token file at /config/gh-token or ~/.config/gh/token
-if [ -z "$GH_TOKEN" ]; then
-    for token_file in /config/gh-token ~/.config/gh/token; do
-        if [ -f "$token_file" ]; then
-            export GH_TOKEN=$(cat "$token_file")
-            echo "Loaded GitHub token from $token_file"
-            break
-        fi
-    done
 fi
 
 # Execute the main command

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,27 @@ set -e
 
 source /home/imbi-automations/.profile
 
+# --- Required Environment Variables ---
+# Check that required environment variables are set
+MISSING_VARS=""
+
+if [ -z "$ANTHROPIC_API_KEY" ] || [ "$ANTHROPIC_API_KEY" = "unspecified" ]; then
+    MISSING_VARS="$MISSING_VARS ANTHROPIC_API_KEY"
+fi
+
+if [ -z "$IMBI_API_KEY" ] || [ "$IMBI_API_KEY" = "unspecified" ]; then
+    MISSING_VARS="$MISSING_VARS IMBI_API_KEY"
+fi
+
+if [ -z "$GH_TOKEN" ] || [ "$GH_TOKEN" = "unspecified" ]; then
+    MISSING_VARS="$MISSING_VARS GH_TOKEN"
+fi
+
+if [ -n "$MISSING_VARS" ]; then
+    echo "Error: Required environment variables are not set:$MISSING_VARS" >&2
+    exit 1
+fi
+
 # --- Initialization Directory Processing ---
 # Similar to database images' /docker-entrypoint-initdb.d pattern
 # Supports: .apt (system packages), .pip (pip packages), .sh (scripts)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -62,16 +62,16 @@ if [ -d "$INIT_DIR" ] && [ "$(ls -A $INIT_DIR 2>/dev/null)" ]; then
     # Install apt packages (batch for efficiency)
     if [ -n "$APT_PACKAGES" ]; then
         echo "Installing system packages: $APT_PACKAGES"
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends $APT_PACKAGES
-        sudo apt-get clean
+        sudo apt-get update >> /var/log/entrypoint.log 2>&1
+        sudo apt-get install -y --no-install-recommends $APT_PACKAGES >> /var/log/entrypoint.log 2>&1
+        sudo apt-get clean >> /var/log/entrypoint.log 2>&1
         sudo rm -rf /var/lib/apt/lists/*
     fi
 
     # Install pip packages
     for f in $PIP_FILES; do
         echo "Installing pip packages from: $f"
-        pip install --user --no-cache-dir -r "$f"
+        pip install --user --no-cache-dir -r "$f" >> /var/log/entrypoint.log 2>&1
     done
 
     # Run shell scripts

--- a/docs/actions/claude.md
+++ b/docs/actions/claude.md
@@ -239,9 +239,9 @@ Prompts have access to all workflow context variables:
 | `github_repository` | GitHub repository (if applicable) |
 | `working_directory` | Execution directory path (task agent runs in `repository/` subdirectory) |
 | `starting_commit` | Initial commit SHA |
-| `commit_author` | Git commit author (from config) |
-| `commit_author_name` | Author name only |
-| `commit_author_address` | Author email only |
+| `commit_author` | Git commit author string (e.g., "Name <email>") |
+| `commit_author_name` | Git author name (from `git.user_name`) |
+| `commit_author_address` | Git author email (from `git.user_email`) |
 | `workflow_name` | Current workflow name |
 
 ## Examples

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,4 @@
-# Configuration
+# Configuration File
 
 Imbi Automations uses TOML-based configuration files with Pydantic validation for all settings. This document describes all available configuration options.
 
@@ -15,7 +15,6 @@ imbi-automations config.toml workflows/workflow-name --all-projects
 ```toml
 # Global Settings
 ai_commits = false
-commit_author = "Imbi Automations <noreply@example.com>"
 dry_run = false
 dry_run_dir = "./dry-runs"
 error_dir = "./errors"
@@ -27,15 +26,20 @@ api_key = "${ANTHROPIC_API_KEY}"  # Or set directly
 bedrock = false
 model = "claude-3-5-sonnet-latest"
 
-# Claude Code SDK Configuration
-[claude_code]
+# Claude Agent SDK Configuration
+[claude]
 executable = "claude"
 enabled = true
 
+# Git Configuration
+[git]
+user_name = "Imbi Automations"
+user_email = "automations@imbi.ai"
+
 # GitHub API Configuration
 [github]
-api_key = "ghp_your_github_token"
-hostname = "github.com"
+token = "ghp_your_github_token"
+host = "github.com"
 
 # Imbi Project Management Configuration
 [imbi]
@@ -60,26 +64,12 @@ When enabled, uses Anthropic API to generate commit messages based on changes.
 ai_commits = true
 ```
 
-### commit_author
-
-Git commit author information for automated commits.
-
-**Type:** `string`  
-**Default:** `"Imbi Automations <noreply@aweber.com>"`  
-**Format:** `"Name <email>"`  
-
-
-```toml
-commit_author = "Bot User <bot@example.com>"
-```
-
 ### error_dir
 
 Directory to store error logs and debugging information when workflows fail.
 
 **Type:** `path`  
-
-**Default:** `"./errors"`  
+**Default:** `./errors`  
 
 ```toml
 error_dir = "/var/log/imbi-automations/errors"
@@ -137,7 +127,7 @@ Working directories are preserved to `dry_run_dir` for inspection.
 Directory for saving repository state during dry-run executions.
 
 **Type:** `path`  
-**Default:** `"./dry-runs"`  
+**Default:** `./dry-runs`  
 
 ```toml
 dry_run_dir = "./review-changes"
@@ -205,86 +195,77 @@ bedrock = true
 Claude model to use for API requests.
 
 **Type:** `string`  
-**Default:** `"claude-3-5-haiku-latest"`  
-
-**Available Models:**  
-
-- `claude-3-5-sonnet-latest` - Most capable, higher cost
-- `claude-3-5-haiku-latest` - Fast and efficient (default)
-- `claude-3-opus-latest` - Highest capability, highest cost
+**Default:** `claude-haiku-4-5-20251001`  
 
 ```toml
 [anthropic]
-model = "claude-3-5-sonnet-latest"
+model = "claude-opus-4-5"
 ```
 
-## Claude Code Configuration
+## Claude Configuration
 
-Configuration for Claude Code SDK integration.
+Configuration for Claude Agent SDK integration.
 
-### [claude_code].executable
+### [claude].executable
 
 Path or command name for Claude Code executable.
 
-**Type:** `string`  
-**Default:** `"claude"`  
+**Type:** `string`
+**Default:** `claude`
 
 ```toml
-[claude_code]
+[claude]
 executable = "/usr/local/bin/claude"
 ```
 
-### [claude_code].enabled
+### [claude].enabled
 
 Enable Claude Code actions in workflows.
 
-**Type:** `boolean`  
-**Default:** `true`  
+**Type:** `boolean`
+**Default:** `true`
 
 Set to `false` to disable all Claude actions:
 
 ```toml
-[claude_code]
+[claude]
 enabled = false
 ```
 
-### [claude_code].base_prompt
+### [claude].base_prompt
 
 Custom base prompt file for Claude Code sessions.
 
-**Type:** `path`  
-
-**Default:** `src/imbi_automations/prompts/claude.md`  
+**Type:** `path`
+**Default:** `src/imbi_automations/prompts/claude.md`
 
 ```toml
-[claude_code]
+[claude]
 base_prompt = "/path/to/custom-prompt.md"
 ```
 
-### [claude_code].plugins
+### [claude].plugins
 
 Plugin and marketplace configuration for Claude Code. These settings are merged with workflow-level plugin settings (workflow values take precedence).
 
 **Type:** `ClaudePluginConfig` object
+**Default:** Empty (no plugins)
 
-**Default:** Empty (no plugins)  
-
-#### [claude_code.plugins].enabled_plugins
+#### [claude.plugins].enabled_plugins
 
 Enable or disable specific plugins from marketplaces.
 
 **Type:** `dict[string, boolean]`  
-
-**Format:** `"plugin-name@marketplace-name" = true/false`  
+**Format:** `plugin-name@marketplace-name" = true/false`  
 
 ```toml
-[claude_code.plugins.enabled_plugins]
+[claude.plugins.enabled_plugins]
 "git-repository@aweber-marketplace" = true
 "python-developer@aweber-marketplace" = true
 "grafana-mcp@aweber-marketplace" = false
 ```
 
-#### [claude_code.plugins.marketplaces]
+#### [claude.plugins.marketplaces]
 
 Configure additional marketplace sources for plugins.
 
@@ -300,71 +281,149 @@ Each marketplace requires a `source` type and corresponding field:
 
 ```toml
 # GitHub marketplace
-[claude_code.plugins.marketplaces.company-tools]
+[claude.plugins.marketplaces.company-tools]
 source = "github"
 repo = "company-org/claude-plugins"
 
 # Git URL marketplace (e.g., GitHub Enterprise)
-[claude_code.plugins.marketplaces.enterprise-tools]
+[claude.plugins.marketplaces.enterprise-tools]
 source = "git"
 url = "https://github.enterprise.com/org/claude-plugins.git"
 
 # Local directory (development)
-[claude_code.plugins.marketplaces.dev-plugins]
+[claude.plugins.marketplaces.dev-plugins]
 source = "directory"
 path = "/path/to/local/marketplace"
 ```
 
-#### [[claude_code.plugins.local_plugins]]
+#### [[claude.plugins.local_plugins]]
 
 Load local plugin directories directly via the Claude Agent SDK.
 
 **Type:** `list[ClaudeLocalPlugin]`  
 
 ```toml
-[[claude_code.plugins.local_plugins]]
+[[claude.plugins.local_plugins]]
 path = "/path/to/local/plugin"
 
-[[claude_code.plugins.local_plugins]]
+[[claude.plugins.local_plugins]]
 path = "/another/plugin/directory"
 ```
 
 #### Complete Plugin Configuration Example
 
 ```toml
-[claude_code]
+[claude]
 enabled = true
 model = "claude-sonnet-4"
 
-[claude_code.plugins.enabled_plugins]
+[claude.plugins.enabled_plugins]
 "git-repository@aweber-marketplace" = true
 "python-developer@aweber-marketplace" = true
 "grafana-mcp@aweber-marketplace" = false
 
-[claude_code.plugins.marketplaces.aweber-marketplace]
+[claude.plugins.marketplaces.aweber-marketplace]
 source = "git"
 url = "https://github.enterprise.com/claude/marketplace.git"
 
-[claude_code.plugins.marketplaces.community]
+[claude.plugins.marketplaces.community]
 source = "github"
 repo = "anthropics/claude-plugins"
 
-[[claude_code.plugins.local_plugins]]
+[[claude.plugins.local_plugins]]
 path = "/home/user/my-custom-plugin"
+```
+
+## Git Configuration
+
+Configuration for git commit operations.
+
+### [git].user_name
+
+Git commit author name.
+
+**Type:** `string`
+**Default:** `Imbi Automations`
+
+```toml
+[git]
+user_name = "Bot User"
+```
+
+### [git].user_email
+
+Git commit author email address.
+
+**Type:** `string`
+**Default:** `automations@imbi.ai`
+
+```toml
+[git]
+user_email = "bot@example.com"
+```
+
+### [git].gpg_sign
+
+Enable GPG signing for commits.
+
+**Type:** `boolean`
+**Default:** `false`
+
+```toml
+[git]
+gpg_sign = true
+signing_key = "ABCD1234..."
+```
+
+### [git].gpg_format
+
+GPG signing format.
+
+**Type:** `string`
+**Default:** `null`
+**Options:** `gpg`, `ssh`, `x509`, `openpgp`
+
+```toml
+[git]
+gpg_format = "ssh"
+```
+
+### [git].signing_key
+
+GPG or SSH signing key identifier.
+
+**Type:** `string`
+**Default:** `null`
+
+```toml
+[git]
+signing_key = "~/.ssh/id_ed25519.pub"
+```
+
+### [git].commit_args
+
+Additional arguments to pass to git commit commands.
+
+**Type:** `string`
+**Default:** `""`
+
+```toml
+[git]
+commit_args = "--no-verify"
 ```
 
 ## GitHub Configuration
 
 Configuration for GitHub API integration.
 
-### [github].api_key
+### [github].token
 
 GitHub personal access token or fine-grained token.
 
-**Type:** `string` (secret)  
-**Required:** For GitHub workflows  
+**Type:** `string` (secret)
+**Required:** For GitHub workflows
 
-**Token Permissions Required:**  
+**Token Permissions Required:**
 
 - `repo` - Full repository access
 - `workflow` - Update GitHub Actions workflows
@@ -372,20 +431,20 @@ GitHub personal access token or fine-grained token.
 
 ```toml
 [github]
-api_key = "ghp_your_github_personal_access_token"
+token = "ghp_your_github_personal_access_token"
 ```
 
-### [github].hostname
+### [github].host
 
 GitHub hostname for Enterprise installations.
 
-**Type:** `string`  
-**Default:** `"github.com"`  
+**Type:** `string`
+**Default:** `github.com`
 
 For GitHub Enterprise:
 ```toml
 [github]
-hostname = "github.enterprise.com"
+host = "github.enterprise.com"
 ```
 
 ## Imbi Configuration
@@ -423,10 +482,10 @@ Project identifier field names in Imbi for external systems.
 **Type:** `string`  
 **Defaults:**  
 
-- `github_identifier = "github"`
-- `pagerduty_identifier = "pagerduty"`
-- `sonarqube_identifier = "sonarqube"`
-- `sentry_identifier = "sentry"`
+- `github_identifier = "github`
+- `pagerduty_identifier = "pagerduty`
+- `sonarqube_identifier = "sonarqube`
+- `sentry_identifier = "sentry`
 
 These specify which Imbi project identifier fields contain external system references:
 
@@ -442,11 +501,11 @@ Link type names in Imbi for external system URLs.
 **Type:** `string`  
 **Defaults:**  
 
-- `github_link = "GitHub Repository"`
-- `grafana_link = "Grafana Dashboard"`
-- `pagerduty_link = "PagerDuty"`
-- `sentry_link = "Sentry"`
-- `sonarqube_link = "SonarQube"`
+- `github_link = "GitHub Repository`
+- `grafana_link = "Grafana Dashboard`
+- `pagerduty_link = "PagerDuty`
+- `sentry_link = "Sentry`
+- `sonarqube_link = "SonarQube`
 
 These specify the link type names used in Imbi to store external URLs:
 
@@ -521,28 +580,33 @@ cat ~/.cache/imbi-automations/metadata.json | jq .
 
 ## Environment Variables
 
-Several configuration values support environment variable substitution:
+All configuration sections support automatic environment variable loading via Pydantic Settings. Each section has a prefix:
 
-### Supported in Configuration File
+| Section | Prefix | Example Variable |
+|---------|--------|------------------|
+| `[anthropic]` | `ANTHROPIC_` | `ANTHROPIC_API_KEY` |
+| `[claude]` | `CLAUDE_` | `CLAUDE_MODEL` |
+| `[git]` | `GIT_` | `GIT_USER_NAME` |
+| `[github]` | `GH_` | `GH_TOKEN` |
+| `[imbi]` | `IMBI_` | `IMBI_API_KEY` |
+
+For a complete reference of all available environment variables, see [Environment Variables](environment-variables.md).
+
+### Quick Example
+
+```bash
+# Set required environment variables
+export GH_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxx"
+export IMBI_API_KEY="your-api-key-uuid"
+export IMBI_HOSTNAME="imbi.example.com"
+```
+
+Then use empty sections in your config to load from environment:
 
 ```toml
 [github]
-api_key = "${GITHUB_TOKEN}"
-
-[anthropic]
-api_key = "${ANTHROPIC_API_KEY}"
-
 [imbi]
-api_key = "${IMBI_API_KEY}"
 ```
-
-### Environment Variable Defaults
-
-Some fields use environment variables as defaults if not specified:
-
-| Configuration Field | Environment Variable |
-|---------------------|---------------------|
-| `anthropic.api_key` | `ANTHROPIC_API_KEY` |
 
 ## Minimal Configuration
 
@@ -550,7 +614,7 @@ The absolute minimum configuration for basic GitHub workflows:
 
 ```toml
 [github]
-api_key = "ghp_your_token"
+token = "ghp_your_token"
 
 [imbi]
 api_key = "your-imbi-key"
@@ -565,17 +629,17 @@ Configuration is validated at startup using Pydantic. Common errors:
 
 ```
 ValidationError: 1 validation error for Configuration
-github.api_key
+github.token
   field required (type=value_error.missing)
 ```
 
 **Solution:** Add the required field to your config.toml
 
-### Invalid API Key Format
+### Invalid Token Format
 
 ```
 ValidationError: 1 validation error for Configuration
-github.api_key
+github.token
   string does not match regex (type=value_error.str.regex)
 ```
 
@@ -600,11 +664,11 @@ imbi.hostname
 ```toml
 # ❌ BAD - Keys in config file
 [github]
-api_key = "ghp_actual_key_here"
+token = "ghp_actual_key_here"
 
 # ✅ GOOD - Environment variables
 [github]
-api_key = "${GITHUB_TOKEN}"
+token = "${GITHUB_TOKEN}"
 ```
 
 ### File Permissions
@@ -644,10 +708,12 @@ imbi-automations config.prod.toml workflows/deploy
 ### GitHub Only Workflows
 
 ```toml
-commit_author = "GitHub Bot <bot@example.com>"
+[git]
+user_name = "GitHub Bot"
+user_email = "bot@example.com"
 
 [github]
-api_key = "${GITHUB_TOKEN}"
+token = "${GITHUB_TOKEN}"
 
 [imbi]
 api_key = "${IMBI_API_KEY}"
@@ -658,8 +724,8 @@ hostname = "imbi.example.com"
 
 ```toml
 [github]
-api_key = "${GITHUB_ENTERPRISE_TOKEN}"
-hostname = "github.enterprise.com"
+token = "${GITHUB_ENTERPRISE_TOKEN}"
+host = "github.enterprise.com"
 
 [imbi]
 api_key = "${IMBI_API_KEY}"
@@ -675,12 +741,12 @@ ai_commits = true
 api_key = "${ANTHROPIC_API_KEY}"
 model = "claude-3-5-sonnet-latest"
 
-[claude_code]
+[claude]
 enabled = true
 executable = "claude"
 
 [github]
-api_key = "${GITHUB_TOKEN}"
+token = "${GITHUB_TOKEN}"
 
 [imbi]
 api_key = "${IMBI_API_KEY}"
@@ -694,7 +760,7 @@ preserve_on_error = true
 error_dir = "/tmp/imbi-errors"
 
 [github]
-api_key = "${GITHUB_TOKEN}"
+token = "${GITHUB_TOKEN}"
 
 [imbi]
 api_key = "${IMBI_API_KEY}"
@@ -709,7 +775,7 @@ dry_run = true
 dry_run_dir = "./review-changes"
 
 [github]
-api_key = "${GITHUB_TOKEN}"
+token = "${GITHUB_TOKEN}"
 
 [imbi]
 api_key = "${IMBI_API_KEY}"
@@ -747,7 +813,7 @@ imbi-automations /path/to/config.toml workflows/name --all-projects
 1. Validate TOML syntax with online validator
 2. Check for missing quotes around strings
 3. Verify section headers use `[section]` format
-4. Ensure key-value pairs use `key = "value"` format
+4. Ensure key-value pairs use `key = "value` format
 
 ## Advanced Configuration
 
@@ -767,19 +833,22 @@ Creates:
         └── error.log
 ```
 
-### Custom Commit Author Per Workflow
+### Custom Git Author Per Workflow
 
 Set in workflow config.toml instead:
 
 ```toml
 # workflows/my-workflow/config.toml
-commit_author = "Workflow Bot <workflow@example.com>"
+[git]
+user_name = "Workflow Bot"
+user_email = "workflow@example.com"
 ```
 
-Overrides global `commit_author` for that workflow only.
+Overrides global git author settings for that workflow only.
 
 ## See Also
 
+- [Environment Variables](environment-variables.md) - Complete environment variable reference
 - [Workflow Actions](actions/index.md) - Complete action configuration reference
 - [Architecture](architecture.md) - System design and components
 - [GitHub Actions](actions/github.md) - GitHub-specific configuration

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -14,7 +14,9 @@ docker run --rm \
     -v $(pwd)/config.toml:/opt/config/config.toml:ro \
     -v $(pwd)/workflows:/opt/workflows:ro \
     -v ~/.ssh:/home/imbi-automations/.ssh:ro \
-    -e GH_TOKEN="ghp_your_token" \
+    -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+    -e IMBI_API_KEY="$IMBI_API_KEY" \
+    -e GH_TOKEN="$GH_TOKEN" \
     aweber/imbi-automations:latest \
     /opt/config/config.toml \
     /opt/workflows/my-workflow \
@@ -33,11 +35,26 @@ docker run --rm \
 
 ## Environment Variables
 
+### Required Variables
+
+The following environment variables **must** be set when running the container. The entrypoint will exit with an error if any are missing:
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | Anthropic API key for Claude |
+| `IMBI_API_KEY` | Imbi API key |
+| `GH_TOKEN` | GitHub personal access token |
+
+!!! note
+    These variables are required even if the same values are specified in the configuration file. When running in Docker, the configuration file does not need to include `anthropic.api_key`, `imbi.api_key`, or `github.token` - they are automatically loaded from environment variables via pydantic-settings.
+
+### Optional Variables
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `GIT_USER_NAME` | `Imbi Automations` | Git commit author name |
 | `GIT_USER_EMAIL` | `imbi-automations@aweber.com` | Git commit author email |
-| `GH_TOKEN` | - | GitHub personal access token |
+| `GH_HOST` | `github.com` | GitHub hostname (for GitHub Enterprise) |
 
 ## SSH Commit Signing
 
@@ -214,9 +231,13 @@ services:
       - ./workflows:/opt/workflows:ro
       - ~/.ssh:/home/imbi-automations/.ssh:ro
     environment:
+      # Required
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - IMBI_API_KEY=${IMBI_API_KEY}
+      - GH_TOKEN=${GH_TOKEN}
+      # Optional
       - GIT_USER_NAME=Imbi Automations
       - GIT_USER_EMAIL=imbi-automations@example.com
-      - GH_TOKEN=${GH_TOKEN}
 ```
 
 Run with:

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,242 @@
+# Environment Variables
+
+Imbi Automations supports configuration through environment variables. These can be used instead of or in addition to the TOML configuration file. Environment variables take precedence when a configuration section is not explicitly defined in the config file.
+
+## Quick Reference
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `ANTHROPIC_API_KEY` | Anthropic API key for Claude | For AI features |
+| `GH_TOKEN` | GitHub personal access token | For GitHub workflows |
+| `IMBI_API_KEY` | Imbi API authentication key | Always |
+| `IMBI_HOSTNAME` | Imbi instance hostname | Always |
+
+## How Environment Variables Work
+
+Each configuration section uses a prefix for its environment variables:
+
+| Section | Prefix | Example |
+|---------|--------|---------|
+| `[anthropic]` | `ANTHROPIC_` | `ANTHROPIC_API_KEY` |
+| `[claude]` | `CLAUDE_` | `CLAUDE_MODEL` |
+| `[git]` | `GIT_` | `GIT_USER_NAME` |
+| `[github]` | `GH_` | `GH_TOKEN` |
+| `[imbi]` | `IMBI_` | `IMBI_API_KEY` |
+
+Environment variables are **case-insensitive** and support `.env` file loading.
+
+## Anthropic Configuration
+
+Environment variables for Anthropic Claude API integration.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ANTHROPIC_API_KEY` | secret | - | Anthropic API key for Claude models |
+| `ANTHROPIC_BEDROCK` | boolean | `false` | Use AWS Bedrock instead of direct API |
+| `ANTHROPIC_MODEL` | string | `claude-haiku-4-5-20251001` | Claude model to use |
+
+**Example:**
+```bash
+export ANTHROPIC_API_KEY="sk-ant-api03-..."
+export ANTHROPIC_MODEL="claude-sonnet-4-20250514"
+```
+
+## Claude Agent SDK Configuration
+
+Environment variables for Claude Agent SDK integration.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `CLAUDE_EXECUTABLE` | string | `claude` | Path to Claude Code executable |
+| `CLAUDE_BASE_PROMPT` | path | (built-in) | Custom base prompt file path |
+| `CLAUDE_ENABLED` | boolean | `true` | Enable Claude Code actions |
+| `CLAUDE_MODEL` | string | `claude-haiku-4-5` | Model for Claude Agent SDK |
+
+**Example:**
+```bash
+export CLAUDE_EXECUTABLE="/usr/local/bin/claude"
+export CLAUDE_MODEL="claude-sonnet-4"
+export CLAUDE_ENABLED="true"
+```
+
+## Git Configuration
+
+Environment variables for git commit operations.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `GIT_USER_NAME` | string | `Imbi Automations` | Git commit author name |
+| `GIT_USER_EMAIL` | string | `automations@imbi.ai` | Git commit author email |
+| `GIT_GPG_SIGN` | boolean | `false` | Enable GPG signing for commits |
+| `GIT_GPG_FORMAT` | string | - | Signing format: `gpg`, `ssh`, `x509`, `openpgp` |
+| `GIT_SIGNING_KEY` | string | - | GPG or SSH signing key identifier |
+| `GIT_SSH_PROGRAM` | string | - | SSH program for signing |
+| `GIT_GPG_PROGRAM` | string | - | GPG program path |
+| `GIT_COMMIT_ARGS` | string | `""` | Additional git commit arguments |
+
+**Example:**
+```bash
+export GIT_USER_NAME="CI Bot"
+export GIT_USER_EMAIL="ci-bot@example.com"
+export GIT_GPG_SIGN="true"
+export GIT_GPG_FORMAT="ssh"
+export GIT_SIGNING_KEY="~/.ssh/id_ed25519.pub"
+```
+
+## GitHub Configuration
+
+Environment variables for GitHub API integration.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `GH_TOKEN` | secret | **required** | GitHub personal access token |
+| `GH_HOST` | string | `github.com` | GitHub hostname (for Enterprise) |
+
+**Example:**
+```bash
+export GH_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxx"
+export GH_HOST="github.enterprise.com"
+```
+
+**Token Permissions Required:**
+
+- `repo` - Full repository access
+- `workflow` - Update GitHub Actions workflows
+- `admin:org` - Manage organization (for environment sync)
+
+## Imbi Configuration
+
+Environment variables for Imbi project management integration.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `IMBI_API_KEY` | secret | **required** | Imbi API authentication key |
+| `IMBI_HOSTNAME` | string | **required** | Imbi instance hostname |
+| `IMBI_GITHUB_IDENTIFIER` | string | `github` | Project identifier field for GitHub |
+| `IMBI_PAGERDUTY_IDENTIFIER` | string | `pagerduty` | Project identifier field for PagerDuty |
+| `IMBI_SONARQUBE_IDENTIFIER` | string | `sonarqube` | Project identifier field for SonarQube |
+| `IMBI_SENTRY_IDENTIFIER` | string | `sentry` | Project identifier field for Sentry |
+| `IMBI_GITHUB_LINK` | string | `GitHub Repository` | Link type name for GitHub URLs |
+| `IMBI_GRAFANA_LINK` | string | `Grafana Dashboard` | Link type name for Grafana URLs |
+| `IMBI_PAGERDUTY_LINK` | string | `PagerDuty` | Link type name for PagerDuty URLs |
+| `IMBI_SENTRY_LINK` | string | `Sentry` | Link type name for Sentry URLs |
+| `IMBI_SONARQUBE_LINK` | string | `SonarQube` | Link type name for SonarQube URLs |
+
+**Example:**
+```bash
+export IMBI_API_KEY="your-api-key-uuid"
+export IMBI_HOSTNAME="imbi.example.com"
+export IMBI_GITHUB_IDENTIFIER="github-id"
+```
+
+## Using .env Files
+
+Imbi Automations automatically loads environment variables from a `.env` file in the current directory:
+
+```bash
+# .env
+ANTHROPIC_API_KEY=sk-ant-api03-...
+GH_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+IMBI_API_KEY=your-api-key-uuid
+IMBI_HOSTNAME=imbi.example.com
+```
+
+**Security Note:** Never commit `.env` files to version control. Add `.env` to your `.gitignore`.
+
+## Precedence Rules
+
+Configuration values are resolved in the following order (highest to lowest priority):
+
+1. **Environment variables** - Always checked first
+2. **Config file values** - From TOML configuration
+3. **Default values** - Built-in defaults
+
+When a configuration section is defined in the TOML file, environment variables serve as defaults for any fields not explicitly set in that section.
+
+**Example:**
+```toml
+# config.toml
+[github]
+host = "github.enterprise.com"
+# token not set - will use GH_TOKEN environment variable
+```
+
+```bash
+export GH_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxx"
+```
+
+In this case, `host` comes from the config file and `token` comes from the environment variable.
+
+## Minimal Environment Setup
+
+For basic GitHub workflows, set these environment variables:
+
+```bash
+export GH_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxx"
+export IMBI_API_KEY="your-api-key-uuid"
+export IMBI_HOSTNAME="imbi.example.com"
+```
+
+Then use a minimal config file:
+
+```toml
+# config.toml
+[github]
+[imbi]
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+env:
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  IMBI_API_KEY: ${{ secrets.IMBI_API_KEY }}
+  IMBI_HOSTNAME: imbi.example.com
+
+steps:
+  - name: Run workflow
+    run: imbi-automations config.toml workflows/update-deps --all-projects
+```
+
+### Docker
+
+```bash
+docker run -e GH_TOKEN -e IMBI_API_KEY -e IMBI_HOSTNAME \
+  imbi-automations config.toml workflows/update-deps --all-projects
+```
+
+Or with an env file:
+
+```bash
+docker run --env-file .env \
+  imbi-automations config.toml workflows/update-deps --all-projects
+```
+
+## Troubleshooting
+
+### Variable Not Being Read
+
+1. Check the variable name matches the expected prefix + field name
+2. Environment variables are case-insensitive
+3. Ensure the config section exists (even if empty) in the TOML file
+
+### Secret Values in Logs
+
+Secret values (`api_key`, `token`) are stored as `SecretStr` and will not appear in logs or error messages. They display as `**********` when printed.
+
+### Checking Current Configuration
+
+Use verbose mode to see which configuration values are being used:
+
+```bash
+imbi-automations config.toml workflows/test --all-projects -vvv
+```
+
+## See Also
+
+- [Configuration Reference](configuration.md) - Complete TOML configuration options
+- [CLI Reference](cli.md) - Command-line options
+- [Docker](docker.md) - Running in containers

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,9 @@ edit_uri: edit/main/docs/
 nav:
   - Home: index.md
   - Architecture: architecture.md
-  - Configuration: configuration.md
+  - Configuration:
+     - Configuration File: configuration.md
+     - Environment Variables: environment-variables.md
   - Docker: docker.md
   - Workflows:
     - Overview: workflows.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "imbi-automations"
-version = "1.0.0a12"
+version = "1.0.0a13"
 description = "CLI tool for executing automated workflows across Imbi projects with AI-powered transformations and GitHub PR integration."
 authors = [
   {name = "Gavin M. Roy", email = "gavinr@aweber.com"},

--- a/src/imbi_automations/actions/claude.py
+++ b/src/imbi_automations/actions/claude.py
@@ -7,7 +7,6 @@ AI-powered code transformations.
 
 import pathlib
 import typing
-from email import utils as email_utils
 
 from imbi_automations import claude, mixins, models, prompts
 
@@ -33,11 +32,11 @@ class ClaudeAction(mixins.WorkflowLoggerMixin):
         self.has_planning_prompt: bool = False
         self.last_error: models.ClaudeAgentValidationResult | None = None
         self.task_plan: models.ClaudeAgentPlanningResult | None = None
-        commit_author = email_utils.parseaddr(self.configuration.commit_author)
+        git = configuration.git
         self.prompt_kwargs = {
-            'commit_author': self.configuration.commit_author,
-            'commit_author_name': commit_author[0],
-            'commit_author_address': commit_author[1],
+            'commit_author': f'{git.user_name} <{git.user_email}>',
+            'commit_author_name': git.user_name,
+            'commit_author_address': git.user_email,
             'workflow_name': context.workflow.configuration.name,
             'working_directory': self.context.working_directory,
         }

--- a/src/imbi_automations/claude.py
+++ b/src/imbi_automations/claude.py
@@ -11,7 +11,6 @@ import os
 import pathlib
 import re
 import typing
-from email import utils as email_utils
 
 import anthropic
 import claude_agent_sdk
@@ -166,11 +165,12 @@ class Claude(mixins.WorkflowLoggerMixin):
         self.context = context
         self.logger: logging.Logger = LOGGER
         self.session_id: str | None = None
-        commit_author = email_utils.parseaddr(self.configuration.commit_author)
         self.prompt_kwargs = {
-            'commit_author': self.configuration.commit_author,
-            'commit_author_name': commit_author[0],
-            'commit_author_address': commit_author[1],
+            'commit_author': (
+                f'{config.git.user_name} <{config.git.user_email}>'
+            ),
+            'commit_author_name': config.git.user_name,
+            'commit_author_address': config.git.user_email,
             'configuration': self.configuration,
             'workflow_name': context.workflow.configuration.name,
             'working_directory': self.context.working_directory,
@@ -383,7 +383,7 @@ class Claude(mixins.WorkflowLoggerMixin):
             ],
             cwd=self.context.working_directory / 'repository',
             mcp_servers=mcp_servers,
-            model=self.configuration.claude_code.model,
+            model=self.configuration.claude.model,
             plugins=sdk_plugins,
             settings=str(settings),
             setting_sources=['local'],
@@ -433,7 +433,7 @@ class Claude(mixins.WorkflowLoggerMixin):
 
         # Add merged plugin configuration
         merged_plugins = _merge_plugin_configs(
-            self.configuration.claude_code.plugins,
+            self.configuration.claude.plugins,
             self.context.workflow.configuration.plugins,
         )
 

--- a/src/imbi_automations/clients/github.py
+++ b/src/imbi_automations/clients/github.py
@@ -35,10 +35,9 @@ class GitHub(http.BaseURLHTTPClient):
             raise errors.ConfigurationError('GitHub configuration missing')
 
         super().__init__(transport)
-        self._base_url = f'https://{config.github.hostname}'
+        self._base_url = f'https://{config.github.host}'
         self.add_header(
-            'Authorization',
-            f'Bearer {config.github.api_key.get_secret_value()}',
+            'Authorization', f'Bearer {config.github.token.get_secret_value()}'
         )
         self.add_header('X-GitHub-Api-Version', '2022-11-28')
         self.add_header('Accept', 'application/vnd.github+json')

--- a/src/imbi_automations/committer.py
+++ b/src/imbi_automations/committer.py
@@ -41,7 +41,7 @@ class Committer(mixins.WorkflowLoggerMixin):
         if (
             action.ai_commit
             and self.configuration.ai_commits
-            and self.configuration.claude_code.enabled
+            and self.configuration.claude.enabled
         ):
             return await self._claude_commit(context, action)
         else:
@@ -114,7 +114,8 @@ class Committer(mixins.WorkflowLoggerMixin):
             commit_sha = await git.commit_changes(
                 working_directory=repo_dir,
                 message=message,
-                commit_author=self.configuration.commit_author,
+                user_name=self.configuration.git.user_name,
+                user_email=self.configuration.git.user_email,
             )
         except RuntimeError as exc:
             self.logger.error(

--- a/src/imbi_automations/git.py
+++ b/src/imbi_automations/git.py
@@ -263,14 +263,16 @@ async def remove_files(
 async def commit_changes(
     working_directory: pathlib.Path,
     message: str,
-    commit_author: str | None = None,
+    user_name: str | None = None,
+    user_email: str | None = None,
 ) -> str:
     """Commit staged changes to git repository.
 
     Args:
         working_directory: Git repository working directory
         message: Commit message
-        commit_author: Commit author name and email (default: None)
+        user_name: Commit author name (default: None)
+        user_email: Commit author email (default: None)
 
     Returns:
         Commit SHA hash
@@ -289,8 +291,8 @@ async def commit_changes(
     command = ['git', 'commit', '-F', '../commit-msg.txt']
 
     # Add author information if provided
-    if commit_author:
-        command.extend(['--author', f'"{commit_author}"'])
+    if user_name and user_email:
+        command.extend(['--author', f'"{user_name} <{user_email}>"'])
 
     command += ['--all']
 

--- a/src/imbi_automations/models/__init__.py
+++ b/src/imbi_automations/models/__init__.py
@@ -18,8 +18,9 @@ from .claude import (
 )
 from .configuration import (
     AnthropicConfiguration,
-    ClaudeCodeConfiguration,
+    ClaudeAgentConfiguration,
     Configuration,
+    GitConfiguration,
     GitHubConfiguration,
     ImbiConfiguration,
 )
@@ -88,11 +89,11 @@ __all__ = [
     'imbi',
     'mcp',
     'AnthropicConfiguration',
+    'ClaudeAgentConfiguration',
     'ClaudeAgentPlanningResult',
     'ClaudeAgentTaskResult',
     'ClaudeAgentType',
     'ClaudeAgentValidationResult',
-    'ClaudeCodeConfiguration',
     'ClaudeLocalPlugin',
     'ClaudeMarketplace',
     'ClaudeMarketplaceSource',
@@ -101,6 +102,7 @@ __all__ = [
     'Configuration',
     'GitCommit',
     'GitCommitSummary',
+    'GitConfiguration',
     'GitFileChange',
     'GitHubConfiguration',
     'GitHubEnvironment',

--- a/src/imbi_automations/workflow_engine.py
+++ b/src/imbi_automations/workflow_engine.py
@@ -59,7 +59,7 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
         )
         self._set_workflow_logger(workflow)
 
-        if not self.configuration.claude_code.enabled and (
+        if not self.configuration.claude.enabled and (
             self._needs_claude_code
             or workflow.configuration.github.create_pull_request
         ):
@@ -253,7 +253,7 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
         if context.has_repository_changes:
             if (
                 self.workflow.configuration.github.create_pull_request
-                and self.configuration.claude_code.enabled
+                and self.configuration.claude.enabled
             ):
                 pr, branch_name = await self._create_pull_request(context)
                 context.pull_request = pr

--- a/src/imbi_automations/workflow_filter.py
+++ b/src/imbi_automations/workflow_filter.py
@@ -113,9 +113,11 @@ class Filter(mixins.WorkflowLoggerMixin):
 
     async def _filter_github_action_status(
         self, project: models.ImbiProject
-    ) -> str:
+    ) -> str | None:
         client = clients.GitHub.get_instance(config=self.configuration)
         repository = await client.get_repository(project)
+        if repository is None:
+            return None
         return await client.get_repository_workflow_status(repository)
 
     @staticmethod

--- a/tests/actions/test_callable.py
+++ b/tests/actions/test_callable.py
@@ -89,7 +89,9 @@ class CallableActionTestCase(base.AsyncTestCase):
         )
 
         self.configuration = models.Configuration(
-            github=models.GitHubConfiguration(api_key='test-key'),
+            github=models.GitHubConfiguration(
+                token='test-key'  # noqa: S106
+            ),
             imbi=models.ImbiConfiguration(
                 api_key='test-key', hostname='imbi.example.com'
             ),

--- a/tests/actions/test_claude.py
+++ b/tests/actions/test_claude.py
@@ -18,11 +18,15 @@ class ClaudeActionTestCase(base.AsyncTestCase):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.working_directory = pathlib.Path(self.temp_dir.name)
         self.config = models.Configuration(
-            claude_code=models.ClaudeCodeConfiguration(executable='claude'),
+            claude=models.ClaudeAgentConfiguration(executable='claude'),
             anthropic=models.AnthropicConfiguration(),
+            git=models.GitConfiguration(
+                user_name='Test Author', user_email='test@example.com'
+            ),
             imbi=models.ImbiConfiguration(api_key='test', hostname='test.com'),
-            github=models.GitHubConfiguration(api_key='test'),
-            commit_author='Test Author <test@example.com>',
+            github=models.GitHubConfiguration(
+                token='test'  # noqa: S106
+            ),
         )
 
         # Create required directory structure

--- a/tests/actions/test_docker.py
+++ b/tests/actions/test_docker.py
@@ -52,7 +52,9 @@ class DockerTestCase(base.AsyncTestCase):
         )
 
         self.configuration = models.Configuration(
-            github=models.GitHubConfiguration(api_key='test-key'),
+            github=models.GitHubConfiguration(
+                token='test-key'  # noqa: S106
+            ),
             imbi=models.ImbiConfiguration(
                 api_key='test-key', hostname='imbi.example.com'
             ),

--- a/tests/actions/test_file_actions.py
+++ b/tests/actions/test_file_actions.py
@@ -64,7 +64,9 @@ class FileActionsTestCase(base.AsyncTestCase):
         )
 
         self.configuration = models.Configuration(
-            github=models.GitHubConfiguration(api_key='test-key'),
+            github=models.GitHubConfiguration(
+                token='test-key'  # noqa: S106
+            ),
             imbi=models.ImbiConfiguration(
                 api_key='test-key', hostname='imbi.example.com'
             ),

--- a/tests/actions/test_github.py
+++ b/tests/actions/test_github.py
@@ -74,7 +74,9 @@ class GitHubActionsTestCase(base.AsyncTestCase):
 
         # Create configuration
         self.configuration = models.Configuration(
-            github=models.GitHubConfiguration(api_key='test-key'),
+            github=models.GitHubConfiguration(
+                token='test-key'  # noqa: S106
+            ),
             imbi=models.ImbiConfiguration(
                 api_key='test-key', hostname='imbi.example.com'
             ),

--- a/tests/actions/test_shell.py
+++ b/tests/actions/test_shell.py
@@ -56,7 +56,9 @@ class ShellTestCase(base.AsyncTestCase):
         )
 
         self.configuration = models.Configuration(
-            github=models.GitHubConfiguration(api_key='test-key'),
+            github=models.GitHubConfiguration(
+                token='test-key'  # noqa: S106
+            ),
             imbi=models.ImbiConfiguration(
                 api_key='test-key', hostname='imbi.example.com'
             ),

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -419,10 +419,12 @@ class ClaudeTestCase(base.AsyncTestCase):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.working_directory = pathlib.Path(self.temp_dir.name)
         self.config = models.Configuration(
-            claude_code=models.ClaudeCodeConfiguration(executable='claude'),
+            claude=models.ClaudeAgentConfiguration(executable='claude'),
             anthropic=models.AnthropicConfiguration(),
+            git=models.GitConfiguration(
+                user_name='Test Author', user_email='test@example.com'
+            ),
             imbi=models.ImbiConfiguration(api_key='test', hostname='test.com'),
-            commit_author='Test Author <test@example.com>',
         )
 
         # Create required directory structure

--- a/tests/test_condition_checker.py
+++ b/tests/test_condition_checker.py
@@ -39,7 +39,8 @@ class ConditionCheckerTestCase(base.AsyncTestCase):
                 api_key='test-key', hostname='imbi.test.com'
             ),
             github=models.GitHubConfiguration(
-                api_key='test-github-key', hostname='github.com'
+                token='test-github-key',  # noqa: S106
+                host='github.com',
             ),
         )
         self.checker = condition_checker.ConditionChecker(

--- a/tests/test_engine_pull_request.py
+++ b/tests/test_engine_pull_request.py
@@ -26,9 +26,10 @@ class WorkflowEnginePullRequestTestCase(base.AsyncTestCase):
                 api_key='test-key', hostname='imbi.test.com'
             ),
             github=models.GitHubConfiguration(
-                api_key='test-github-key', hostname='github.com'
+                token='test-github-key',  # noqa: S106
+                host='github.com',
             ),
-            claude_code=models.ClaudeCodeConfiguration(enabled=True),
+            claude=models.ClaudeAgentConfiguration(enabled=True),
         )
 
         # Create mock workflow with path name for slugification

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1364,9 +1364,10 @@ class WorkflowEngineGitTestCase(base.AsyncTestCase):
                 api_key='test-key', hostname='imbi.test.com'
             ),
             github=models.GitHubConfiguration(
-                api_key='test-github-key', hostname='github.com'
+                token='test-github-key',  # noqa: S106
+                host='github.com',
             ),
-            claude_code=models.ClaudeCodeConfiguration(enabled=False),
+            claude=models.ClaudeAgentConfiguration(enabled=False),
         )
 
         # Create mock workflow

--- a/tests/test_workflow_filter.py
+++ b/tests/test_workflow_filter.py
@@ -13,7 +13,9 @@ class WorkflowFilterTestCase(base.AsyncTestCase):
         super().setUp()
         # Create mock configuration
         self.configuration = models.Configuration(
-            github=models.GitHubConfiguration(api_key='test-key'),
+            github=models.GitHubConfiguration(
+                token='test-key'  # noqa: S106
+            ),
             imbi=models.ImbiConfiguration(
                 api_key='test-key', hostname='imbi.example.com'
             ),


### PR DESCRIPTION
## Summary

This release includes configuration refactoring, Docker improvements, and a fix for the failed Docker publishing pipeline.

## Changes

**Docker Publishing Fix:**
- Add `attestations: write` permission to Docker workflow - this was accidentally removed in a previous commit and caused releases 1.0.0a11 and 1.0.0a12 to fail with "Resource not accessible by integration" error

**Configuration Refactoring:**
- Refactor configuration to use pydantic-settings with environment variable prefixes
- Rename `claude_code` config section to `claude` for consistency
- Add `git` config section with `user_name`, `user_email`, `gpg_sign`, `gpg_format`, `signing_key`, and `commit_args`
- Rename `github.api_key` to `github.token` and `hostname` to `host`

**Docker Image Improvements:**
- Install Claude Code as non-root user (security improvement)
- Add required environment variables to Dockerfile for Claude Code SDK
- Simplify docker-entrypoint.sh SSH and GH token handling
- Add chmod/chown to sudoers for runtime permission fixes

**Documentation:**
- Add `environment-variables.md` with complete env var reference
- Update `configuration.md` with new config structure

**Development:**
- Update actionlint to v1.7.9 in pre-commit config

## Test Plan

- [ ] Verify all tests pass
- [ ] Create release tag and confirm Docker publish workflow succeeds
- [ ] Verify Docker image builds and runs correctly

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This release includes a critical Docker workflow fix, comprehensive configuration refactoring, and Docker security improvements.

**Key Changes:**
- Fixed Docker publishing pipeline by restoring `attestations: write` permission that was accidentally removed
- Refactored configuration to use pydantic-settings with environment variable prefixes (`ANTHROPIC_`, `CLAUDE_`, `GIT_`, `GH_`, `IMBI_`)
- Renamed `claude_code` config section to `claude` for consistency
- Replaced `commit_author` string with structured `git.user_name` and `git.user_email` fields
- Renamed GitHub config fields: `api_key` → `token`, `hostname` → `host`
- Improved Docker security by installing Claude Code as non-root user
- Added comprehensive environment variables documentation

**Code Quality:**
- All changes are well-coordinated across the codebase
- Tests updated to match new configuration structure
- Documentation thoroughly updated with new config format
- Breaking changes are clearly documented in configuration migration

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues found
- The changes are well-structured with comprehensive test coverage. The configuration refactoring is systematic and complete, with all references updated consistently. The Docker fix addresses a specific documented issue. Documentation is thorough and accurate.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/docker.yml | 5/5 | Added missing `attestations: write` permission to fix Docker publishing failures in releases 1.0.0a11 and 1.0.0a12 |
| src/imbi_automations/models/configuration.py | 5/5 | Refactored config: renamed `claude_code` to `claude`, renamed GitHub `api_key`/`hostname` to `token`/`host`, added `git` section with user_name/user_email, removed `commit_author` field |
| Dockerfile | 5/5 | Security improvements: Claude Code installed as non-root user, added required env vars (CLAUDE_CODE_USE_ANTHROPIC_API, GH_HOST), added chmod/chown to sudoers |
| docker-entrypoint.sh | 5/5 | Simplified by sourcing .profile, removed GH_TOKEN file loading logic (now handled by env vars), cleaned up SSH host scanning |
| docs/environment-variables.md | 5/5 | New comprehensive documentation for all environment variables with prefixes, defaults, examples, and CI/CD integration patterns |
| docs/configuration.md | 5/5 | Updated to reflect config refactoring: `claude_code` → `claude`, `github.api_key`/`hostname` → `token`/`host`, removed `commit_author`, added `git` section docs |
| src/imbi_automations/git.py | 5/5 | Refactored `commit_changes()` to accept separate `user_name` and `user_email` parameters instead of combined `commit_author` |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->