### PR TITLE
Implement docker build, pull, and push commands

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,21 +5,6 @@ that should be addressed before the 1.0 release.
 
 ## Unimplemented Features
 
-### Docker Actions
-
-The docker action type has three commands that raise `NotImplementedError`:
-
-| Command | File | Line | Priority |
-|---------|------|------|----------|
-| `build` | `src/imbi_automations/actions/docker.py` | 56 | Medium |
-| `pull` | `src/imbi_automations/actions/docker.py` | 135 | Medium |
-| `push` | `src/imbi_automations/actions/docker.py` | 139 | Medium |
-
-**Note:** The `extract` command IS implemented and functional.
-
-**Recommendation for 1.0:** Either implement these commands or remove them from the
-`DockerCommands` enum to avoid exposing non-functional options.
-
 ### Utility Actions
 
 Three utility commands raise `NotImplementedError`:
@@ -51,18 +36,6 @@ These are documented as "planned" but not critical for 1.0:
 **Current state:** Only `set_project_fact` is implemented.
 
 **Recommendation for 1.0:** Document current limitations; these can be post-1.0.
-
-## Documentation Issues
-
-### Template Action Documentation (RESOLVED)
-
-The documentation at `docs/actions/template.md` incorrectly states that context
-variables are not passed to templates. This appears to be outdated - the code at
-`src/imbi_automations/prompts.py:89` does call `kwargs.update(context.model_dump())`
-when context is provided.
-
-**Action:** Update `docs/actions/template.md` to remove the "CRITICAL BUG" warning
-and "KNOWN ISSUE" sections, as context variables ARE properly passed to templates.
 
 ## Test Coverage Gaps
 
@@ -108,8 +81,8 @@ Several action types lack dedicated unit tests:
 ## Pre-1.0 Checklist
 
 ### Must Fix
-- [ ] Update template action documentation to remove incorrect bug warnings
-- [ ] Decide: implement or remove unimplemented docker commands (build/pull/push)
+- [x] Update template action documentation to remove incorrect bug warnings
+- [x] Implement docker build/pull/push commands
 - [ ] Decide: implement or remove unimplemented utility commands
 - [ ] Add unit tests for missing action types (template, git, imbi, utility)
 
@@ -118,7 +91,6 @@ Several action types lack dedicated unit tests:
 - [x] Clarify rollback capabilities in documentation
 
 ### Nice to Have
-- [ ] Implement docker build/pull/push commands
 - [ ] Implement additional Imbi actions (get_project_fact, etc.)
 
 ## Version History


### PR DESCRIPTION
## Summary

- Implement `_execute_build` for building Docker images from Dockerfile
- Implement `_execute_pull` for pulling images from registries
- Implement `_execute_push` for pushing images to registries
- All commands support Jinja2 template syntax for dynamic image names
- Add 12 new unit tests covering success, failure, and template cases
- Update TODO.md to mark docker commands as complete

These three commands previously raised `NotImplementedError`. Now all docker action commands are fully functional.

## Test plan

- [x] All 493 tests pass
- [x] New tests cover: success cases, default tag handling, template rendering, path validation, error handling
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR completes the implementation of Docker build, pull, and push commands that previously raised `NotImplementedError`. The new implementations follow the established patterns from `_execute_extract`:

- **`_execute_build`**: Builds Docker images from a Dockerfile with Jinja2 template support for image names and path resolution
- **`_execute_pull`**: Pulls images from registries with template support for dynamic image names  
- **`_execute_push`**: Pushes images to registries with template support

All three commands:
- Support Jinja2 templating for dynamic image names (e.g., `{{ imbi_project.slug }}`)
- Handle the tag appending logic (defaults to `latest` when not embedded in image name)
- Follow consistent logging patterns with project context
- Leverage the existing `_run_docker_command` helper for error handling

The PR also cleans up outdated planning documents (`PLAN.md`, `imbi-automations-prd.md`) and introduces a new `TODO.md` to track remaining work toward 1.0 release.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it implements straightforward Docker CLI wrappers following established patterns with comprehensive test coverage.
- The implementation follows existing patterns from `_execute_extract`, all 12 new tests cover the happy path, error cases, and edge cases (templates, default tags). The code is well-structured with consistent logging and error handling. No security concerns as Docker commands use controlled inputs from workflow configuration.
- No files require special attention.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/actions/docker.py | 5/5 | Implements `_execute_build`, `_execute_pull`, and `_execute_push` methods, replacing `NotImplementedError` stubs with functional Docker commands that follow established patterns from `_execute_extract`. |
| tests/actions/test_docker.py | 5/5 | Adds 12 new unit tests covering build, pull, and push operations including success cases, default tag handling, template rendering, path validation, and error handling. |
| TODO.md | 5/5 | New tracking document for path to 1.0 release, documenting unimplemented features, test coverage gaps, and a pre-release checklist. |
| PLAN.md | 5/5 | Deleted outdated refactoring plan document that's been superseded by TODO.md and actual implementation work. |
| imbi-automations-prd.md | 5/5 | Deleted outdated PRD document that's no longer needed as the project has matured beyond initial planning. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->