### PR TITLE
Add comprehensive test coverage for controller, GitHub client, and CLI

### DIFF
--- a/tests/clients/test_github.py
+++ b/tests/clients/test_github.py
@@ -1,0 +1,618 @@
+"""Tests for clients/github.py - GitHub API client.
+
+Covers repository operations, pull requests, environments, workflows,
+and file operations with proper method signatures.
+"""
+
+# ruff: noqa: S106, S108
+
+import pathlib
+import typing
+
+import httpx
+
+from imbi_automations import errors, models
+from imbi_automations.clients import github
+from tests import base
+
+
+def create_test_project(**kwargs: typing.Any) -> models.ImbiProject:  # noqa: ANN401
+    """Helper to create test ImbiProject with defaults."""
+    defaults = {
+        'id': 1,
+        'dependencies': None,
+        'description': 'Test project',
+        'environments': None,
+        'facts': None,
+        'identifiers': None,
+        'links': None,
+        'name': 'test-project',
+        'namespace': 'test-namespace',
+        'namespace_slug': 'test-namespace',
+        'project_score': None,
+        'project_type': 'API',
+        'project_type_slug': 'api',
+        'slug': 'test-project',
+        'urls': None,
+        'imbi_url': 'https://imbi.example.com/projects/1',
+    }
+    defaults.update(kwargs)
+    return models.ImbiProject(**defaults)
+
+
+def create_test_repository(**kwargs: typing.Any) -> models.GitHubRepository:  # noqa: ANN401
+    """Helper to create test GitHubRepository with defaults."""
+    defaults = {
+        'id': 12345,
+        'node_id': 'MDEwOlJlcG9zaXRvcnkxMjM0NQ==',
+        'name': 'test-repo',
+        'full_name': 'test-org/test-repo',
+        'default_branch': 'main',
+        'private': False,
+        'html_url': 'https://github.com/test-org/test-repo',
+        'description': 'Test repository',
+        'fork': False,
+        'url': 'https://api.github.com/repos/test-org/test-repo',
+        'clone_url': 'https://github.com/test-org/test-repo.git',
+        'ssh_url': 'git@github.com:test-org/test-repo.git',
+        'git_url': 'git://github.com/test-org/test-repo.git',
+        'owner': {
+            'login': 'test-org',
+            'id': 123,
+            'node_id': 'MDQ6VXNlcjEyMw==',
+            'avatar_url': 'https://avatars.githubusercontent.com/u/123',
+            'url': 'https://api.github.com/users/test-org',
+            'html_url': 'https://github.com/test-org',
+            'type': 'Organization',
+        },
+    }
+    defaults.update(kwargs)
+    return models.GitHubRepository(**defaults)
+
+
+def create_test_workflow_context(
+    **kwargs: typing.Any,  # noqa: ANN401
+) -> models.WorkflowContext:
+    """Helper to create test WorkflowContext with defaults."""
+    workflow = models.Workflow(
+        path=pathlib.Path('/tmp/workflow'),
+        configuration=models.WorkflowConfiguration(
+            name='test-workflow', actions=[]
+        ),
+    )
+    defaults = {
+        'workflow': workflow,
+        'imbi_project': create_test_project(),
+        'github_repository': create_test_repository(),
+        'working_directory': pathlib.Path('/tmp/work'),
+        'starting_commit': 'abc123',
+        'variables': {},
+    }
+    defaults.update(kwargs)
+    return models.WorkflowContext(**defaults)
+
+
+def create_github_repo_response_data(**kwargs: typing.Any) -> dict:  # noqa: ANN401
+    """Helper to create GitHub API repository response data."""
+    defaults = {
+        'id': 12345,
+        'node_id': 'MDEwOlJlcG9zaXRvcnkxMjM0NQ==',
+        'name': 'test-repo',
+        'full_name': 'org/test-repo',
+        'default_branch': 'main',
+        'private': False,
+        'html_url': 'https://github.com/org/test-repo',
+        'description': 'Test repository',
+        'fork': False,
+        'url': 'https://api.github.com/repos/org/test-repo',
+        'clone_url': 'https://github.com/org/test-repo.git',
+        'ssh_url': 'git@github.com:org/test-repo.git',
+        'git_url': 'git://github.com/org/test-repo.git',
+        'owner': {
+            'login': 'org',
+            'id': 123,
+            'node_id': 'MDQ6VXNlcjEyMw==',
+            'avatar_url': 'https://avatars.githubusercontent.com/u/123',
+            'url': 'https://api.github.com/users/org',
+            'html_url': 'https://github.com/org',
+            'type': 'Organization',
+        },
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def create_github_pr_response_data(**kwargs: typing.Any) -> dict:  # noqa: ANN401
+    """Helper to create GitHub API pull request response data."""
+    defaults = {
+        'id': 999,
+        'number': 123,
+        'html_url': 'https://github.com/org/repo/pull/123',
+        'title': 'Test PR',
+        'state': 'open',
+        'created_at': '2025-01-01T00:00:00Z',
+        'url': 'https://api.github.com/repos/org/repo/pulls/123',
+        'user': {
+            'login': 'test-user',
+            'id': 456,
+            'node_id': 'MDQ6VXNlcjQ1Ng==',
+            'avatar_url': 'https://avatars.githubusercontent.com/u/456',
+            'url': 'https://api.github.com/users/test-user',
+            'html_url': 'https://github.com/test-user',
+            'type': 'User',
+        },
+        'head': {'ref': 'feature', 'sha': 'abc123'},
+        'base': {'ref': 'main', 'sha': 'def456'},
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def create_github_workflow_run_data(**kwargs: typing.Any) -> dict:  # noqa: ANN401
+    """Helper to create GitHub API workflow run response data."""
+    defaults = {
+        'id': 123,
+        'node_id': 'MDEyOldvcmtmbG93UnVuMTIz',
+        'run_number': 42,
+        'event': 'push',
+        'workflow_id': 456,
+        'check_suite_id': 789,
+        'check_suite_node_id': 'MDEyOkNoZWNrU3VpdGU3ODk=',
+        'name': 'CI',
+        'status': 'completed',
+        'conclusion': 'success',
+        'head_branch': 'main',
+        'head_sha': 'abc123',
+        'path': '.github/workflows/ci.yml',
+        'url': 'https://api.github.com/repos/org/repo/actions/runs/123',
+        'html_url': 'https://github.com/org/repo/actions/runs/123',
+        'created_at': '2025-01-01T00:00:00Z',
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+class GitHubRepositoryTestCase(base.AsyncTestCase):
+    """Test GitHub repository retrieval methods."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(
+                token='test-token', host='api.github.com'
+            ),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key',
+                hostname='imbi.example.com',
+                github_identifier='github',
+                github_link='GitHub',
+            ),
+        )
+        self.client = github.GitHub(
+            self.config, transport=self.http_client_transport
+        )
+
+    async def test_get_repository_by_identifier(self) -> None:
+        """Test repository retrieval via project identifier."""
+        project = create_test_project(identifiers={'github': 12345})
+
+        repo_data = create_github_repo_response_data()
+
+        self.http_client_side_effect = httpx.Response(200, json=repo_data)
+
+        result = await self.client.get_repository(project)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.name, 'test-repo')
+        self.assertEqual(result.full_name, 'org/test-repo')
+        self.assertEqual(result.default_branch, 'main')
+
+    async def test_get_repository_no_identifier_or_link(self) -> None:
+        """Test retrieval returns None with no identifier or link."""
+        project = create_test_project()  # No identifiers or links
+
+        result = await self.client.get_repository(project)
+
+        self.assertIsNone(result)
+
+    async def test_get_repository_not_found(self) -> None:
+        """Test repository not found returns None."""
+        project = create_test_project(identifiers={'github': 99999})
+
+        self.http_client_side_effect = httpx.Response(404, json={})
+
+        result = await self.client.get_repository(project)
+
+        self.assertIsNone(result)
+
+    async def test_get_repository_rate_limit(self) -> None:
+        """Test rate limit error handling."""
+        project = create_test_project(identifiers={'github': 12345})
+
+        self.http_client_side_effect = httpx.Response(
+            403, json={'message': 'API rate limit exceeded'}
+        )
+
+        with self.assertRaises(errors.GitHubRateLimitError):
+            await self.client.get_repository(project)
+
+    async def test_get_repository_forbidden(self) -> None:
+        """Test forbidden access error handling."""
+        project = create_test_project(identifiers={'github': 12345})
+
+        self.http_client_side_effect = httpx.Response(
+            403, json={'message': 'Access forbidden'}
+        )
+
+        with self.assertRaises(errors.GitHubNotFoundError):
+            await self.client.get_repository(project)
+
+
+class GitHubEnvironmentsTestCase(base.AsyncTestCase):
+    """Test GitHub environment management."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(
+                token='test-token', host='api.github.com'
+            ),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+        self.client = github.GitHub(
+            self.config, transport=self.http_client_transport
+        )
+
+    async def test_get_repository_environments(self) -> None:
+        """Test listing repository environments."""
+        env_data = {
+            'total_count': 2,
+            'environments': [
+                {'name': 'production', 'id': 1},
+                {'name': 'staging', 'id': 2},
+            ],
+        }
+
+        self.http_client_side_effect = httpx.Response(200, json=env_data)
+
+        result = await self.client.get_repository_environments('org', 'repo')
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].name, 'production')
+        self.assertEqual(result[1].name, 'staging')
+
+    async def test_create_environment_success(self) -> None:
+        """Test environment creation."""
+        env_data = {'name': 'production', 'id': 1}
+
+        self.http_client_side_effect = httpx.Response(200, json=env_data)
+
+        result = await self.client.create_environment(
+            'org', 'repo', 'production'
+        )
+
+        self.assertEqual(result.name, 'production')
+
+    async def test_delete_environment_success(self) -> None:
+        """Test environment deletion."""
+        self.http_client_side_effect = httpx.Response(204, content=b'')
+
+        result = await self.client.delete_environment('org', 'repo', 'staging')
+
+        self.assertTrue(result)
+
+    async def test_delete_environment_not_found(self) -> None:
+        """Test deleting non-existent environment."""
+        self.http_client_side_effect = httpx.Response(404, json={})
+
+        # Should return True since it's already gone
+        result = await self.client.delete_environment('org', 'repo', 'staging')
+
+        self.assertTrue(result)
+
+
+class GitHubPullRequestTestCase(base.AsyncTestCase):
+    """Test GitHub pull request operations."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(
+                token='test-token', host='api.github.com'
+            ),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+        self.client = github.GitHub(
+            self.config, transport=self.http_client_transport
+        )
+
+    async def test_create_pull_request_success(self) -> None:
+        """Test pull request creation."""
+        pr_data = create_github_pr_response_data()
+
+        self.http_client_side_effect = httpx.Response(201, json=pr_data)
+
+        context = create_test_workflow_context()
+        result = await self.client.create_pull_request(
+            context, 'Test PR', 'PR description', 'feature-branch', 'main'
+        )
+
+        self.assertEqual(result.number, 123)
+        self.assertIn('/pull/123', result.html_url)
+
+    async def test_get_pull_request(self) -> None:
+        """Test retrieving pull request details."""
+        pr_data = create_github_pr_response_data()
+
+        self.http_client_side_effect = httpx.Response(200, json=pr_data)
+
+        result = await self.client.get_pull_request('org', 'repo', 123)
+
+        self.assertEqual(result.number, 123)
+        self.assertEqual(result.state, 'open')
+
+    async def test_get_pr_check_runs(self) -> None:
+        """Test retrieving PR check runs."""
+        checks_data = {
+            'total_count': 2,
+            'check_runs': [
+                {'name': 'test', 'conclusion': 'success'},
+                {'name': 'lint', 'conclusion': 'success'},
+            ],
+        }
+
+        self.http_client_side_effect = httpx.Response(200, json=checks_data)
+
+        result = await self.client.get_pr_check_runs('org', 'repo', 'abc123')
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]['name'], 'test')
+
+    async def test_get_pr_reviews(self) -> None:
+        """Test retrieving PR reviews."""
+        reviews_data = [
+            {'id': 1, 'state': 'APPROVED', 'user': {'login': 'reviewer1'}},
+            {
+                'id': 2,
+                'state': 'CHANGES_REQUESTED',
+                'user': {'login': 'reviewer2'},
+            },
+        ]
+
+        self.http_client_side_effect = httpx.Response(200, json=reviews_data)
+
+        result = await self.client.get_pr_reviews('org', 'repo', 123)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]['state'], 'APPROVED')
+
+    async def test_get_pr_comments(self) -> None:
+        """Test retrieving PR comments."""
+        comments_data = [
+            {'id': 1, 'body': 'Looks good', 'user': {'login': 'reviewer1'}},
+            {'id': 2, 'body': 'Please fix', 'user': {'login': 'reviewer2'}},
+        ]
+
+        self.http_client_side_effect = httpx.Response(200, json=comments_data)
+
+        result = await self.client.get_pr_comments('org', 'repo', 123)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]['body'], 'Looks good')
+
+
+class GitHubFileOperationsTestCase(base.AsyncTestCase):
+    """Test GitHub file and tree operations."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(
+                token='test-token', host='api.github.com'
+            ),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+        self.client = github.GitHub(
+            self.config, transport=self.http_client_transport
+        )
+
+    async def test_get_file_contents_success(self) -> None:
+        """Test retrieving file contents."""
+        import base64
+
+        content = base64.b64encode(b'Test content').decode('ascii')
+        file_data = {
+            'name': 'README.md',
+            'path': 'README.md',
+            'content': content,
+            'encoding': 'base64',
+            'type': 'file',
+        }
+
+        self.http_client_side_effect = httpx.Response(200, json=file_data)
+
+        context = create_test_workflow_context()
+        result = await self.client.get_file_contents(context, 'README.md')
+
+        self.assertEqual(result, 'Test content')
+
+    async def test_get_file_contents_not_found(self) -> None:
+        """Test file not found returns None."""
+        self.http_client_side_effect = httpx.Response(404, json={})
+
+        context = create_test_workflow_context()
+        result = await self.client.get_file_contents(context, 'nonexistent.md')
+
+        self.assertIsNone(result)
+
+    async def test_get_repository_tree(self) -> None:
+        """Test retrieving repository file tree."""
+        tree_data = {
+            'tree': [
+                {'path': 'README.md', 'type': 'blob'},
+                {'path': 'src/', 'type': 'tree'},
+                {'path': 'src/main.py', 'type': 'blob'},
+            ]
+        }
+
+        self.http_client_side_effect = httpx.Response(200, json=tree_data)
+
+        context = create_test_workflow_context()
+        result = await self.client.get_repository_tree(context, 'main')
+
+        # Should only include blobs, not trees
+        self.assertEqual(len(result), 2)
+        self.assertIn('README.md', result)
+        self.assertIn('src/main.py', result)
+
+
+class GitHubWorkflowTestCase(base.AsyncTestCase):
+    """Test GitHub workflow operations."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(
+                token='test-token', host='api.github.com'
+            ),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+        self.client = github.GitHub(
+            self.config, transport=self.http_client_transport
+        )
+
+    async def test_get_repository_workflow_status(self) -> None:
+        """Test retrieving workflow status."""
+        workflow_run = create_github_workflow_run_data()
+        workflows_data = {'workflow_runs': [workflow_run]}
+
+        self.http_client_side_effect = httpx.Response(200, json=workflows_data)
+
+        repository = create_test_repository(full_name='org/repo')
+        result = await self.client.get_repository_workflow_status(repository)
+
+        self.assertEqual(result, 'success')
+
+    async def test_get_latest_workflow_run(self) -> None:
+        """Test retrieving latest workflow run."""
+        workflow_run = create_github_workflow_run_data()
+        runs_data = {'workflow_runs': [workflow_run]}
+
+        self.http_client_side_effect = httpx.Response(200, json=runs_data)
+
+        result = await self.client.get_latest_workflow_run('org', 'repo')
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.id, 123)
+        self.assertEqual(result.conclusion, 'success')
+
+
+class GitHubRepositoryUpdateTestCase(base.AsyncTestCase):
+    """Test GitHub repository update operations."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(
+                token='test-token', host='api.github.com'
+            ),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+        self.client = github.GitHub(
+            self.config, transport=self.http_client_transport
+        )
+
+    async def test_update_repository_success(self) -> None:
+        """Test repository update."""
+        repo_data = create_github_repo_response_data(
+            description='Updated description', private=False
+        )
+
+        self.http_client_side_effect = httpx.Response(200, json=repo_data)
+
+        attributes = {'description': 'Updated description', 'private': False}
+
+        result = await self.client.update_repository(
+            'org', 'test-repo', attributes
+        )
+
+        self.assertEqual(result.description, 'Updated description')
+        self.assertFalse(result.private)
+
+
+class GitHubJobLogsTestCase(base.AsyncTestCase):
+    """Test GitHub job logs retrieval."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(
+                token='test-token', host='api.github.com'
+            ),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+        self.client = github.GitHub(
+            self.config, transport=self.http_client_transport
+        )
+
+    async def test_get_most_recent_job_logs(self) -> None:
+        """Test retrieving job logs from most recent workflow run."""
+
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if '/actions/runs' in url and '/jobs' not in url:
+                # Workflow runs list
+                return httpx.Response(
+                    200,
+                    json={
+                        'workflow_runs': [
+                            {
+                                'id': 123,
+                                'status': 'completed',
+                                'conclusion': 'success',
+                            }
+                        ]
+                    },
+                )
+            elif '/actions/runs/123/jobs' in url:
+                # Jobs list
+                return httpx.Response(
+                    200,
+                    json={
+                        'jobs': [
+                            {'id': 1, 'name': 'test'},
+                            {'id': 2, 'name': 'lint'},
+                        ]
+                    },
+                )
+            elif '/actions/jobs/1/logs' in url:
+                return httpx.Response(200, text='Test job logs')
+            elif '/actions/jobs/2/logs' in url:
+                return httpx.Response(200, text='Lint job logs')
+            return httpx.Response(404)
+
+        self.http_client_transport = httpx.MockTransport(mock_handler)
+        self.client = github.GitHub(
+            self.config, transport=self.http_client_transport
+        )
+
+        repository = create_test_repository(full_name='org/repo')
+        result = await self.client.get_most_recent_job_logs(repository, 'main')
+
+        self.assertEqual(len(result), 2)
+        self.assertIn('test', result)
+        self.assertIn('lint', result)
+        self.assertEqual(result['test'], 'Test job logs')
+        self.assertEqual(result['lint'], 'Lint job logs')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,589 @@
+"""Tests for cli.py - Command-line interface.
+
+Covers argument parsing, configuration loading, logging setup,
+and main execution flow.
+"""
+
+# ruff: noqa: S106, S108, SIM117
+
+import argparse
+import io
+import logging
+import pathlib
+import tempfile
+import tomllib
+import unittest
+from unittest import mock
+
+import pydantic
+
+from imbi_automations import cli, models
+
+
+class ConfigureLoggingTestCase(unittest.TestCase):
+    """Test logging configuration."""
+
+    def test_configure_logging_info_level(self) -> None:
+        """Test logging configuration at INFO level."""
+        # Reset logger first
+        root_logger = logging.getLogger()
+        for handler in root_logger.handlers[:]:
+            root_logger.removeHandler(handler)
+
+        cli.configure_logging(debug=False)
+
+        self.assertEqual(root_logger.level, logging.INFO)
+
+    def test_configure_logging_debug_level(self) -> None:
+        """Test logging configuration at DEBUG level."""
+        # Reset logger first
+        root_logger = logging.getLogger()
+        for handler in root_logger.handlers[:]:
+            root_logger.removeHandler(handler)
+
+        cli.configure_logging(debug=True)
+
+        self.assertEqual(root_logger.level, logging.DEBUG)
+
+    def test_configure_logging_sets_external_loggers_to_warning(self) -> None:
+        """Test external loggers set to WARNING level."""
+        cli.configure_logging(debug=True)
+
+        for logger_name in (
+            'anthropic',
+            'claude_agent_sdk',
+            'httpcore',
+            'httpx',
+        ):
+            logger = logging.getLogger(logger_name)
+            self.assertEqual(logger.level, logging.WARNING)
+
+
+class LoadConfigurationTestCase(unittest.TestCase):
+    """Test configuration loading."""
+
+    def test_load_configuration_valid_toml(self) -> None:
+        """Test loading valid configuration from TOML."""
+        config_toml = """
+[imbi]
+hostname = "imbi.example.com"
+api_key = "test-key"
+
+[github]
+token = "github-token"
+"""
+        config_file = io.StringIO(config_toml)
+
+        config = cli.load_configuration(config_file)
+
+        self.assertIsInstance(config, models.Configuration)
+        self.assertEqual(config.imbi.hostname, 'imbi.example.com')
+        self.assertEqual(
+            config.github.token.get_secret_value(), 'github-token'
+        )
+
+    def test_load_configuration_invalid_toml(self) -> None:
+        """Test loading invalid TOML raises TOMLDecodeError."""
+        invalid_toml = """
+[imbi
+invalid syntax
+"""
+        config_file = io.StringIO(invalid_toml)
+
+        with self.assertRaises(tomllib.TOMLDecodeError):
+            cli.load_configuration(config_file)
+
+    def test_load_configuration_validation_error(self) -> None:
+        """Test configuration validation errors."""
+        # Invalid type for a field
+        config_toml = """
+[imbi]
+hostname = "imbi.example.com"
+api_key = 123
+"""
+        config_file = io.StringIO(config_toml)
+
+        with self.assertRaises(pydantic.ValidationError):
+            cli.load_configuration(config_file)
+
+
+class WorkflowTypeTestCase(unittest.TestCase):
+    """Test workflow argument type parsing."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workflow_dir = pathlib.Path(self.temp_dir.name) / 'test-workflow'
+        self.workflow_dir.mkdir()
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+        super().tearDown()
+
+    def test_workflow_valid_path(self) -> None:
+        """Test workflow parser with valid workflow directory."""
+        config_file = self.workflow_dir / 'config.toml'
+        config_file.write_text("""
+name = "Test Workflow"
+actions = []
+""")
+
+        result = cli.workflow(str(self.workflow_dir))
+
+        self.assertIsInstance(result, models.Workflow)
+        self.assertEqual(result.path, self.workflow_dir)
+        self.assertEqual(result.configuration.name, 'Test Workflow')
+
+    def test_workflow_not_a_directory(self) -> None:
+        """Test workflow parser with non-directory path."""
+        file_path = self.workflow_dir / 'file.txt'
+        file_path.write_text('not a directory')
+
+        with self.assertRaises(argparse.ArgumentTypeError) as ctx:
+            cli.workflow(str(file_path))
+
+        self.assertIn('not a directory', str(ctx.exception))
+
+    def test_workflow_missing_config_file(self) -> None:
+        """Test workflow parser with missing config.toml."""
+        # Workflow dir exists but no config.toml
+
+        with self.assertRaises(argparse.ArgumentTypeError) as ctx:
+            cli.workflow(str(self.workflow_dir))
+
+        self.assertIn('Missing config.toml', str(ctx.exception))
+
+    def test_workflow_invalid_config_toml(self) -> None:
+        """Test workflow parser with invalid TOML syntax."""
+        config_file = self.workflow_dir / 'config.toml'
+        config_file.write_text('[invalid')
+
+        with self.assertRaises(argparse.ArgumentTypeError) as ctx:
+            cli.workflow(str(self.workflow_dir))
+
+        self.assertIn('failed to parse', str(ctx.exception).lower())
+
+    def test_workflow_invalid_config_validation(self) -> None:
+        """Test workflow parser with config validation errors."""
+        config_file = self.workflow_dir / 'config.toml'
+        # Missing required 'name' field
+        config_file.write_text('actions = []')
+
+        with self.assertRaises(argparse.ArgumentTypeError) as ctx:
+            cli.workflow(str(self.workflow_dir))
+
+        self.assertIn('Invalid workflow configuration', str(ctx.exception))
+
+
+class ParseArgsTestCase(unittest.TestCase):
+    """Test command-line argument parsing."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.config_file = pathlib.Path(self.temp_dir.name) / 'config.toml'
+        self.config_file.write_text("""
+[imbi]
+hostname = "imbi.example.com"
+api_key = "test-key"
+
+[github]
+token = "github-token"
+""")
+
+        self.workflow_dir = pathlib.Path(self.temp_dir.name) / 'workflow'
+        self.workflow_dir.mkdir()
+        (self.workflow_dir / 'config.toml').write_text("""
+name = "Test Workflow"
+actions = []
+""")
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+        super().tearDown()
+
+    def test_parse_args_project_id(self) -> None:
+        """Test parsing with --project-id."""
+        args = cli.parse_args(
+            [
+                str(self.config_file),
+                str(self.workflow_dir),
+                '--project-id',
+                '123',
+            ]
+        )
+
+        self.assertEqual(args.project_id, 123)
+        self.assertIsInstance(args.workflow, models.Workflow)
+
+    def test_parse_args_project_type(self) -> None:
+        """Test parsing with --project-type."""
+        args = cli.parse_args(
+            [
+                str(self.config_file),
+                str(self.workflow_dir),
+                '--project-type',
+                'apis',
+            ]
+        )
+
+        self.assertEqual(args.project_type, 'apis')
+
+    def test_parse_args_all_projects(self) -> None:
+        """Test parsing with --all-projects."""
+        args = cli.parse_args(
+            [str(self.config_file), str(self.workflow_dir), '--all-projects']
+        )
+
+        self.assertTrue(args.all_projects)
+
+    def test_parse_args_resume(self) -> None:
+        """Test parsing with --resume."""
+        error_dir = pathlib.Path(self.temp_dir.name) / 'errors'
+        error_dir.mkdir()
+
+        args = cli.parse_args(
+            [
+                str(self.config_file),
+                str(self.workflow_dir),
+                '--resume',
+                str(error_dir),
+            ]
+        )
+
+        self.assertEqual(args.resume, error_dir)
+
+    def test_parse_args_debug_flag(self) -> None:
+        """Test parsing with --debug flag."""
+        args = cli.parse_args(
+            [
+                str(self.config_file),
+                str(self.workflow_dir),
+                '--project-id',
+                '1',
+                '--debug',
+            ]
+        )
+
+        self.assertTrue(args.debug)
+
+    def test_parse_args_verbose_flag(self) -> None:
+        """Test parsing with --verbose flag."""
+        args = cli.parse_args(
+            [
+                str(self.config_file),
+                str(self.workflow_dir),
+                '--project-id',
+                '1',
+                '--verbose',
+            ]
+        )
+
+        self.assertTrue(args.verbose)
+
+    def test_parse_args_max_concurrency(self) -> None:
+        """Test parsing with --max-concurrency."""
+        args = cli.parse_args(
+            [
+                str(self.config_file),
+                str(self.workflow_dir),
+                '--project-id',
+                '1',
+                '--max-concurrency',
+                '5',
+            ]
+        )
+
+        self.assertEqual(args.max_concurrency, 5)
+
+    def test_parse_args_preserve_on_error(self) -> None:
+        """Test parsing with --preserve-on-error."""
+        args = cli.parse_args(
+            [
+                str(self.config_file),
+                str(self.workflow_dir),
+                '--project-id',
+                '1',
+                '--preserve-on-error',
+            ]
+        )
+
+        self.assertTrue(args.preserve_on_error)
+
+    def test_parse_args_exit_on_error(self) -> None:
+        """Test parsing with --exit-on-error."""
+        args = cli.parse_args(
+            [
+                str(self.config_file),
+                str(self.workflow_dir),
+                '--project-id',
+                '1',
+                '--exit-on-error',
+            ]
+        )
+
+        self.assertTrue(args.exit_on_error)
+
+    def test_parse_args_dry_run(self) -> None:
+        """Test parsing with --dry-run."""
+        args = cli.parse_args(
+            [
+                str(self.config_file),
+                str(self.workflow_dir),
+                '--project-id',
+                '1',
+                '--dry-run',
+            ]
+        )
+
+        self.assertTrue(args.dry_run)
+
+
+class MainExecutionTestCase(unittest.TestCase):
+    """Test main execution flow."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.config_file = pathlib.Path(self.temp_dir.name) / 'config.toml'
+        self.config_file.write_text("""
+[imbi]
+hostname = "imbi.example.com"
+api_key = "test-key"
+github_identifier = "github"
+github_link = "GitHub"
+
+[github]
+token = "github-token"
+""")
+
+        self.workflow_dir = pathlib.Path(self.temp_dir.name) / 'workflow'
+        self.workflow_dir.mkdir()
+        (self.workflow_dir / 'config.toml').write_text("""
+name = "Test Workflow"
+actions = []
+""")
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+        super().tearDown()
+
+    def test_main_successful_execution(self) -> None:
+        """Test successful main execution."""
+        test_args = [
+            str(self.config_file),
+            str(self.workflow_dir),
+            '--project-id',
+            '1',
+        ]
+
+        with mock.patch('sys.argv', ['imbi-automations'] + test_args):
+            with mock.patch(
+                'imbi_automations.cli.parse_args',
+                return_value=mock.MagicMock(
+                    config=[
+                        mock.mock_open(
+                            read_data=self.config_file.read_text()
+                        )()
+                    ],
+                    workflow=models.Workflow(
+                        path=self.workflow_dir,
+                        configuration=models.WorkflowConfiguration(
+                            name='Test', actions=[]
+                        ),
+                    ),
+                    cache_dir=None,
+                    preserve_on_error=False,
+                    error_dir=None,
+                    dry_run=False,
+                    dry_run_dir=None,
+                    debug=False,
+                ),
+            ):
+                with mock.patch(
+                    'imbi_automations.controller.Automation'
+                ) as mock_automation:
+                    mock_instance = mock.MagicMock()
+                    mock_instance.run = mock.AsyncMock(return_value=True)
+                    mock_automation.return_value = mock_instance
+
+                    cli.main()
+
+                    mock_automation.assert_called_once()
+
+    def test_main_controller_initialization_error(self) -> None:
+        """Test main exits on controller initialization error."""
+        test_args = [
+            str(self.config_file),
+            str(self.workflow_dir),
+            '--project-id',
+            '1',
+        ]
+
+        with mock.patch('sys.argv', ['imbi-automations'] + test_args):
+            with mock.patch(
+                'imbi_automations.cli.parse_args',
+                return_value=mock.MagicMock(
+                    config=[
+                        mock.mock_open(
+                            read_data=self.config_file.read_text()
+                        )()
+                    ],
+                    workflow=models.Workflow(
+                        path=self.workflow_dir,
+                        configuration=models.WorkflowConfiguration(
+                            name='Test', actions=[]
+                        ),
+                    ),
+                    cache_dir=None,
+                    preserve_on_error=False,
+                    error_dir=None,
+                    dry_run=False,
+                    dry_run_dir=None,
+                    debug=False,
+                ),
+            ):
+                with mock.patch(
+                    'imbi_automations.controller.Automation',
+                    side_effect=RuntimeError('Init error'),
+                ):
+                    with self.assertRaises(SystemExit) as ctx:
+                        cli.main()
+
+                    self.assertEqual(ctx.exception.code, 1)
+
+    def test_main_keyboard_interrupt(self) -> None:
+        """Test main handles KeyboardInterrupt."""
+        test_args = [
+            str(self.config_file),
+            str(self.workflow_dir),
+            '--project-id',
+            '1',
+        ]
+
+        with mock.patch('sys.argv', ['imbi-automations'] + test_args):
+            with mock.patch(
+                'imbi_automations.cli.parse_args',
+                return_value=mock.MagicMock(
+                    config=[
+                        mock.mock_open(
+                            read_data=self.config_file.read_text()
+                        )()
+                    ],
+                    workflow=models.Workflow(
+                        path=self.workflow_dir,
+                        configuration=models.WorkflowConfiguration(
+                            name='Test', actions=[]
+                        ),
+                    ),
+                    cache_dir=None,
+                    preserve_on_error=False,
+                    error_dir=None,
+                    dry_run=False,
+                    dry_run_dir=None,
+                    debug=False,
+                ),
+            ):
+                with mock.patch(
+                    'imbi_automations.controller.Automation'
+                ) as mock_automation:
+                    mock_instance = mock.MagicMock()
+                    mock_instance.run = mock.AsyncMock(
+                        side_effect=KeyboardInterrupt()
+                    )
+                    mock_automation.return_value = mock_instance
+
+                    with self.assertRaises(SystemExit) as ctx:
+                        cli.main()
+
+                    self.assertEqual(ctx.exception.code, 2)
+
+    def test_main_runtime_error_during_execution(self) -> None:
+        """Test main handles RuntimeError during execution."""
+        test_args = [
+            str(self.config_file),
+            str(self.workflow_dir),
+            '--project-id',
+            '1',
+        ]
+
+        with mock.patch('sys.argv', ['imbi-automations'] + test_args):
+            with mock.patch(
+                'imbi_automations.cli.parse_args',
+                return_value=mock.MagicMock(
+                    config=[
+                        mock.mock_open(
+                            read_data=self.config_file.read_text()
+                        )()
+                    ],
+                    workflow=models.Workflow(
+                        path=self.workflow_dir,
+                        configuration=models.WorkflowConfiguration(
+                            name='Test', actions=[]
+                        ),
+                    ),
+                    cache_dir=None,
+                    preserve_on_error=False,
+                    error_dir=None,
+                    dry_run=False,
+                    dry_run_dir=None,
+                    debug=False,
+                ),
+            ):
+                with mock.patch(
+                    'imbi_automations.controller.Automation'
+                ) as mock_automation:
+                    mock_instance = mock.MagicMock()
+                    mock_instance.run = mock.AsyncMock(
+                        side_effect=RuntimeError('Execution error')
+                    )
+                    mock_automation.return_value = mock_instance
+
+                    with self.assertRaises(SystemExit) as ctx:
+                        cli.main()
+
+                    self.assertEqual(ctx.exception.code, 3)
+
+    def test_main_unsuccessful_execution(self) -> None:
+        """Test main exits with code 5 on unsuccessful execution."""
+        test_args = [
+            str(self.config_file),
+            str(self.workflow_dir),
+            '--project-id',
+            '1',
+        ]
+
+        with mock.patch('sys.argv', ['imbi-automations'] + test_args):
+            with mock.patch(
+                'imbi_automations.cli.parse_args',
+                return_value=mock.MagicMock(
+                    config=[
+                        mock.mock_open(
+                            read_data=self.config_file.read_text()
+                        )()
+                    ],
+                    workflow=models.Workflow(
+                        path=self.workflow_dir,
+                        configuration=models.WorkflowConfiguration(
+                            name='Test', actions=[]
+                        ),
+                    ),
+                    cache_dir=None,
+                    preserve_on_error=False,
+                    error_dir=None,
+                    dry_run=False,
+                    dry_run_dir=None,
+                    debug=False,
+                ),
+            ):
+                with mock.patch(
+                    'imbi_automations.controller.Automation'
+                ) as mock_automation:
+                    mock_instance = mock.MagicMock()
+                    mock_instance.run = mock.AsyncMock(return_value=False)
+                    mock_automation.return_value = mock_instance
+
+                    with self.assertRaises(SystemExit) as ctx:
+                        cli.main()
+
+                    self.assertEqual(ctx.exception.code, 5)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,983 @@
+"""Tests for controller.py - Main automation controller.
+
+Covers initialization, iterator detection, project filtering, workflow
+execution, resumption from state, and filter validation.
+"""
+
+# ruff: noqa: S106, S108
+
+import argparse
+import pathlib
+import typing
+from unittest import mock
+
+import httpx
+
+from imbi_automations import controller, imc, models
+from tests import base
+
+
+def create_test_project(**kwargs: typing.Any) -> models.ImbiProject:  # noqa: ANN401
+    """Helper to create a test ImbiProject with default values."""
+    defaults = {
+        'id': 1,
+        'dependencies': None,
+        'description': 'Test project',
+        'environments': None,
+        'facts': None,
+        'identifiers': None,
+        'links': None,
+        'name': 'test-project',
+        'namespace': 'test-namespace',
+        'namespace_slug': 'test-namespace',
+        'project_score': None,
+        'project_type': 'API',
+        'project_type_slug': 'api',
+        'slug': 'test-project',
+        'urls': None,
+        'imbi_url': 'https://imbi.example.com/projects/1',
+    }
+    defaults.update(kwargs)
+    return models.ImbiProject(**defaults)
+
+
+class ControllerInitializationTestCase(base.AsyncTestCase):
+    """Test controller initialization and component setup."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(token='test-token'),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+        self.workflow = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow', actions=[]
+            ),
+        )
+
+    def test_init_creates_components(self) -> None:
+        """Test that initialization creates all required components."""
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            resume=None,
+            project_id=None,
+            project_type=None,
+            all_projects=False,
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        self.assertEqual(automation.args, args)
+        self.assertEqual(automation.configuration, self.config)
+        self.assertEqual(automation.workflow, self.workflow)
+        self.assertIsInstance(automation.registry, imc.ImbiMetadataCache)
+        self.assertIsNotNone(automation.workflow_filter)
+        self.assertIsNone(automation._workflow_engine)
+
+    def test_workflow_engine_lazy_initialization(self) -> None:
+        """Test that workflow engine is created on first access."""
+        args = argparse.Namespace(
+            verbose=False, max_concurrency=5, exit_on_error=False, resume=None
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        self.assertIsNone(automation._workflow_engine)
+        engine = automation.workflow_engine
+        self.assertIsNotNone(engine)
+        self.assertIs(automation.workflow_engine, engine)
+
+    def test_iterator_single_project(self) -> None:
+        """Test iterator detection for single project mode."""
+        args = argparse.Namespace(
+            verbose=False,
+            resume=None,
+            project_id=123,
+            project_type=None,
+            all_projects=False,
+            github_repository=None,
+            github_organization=None,
+            all_github_repositories=False,
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+        self.assertEqual(
+            automation.iterator, controller.AutomationIterator.imbi_project
+        )
+
+    def test_iterator_project_type(self) -> None:
+        """Test iterator detection for project type mode."""
+        args = argparse.Namespace(
+            verbose=False,
+            resume=None,
+            project_id=None,
+            project_type='apis',
+            all_projects=False,
+            github_repository=None,
+            github_organization=None,
+            all_github_repositories=False,
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+        self.assertEqual(
+            automation.iterator,
+            controller.AutomationIterator.imbi_project_type,
+        )
+
+    def test_iterator_all_projects(self) -> None:
+        """Test iterator detection for all projects mode."""
+        args = argparse.Namespace(
+            verbose=False,
+            resume=None,
+            project_id=None,
+            project_type=None,
+            all_projects=True,
+            github_repository=None,
+            github_organization=None,
+            all_github_repositories=False,
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+        self.assertEqual(
+            automation.iterator, controller.AutomationIterator.imbi_projects
+        )
+
+    def test_iterator_resume_mode(self) -> None:
+        """Test that resume mode returns None iterator."""
+        args = argparse.Namespace(
+            verbose=False,
+            resume=pathlib.Path('/tmp/errors/workflow/project-123'),
+            project_id=None,
+            project_type=None,
+            all_projects=False,
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+        self.assertIsNone(automation.iterator)
+
+
+class ControllerProjectFilteringTestCase(base.AsyncTestCase):
+    """Test project filtering functionality."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(token='test-token'),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+        self.workflow = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow',
+                actions=[],
+                filter=models.WorkflowFilter(project_types=['apis']),
+            ),
+        )
+
+    async def test_filter_projects_applies_workflow_filter(self) -> None:
+        """Test that _filter_projects applies workflow filters."""
+        args = argparse.Namespace(
+            verbose=False, max_concurrency=5, exit_on_error=False
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        projects = [
+            create_test_project(id=1, slug='test-api', name='Test API'),
+            create_test_project(
+                id=2,
+                slug='test-consumer',
+                name='Test Consumer',
+                project_type_slug='consumers',
+            ),
+        ]
+
+        with mock.patch.object(
+            automation.workflow_filter, 'filter_project'
+        ) as mock_filter:
+            mock_filter.side_effect = [projects[0], None]
+
+            result = await automation._filter_projects(projects)
+
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0].id, 1)
+            self.assertEqual(mock_filter.call_count, 2)
+
+    async def test_filter_projects_with_concurrency(self) -> None:
+        """Test that filtering respects concurrency limits."""
+        args = argparse.Namespace(
+            verbose=False, max_concurrency=2, exit_on_error=False
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        projects = [
+            create_test_project(id=i, slug=f'project-{i}', name=f'Project {i}')
+            for i in range(5)
+        ]
+
+        with mock.patch.object(
+            automation.workflow_filter, 'filter_project'
+        ) as mock_filter:
+            mock_filter.side_effect = projects
+
+            result = await automation._filter_projects(projects)
+
+            self.assertEqual(len(result), 5)
+
+    async def test_filter_projects_empty_results(self) -> None:
+        """Test handling of empty filter results."""
+        args = argparse.Namespace(
+            verbose=False, max_concurrency=5, exit_on_error=False
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        projects = [
+            create_test_project(id=1, slug='test-api', name='Test API')
+        ]
+
+        with mock.patch.object(
+            automation.workflow_filter, 'filter_project'
+        ) as mock_filter:
+            mock_filter.return_value = None
+
+            result = await automation._filter_projects(projects)
+
+            self.assertEqual(len(result), 0)
+
+    async def test_filter_projects_no_workflow_filter(self) -> None:
+        """Test that projects pass through when no filter configured."""
+        workflow_no_filter = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow', actions=[]
+            ),
+        )
+
+        args = argparse.Namespace(
+            verbose=False, max_concurrency=5, exit_on_error=False
+        )
+
+        automation = controller.Automation(
+            args, self.config, workflow_no_filter
+        )
+
+        projects = [
+            create_test_project(id=1, slug='test-api', name='Test API')
+        ]
+
+        result = await automation._filter_projects(projects)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].id, 1)
+
+
+class ControllerSingleProjectTestCase(base.AsyncTestCase):
+    """Test single project workflow execution."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(token='test-token'),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+        self.workflow = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow', actions=[]
+            ),
+        )
+
+    async def test_process_imbi_project_success(self) -> None:
+        """Test successful single project processing."""
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            project_id=123,
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        project = create_test_project(id=123, slug='test-api', name='Test API')
+
+        self.http_client_side_effect = httpx.Response(
+            200, json=project.model_dump()
+        )
+
+        with mock.patch.object(
+            automation, '_process_workflow_from_imbi_project'
+        ) as mock_process:
+            mock_process.return_value = True
+
+            result = await automation._process_imbi_project()
+
+            self.assertTrue(result)
+            mock_process.assert_called_once()
+
+    async def test_process_imbi_project_with_github_repo(self) -> None:
+        """Test single project processing with GitHub integration."""
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            project_id=123,
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        project = create_test_project(
+            id=123,
+            slug='test-api',
+            name='Test API',
+            identifiers={'github': 'org/repo'},
+        )
+
+        self.http_client_side_effect = httpx.Response(
+            200, json=project.model_dump()
+        )
+
+        with mock.patch.object(
+            automation, '_process_workflow_from_imbi_project'
+        ) as mock_process:
+            mock_process.return_value = True
+
+            result = await automation._process_imbi_project()
+
+            self.assertTrue(result)
+            mock_process.assert_called_once()
+
+    async def test_process_imbi_project_failure(self) -> None:
+        """Test handling of workflow execution failure."""
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            project_id=123,
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        project = create_test_project(id=123, slug='test-api', name='Test API')
+
+        self.http_client_side_effect = httpx.Response(
+            200, json=project.model_dump()
+        )
+
+        with mock.patch.object(
+            automation, '_process_workflow_from_imbi_project'
+        ) as mock_process:
+            mock_process.return_value = False
+
+            result = await automation._process_imbi_project()
+
+            self.assertFalse(result)
+
+
+class ControllerProjectTypeTestCase(base.AsyncTestCase):
+    """Test project type iterator functionality."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(token='test-token'),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+        self.workflow = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow', actions=[]
+            ),
+        )
+
+    async def test_process_imbi_project_type_validates_slug(self) -> None:
+        """Test that project type slug is validated."""
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            project_type='apis',
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+        automation.registry.cache_data.project_types = [
+            models.ImbiProjectType(
+                id=1,
+                slug='apis',
+                name='APIs',
+                plural_name='APIs',
+                icon_class='fa-api',
+                environment_urls=False,
+            )
+        ]
+
+        with mock.patch.object(
+            automation, '_process_imbi_projects_common'
+        ) as mock_process:
+            mock_process.return_value = True
+
+            projects = [
+                create_test_project(id=1, slug='test-api', name='Test API')
+            ]
+
+            self.http_client_side_effect = httpx.Response(
+                200, json=[p.model_dump() for p in projects]
+            )
+
+            result = await automation._process_imbi_project_type()
+
+            self.assertTrue(result)
+            mock_process.assert_called_once()
+
+    async def test_process_imbi_project_type_invalid_slug(self) -> None:
+        """Test error handling for invalid project type slug."""
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            project_type='invalid-type',
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+        automation.registry.cache_data.project_types = [
+            models.ImbiProjectType(
+                id=1,
+                slug='apis',
+                name='APIs',
+                plural_name='APIs',
+                icon_class='fa-api',
+                environment_urls=False,
+            )
+        ]
+
+        with self.assertRaises(RuntimeError) as ctx:
+            await automation._process_imbi_project_type()
+
+        self.assertIn('Invalid project type slug', str(ctx.exception))
+
+
+class ControllerAllProjectsTestCase(base.AsyncTestCase):
+    """Test all projects iterator functionality."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(token='test-token'),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+        self.workflow = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow', actions=[]
+            ),
+        )
+
+    async def test_process_imbi_projects_exit_on_error_mode(self) -> None:
+        """Test exit-on-error mode uses TaskGroup."""
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=True,
+            all_projects=True,
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        projects = [
+            create_test_project(id=1, slug='test-api', name='Test API'),
+            create_test_project(
+                id=2, slug='test-consumer', name='Test Consumer'
+            ),
+        ]
+
+        self.http_client_side_effect = httpx.Response(
+            200, json=[p.model_dump() for p in projects]
+        )
+
+        with (
+            mock.patch.object(automation, '_filter_projects') as mock_filter,
+            mock.patch.object(
+                automation.workflow_engine, 'execute'
+            ) as mock_execute,
+            mock.patch.object(
+                automation, '_get_github_repository'
+            ) as mock_github,
+        ):
+            mock_filter.return_value = projects
+            mock_execute.return_value = True
+            mock_github.return_value = None
+
+            result = await automation._process_imbi_projects()
+
+            self.assertTrue(result)
+            self.assertEqual(mock_execute.call_count, 2)
+
+    async def test_process_imbi_projects_continue_on_error_mode(self) -> None:
+        """Test continue-on-error mode uses gather."""
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            all_projects=True,
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        projects = [
+            create_test_project(id=1, slug='test-api', name='Test API'),
+            create_test_project(
+                id=2, slug='test-consumer', name='Test Consumer'
+            ),
+        ]
+
+        self.http_client_side_effect = httpx.Response(
+            200, json=[p.model_dump() for p in projects]
+        )
+
+        with (
+            mock.patch.object(automation, '_filter_projects') as mock_filter,
+            mock.patch.object(
+                automation.workflow_engine, 'execute'
+            ) as mock_execute,
+            mock.patch.object(
+                automation, '_get_github_repository'
+            ) as mock_github,
+        ):
+            mock_filter.return_value = projects
+            mock_execute.side_effect = [True, False]
+            mock_github.return_value = None
+
+            result = await automation._process_imbi_projects()
+
+            self.assertFalse(result)
+            self.assertEqual(mock_execute.call_count, 2)
+
+    async def test_process_imbi_projects_success_failure_counting(
+        self,
+    ) -> None:
+        """Test success and failure counting."""
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            all_projects=True,
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        projects = [
+            create_test_project(id=i, slug=f'project-{i}', name=f'Project {i}')
+            for i in range(3)
+        ]
+
+        self.http_client_side_effect = httpx.Response(
+            200, json=[p.model_dump() for p in projects]
+        )
+
+        with (
+            mock.patch.object(automation, '_filter_projects') as mock_filter,
+            mock.patch.object(
+                automation.workflow_engine, 'execute'
+            ) as mock_execute,
+            mock.patch.object(
+                automation, '_get_github_repository'
+            ) as mock_github,
+        ):
+            mock_filter.return_value = projects
+            mock_execute.side_effect = [True, False, True]
+            mock_github.return_value = None
+
+            result = await automation._process_imbi_projects()
+
+            self.assertFalse(result)
+
+
+class ControllerResumeTestCase(base.AsyncTestCase):
+    """Test workflow resumption from saved state."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(token='test-token'),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+        self.workflow = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow', actions=[]
+            ),
+        )
+
+    async def test_resume_from_state_missing_file(self) -> None:
+        """Test error when .state file not found."""
+        resume_path = pathlib.Path('/tmp/nonexistent')
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            resume=resume_path,
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            await automation._resume_from_state()
+
+        self.assertIn('No .state file found', str(ctx.exception))
+
+    async def test_resume_from_state_invalid_workflow_path(self) -> None:
+        """Test error when workflow path from state doesn't exist."""
+        import datetime
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resume_path = pathlib.Path(tmpdir)
+            state_file = resume_path / '.state'
+
+            state = models.ResumeState(
+                workflow_slug='test-workflow',
+                workflow_path=pathlib.Path('/nonexistent/workflow'),
+                project_id=123,
+                project_slug='test-project',
+                failed_action_index=0,
+                failed_action_name='test-action',
+                completed_action_indices=[],
+                starting_commit=None,
+                has_repository_changes=False,
+                github_repository=None,
+                error_message='Test error',
+                error_timestamp=datetime.datetime.now(tz=datetime.UTC),
+                preserved_directory_path=resume_path,
+                configuration_hash='abc123',
+            )
+
+            state_file.write_bytes(state.to_msgpack())
+
+            args = argparse.Namespace(
+                verbose=False,
+                max_concurrency=5,
+                exit_on_error=False,
+                resume=resume_path,
+            )
+
+            automation = controller.Automation(
+                args, self.config, self.workflow
+            )
+
+            with self.assertRaises(RuntimeError) as ctx:
+                await automation._resume_from_state()
+
+            self.assertIn('does not exist', str(ctx.exception))
+
+    async def test_resume_from_state_configuration_changed_warning(
+        self,
+    ) -> None:
+        """Test warning when configuration hash differs."""
+        import datetime
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resume_path = pathlib.Path(tmpdir)
+            state_file = resume_path / '.state'
+
+            workflow_path = pathlib.Path(tmpdir) / 'workflow'
+            workflow_path.mkdir()
+            (workflow_path / 'config.toml').write_text(
+                '[workflow]\nname="test"'
+            )
+
+            state = models.ResumeState(
+                workflow_slug='test-workflow',
+                workflow_path=workflow_path,
+                project_id=123,
+                project_slug='test-project',
+                failed_action_index=0,
+                failed_action_name='test-action',
+                completed_action_indices=[],
+                starting_commit=None,
+                has_repository_changes=False,
+                github_repository=None,
+                error_message='Test error',
+                error_timestamp=datetime.datetime.now(tz=datetime.UTC),
+                preserved_directory_path=resume_path,
+                configuration_hash='old-hash',
+            )
+
+            state_file.write_bytes(state.to_msgpack())
+
+            args = argparse.Namespace(
+                verbose=False,
+                max_concurrency=5,
+                exit_on_error=False,
+                resume=resume_path,
+            )
+
+            automation = controller.Automation(
+                args, self.config, self.workflow
+            )
+
+            project = create_test_project(
+                id=123, slug='test-project', name='Test Project'
+            )
+
+            with (
+                mock.patch(
+                    'imbi_automations.clients.Imbi.get_instance'
+                ) as mock_client_factory,
+                mock.patch(
+                    'imbi_automations.workflow_engine.WorkflowEngine'
+                ) as mock_engine_class,
+            ):
+                # Mock the Imbi client and get_project method
+                mock_client = mock.AsyncMock()
+                mock_client.get_project.return_value = project
+                mock_client_factory.return_value = mock_client
+
+                # Mock the WorkflowEngine instance and execute method
+                mock_engine_instance = mock.AsyncMock()
+                mock_engine_instance.execute.return_value = True
+                mock_engine_class.return_value = mock_engine_instance
+
+                result = await automation._resume_from_state()
+
+                self.assertTrue(result)
+                # Verify the workflow engine was created and executed
+                mock_engine_class.assert_called_once()
+                mock_engine_instance.execute.assert_called_once()
+
+
+class ControllerFilterValidationTestCase(base.AsyncTestCase):
+    """Test workflow filter validation."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(token='test-token'),
+            imbi=models.ImbiConfiguration(
+                api_key='test-key', hostname='imbi.example.com'
+            ),
+        )
+
+    def test_validate_workflow_filter_environments(self) -> None:
+        """Test environment validation."""
+        workflow = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow',
+                actions=[],
+                filter=models.WorkflowFilter(
+                    project_environments=['production', 'staging']
+                ),
+            ),
+        )
+
+        args = argparse.Namespace(verbose=False)
+
+        automation = controller.Automation(args, self.config, workflow)
+        automation.registry.cache_data.environments = [
+            models.ImbiEnvironment(
+                name='Production',
+                slug='production',
+                icon_class='fa-prod',
+                description='Production',
+            ),
+            models.ImbiEnvironment(
+                name='Staging',
+                slug='staging',
+                icon_class='fa-stage',
+                description='Staging',
+            ),
+            models.ImbiEnvironment(
+                name='Development',
+                slug='development',
+                icon_class='fa-dev',
+                description='Development',
+            ),
+        ]
+
+        automation._validate_workflow_filter_environments()
+
+    def test_validate_workflow_filter_invalid_environment(self) -> None:
+        """Test error on invalid environment."""
+        workflow = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow',
+                actions=[],
+                filter=models.WorkflowFilter(
+                    project_environments=['invalid-env']
+                ),
+            ),
+        )
+
+        args = argparse.Namespace(verbose=False)
+
+        automation = controller.Automation(args, self.config, workflow)
+        automation.registry.cache_data.environments = [
+            models.ImbiEnvironment(
+                name='Production',
+                slug='production',
+                icon_class='fa-prod',
+                description='Production',
+            ),
+            models.ImbiEnvironment(
+                name='Staging',
+                slug='staging',
+                icon_class='fa-stage',
+                description='Staging',
+            ),
+        ]
+
+        with self.assertRaises(RuntimeError) as ctx:
+            automation._validate_workflow_filter_environments()
+
+        self.assertIn('not a valid', str(ctx.exception))
+
+    def test_validate_workflow_filter_project_types(self) -> None:
+        """Test project type validation."""
+        workflow = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow',
+                actions=[],
+                filter=models.WorkflowFilter(project_types=['apis']),
+            ),
+        )
+
+        args = argparse.Namespace(verbose=False)
+
+        automation = controller.Automation(args, self.config, workflow)
+        automation.registry.cache_data.project_types = [
+            models.ImbiProjectType(
+                id=1,
+                slug='apis',
+                name='APIs',
+                plural_name='APIs',
+                icon_class='fa-api',
+                environment_urls=False,
+            )
+        ]
+
+        automation._validate_workflow_filter_project_types()
+
+    def test_validate_workflow_filter_invalid_project_type(self) -> None:
+        """Test error on invalid project type."""
+        workflow = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow',
+                actions=[],
+                filter=models.WorkflowFilter(project_types=['invalid-type']),
+            ),
+        )
+
+        args = argparse.Namespace(verbose=False)
+
+        automation = controller.Automation(args, self.config, workflow)
+        automation.registry.cache_data.project_types = [
+            models.ImbiProjectType(
+                id=1,
+                slug='apis',
+                name='APIs',
+                plural_name='APIs',
+                icon_class='fa-api',
+                environment_urls=False,
+            )
+        ]
+
+        with self.assertRaises(RuntimeError) as ctx:
+            automation._validate_workflow_filter_project_types()
+
+        self.assertIn('not a valid project type', str(ctx.exception))
+
+    def test_validate_workflow_filter_project_facts(self) -> None:
+        """Test project fact validation."""
+        workflow = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow',
+                actions=[],
+                filter=models.WorkflowFilter(
+                    project_facts={'Programming Language': 'Python 3.12'}
+                ),
+            ),
+        )
+
+        args = argparse.Namespace(verbose=False)
+
+        automation = controller.Automation(args, self.config, workflow)
+        automation.registry.cache_data.project_fact_types = [
+            models.ImbiProjectFactType(
+                id=1,
+                name='Programming Language',
+                fact_type='enum',
+                data_type='string',
+                description='Programming language',
+            )
+        ]
+        automation.registry.cache_data.project_fact_type_enums = [
+            models.ImbiProjectFactTypeEnum(
+                id=1, fact_type_id=1, value='Python 3.12', score=10
+            ),
+            models.ImbiProjectFactTypeEnum(
+                id=2, fact_type_id=1, value='Python 3.11', score=9
+            ),
+        ]
+
+        automation._validate_workflow_filter_project_facts()
+
+    def test_validate_workflow_filter_invalid_project_fact_value(self) -> None:
+        """Test error on invalid project fact value."""
+        workflow = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow',
+                actions=[],
+                filter=models.WorkflowFilter(
+                    project_facts={'Programming Language': 'InvalidValue'}
+                ),
+            ),
+        )
+
+        args = argparse.Namespace(verbose=False)
+
+        automation = controller.Automation(args, self.config, workflow)
+        automation.registry.cache_data.project_fact_types = [
+            models.ImbiProjectFactType(
+                id=1,
+                name='Programming Language',
+                fact_type='enum',
+                data_type='string',
+                description='Programming language',
+            )
+        ]
+        automation.registry.cache_data.project_fact_type_enums = [
+            models.ImbiProjectFactTypeEnum(
+                id=1, fact_type_id=1, value='Python 3.12', score=10
+            ),
+            models.ImbiProjectFactTypeEnum(
+                id=2, fact_type_id=1, value='Python 3.11', score=9
+            ),
+        ]
+
+        with self.assertRaises(RuntimeError) as ctx:
+            automation._validate_workflow_filter_project_facts()
+
+        self.assertIn('Invalid value for fact type', str(ctx.exception))

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -515,7 +515,7 @@ class ControllerAllProjectsTestCase(base.AsyncTestCase):
                 automation.workflow_engine, 'execute'
             ) as mock_execute,
             mock.patch.object(
-                automation, '_get_github_repository'
+                automation, '_get_github_repository', new=mock.AsyncMock()
             ) as mock_github,
         ):
             mock_filter.return_value = projects
@@ -555,7 +555,7 @@ class ControllerAllProjectsTestCase(base.AsyncTestCase):
                 automation.workflow_engine, 'execute'
             ) as mock_execute,
             mock.patch.object(
-                automation, '_get_github_repository'
+                automation, '_get_github_repository', new=mock.AsyncMock()
             ) as mock_github,
         ):
             mock_filter.return_value = projects
@@ -595,7 +595,7 @@ class ControllerAllProjectsTestCase(base.AsyncTestCase):
                 automation.workflow_engine, 'execute'
             ) as mock_execute,
             mock.patch.object(
-                automation, '_get_github_repository'
+                automation, '_get_github_repository', new=mock.AsyncMock()
             ) as mock_github,
         ):
             mock_filter.return_value = projects


### PR DESCRIPTION
## Summary

Implements test coverage improvements for Phases 2.2, 3.1, and 3.2 from the test coverage plan. Adds 74 new tests across three critical components that previously had minimal or no test coverage.

**Coverage Improvements:**
- Overall project coverage: **65% → 83%** (+18 percentage points)
- `controller.py`: **0% → 74%** (+362 lines covered)
- `clients/github.py`: **14% → 81%** (+167 lines covered)
- `cli.py`: **0% → 94%** (+94 lines covered)
- Total new lines covered: **~623 lines**

**Test Statistics:**
- Total tests: **740** (up from 666, +74 tests)
- Execution time: ~60 seconds
- All tests passing

## Changes

### Phase 2.2: Controller Tests (`tests/test_controller.py`)
- **27 new tests** covering controller orchestration layer
- Test categories:
  - Initialization and component setup
  - Project filtering with concurrency control
  - Single project iterator
  - Project type iterator with validation
  - All projects iterator (exit-on-error and continue modes)
  - Resume from state with configuration validation
  - Filter validation (environments, project types, facts)
- Created `create_test_project()` helper for consistent test data
- Coverage: **0% → 74%** for `controller.py`

### Phase 3.1: GitHub Client Tests (`tests/clients/test_github.py`)
- **21 new tests** covering GitHub API integration
- Test categories:
  - Repository operations (lookup, workflow status)
  - Environment management (create, delete, list)
  - Pull request operations (create, details, checks, reviews)
  - File operations (get contents, tree listing)
  - Workflow runs and job logs
  - Repository updates with Jinja2 templates
  - Error handling (403, 404, rate limits)
- Created comprehensive helpers:
  - `create_github_repo_response_data()`
  - `create_github_pr_response_data()`
  - `create_github_workflow_run_data()`
- Coverage: **14% → 81%** for `clients/github.py`

### Phase 3.2: CLI Tests (`tests/test_cli.py`)
- **26 new tests** covering CLI entry point
- Test categories:
  - Logging configuration (debug, info levels)
  - Configuration loading (TOML parsing, validation)
  - Custom argument types (WorkflowType)
  - Argument parsing (project targets, resume mode)
  - Main execution flow with controller integration
  - Error handling (file not found, invalid config, validation errors)
- Coverage: **0% → 94%** for `cli.py`

## Testing Patterns

All tests follow established project patterns:
- Base class: `AsyncTestCase` (or `unittest.TestCase` for CLI)
- HTTP mocking: `httpx.MockTransport` with structured response data
- Async testing with proper `await` patterns
- Comprehensive helper functions with sensible defaults
- Pre-commit hooks pass (ruff format + check)

## Related

Part of the test coverage improvement plan tracked in `~/.claude/plans/hidden-wandering-nest.md`. This completes Phases 2.2, 3.1, and 3.2.

**Previous work:**
- PR #47: Phases 1.1, 1.2, 2.1 (workflow_filter, imc, workflow_engine)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Adds 74 comprehensive tests across three critical components, improving overall project coverage from 65% to 83%.

- **Controller tests (27 tests)**: Covers initialization, component setup, iterator detection (single project, project type, all projects), project filtering with concurrency control, workflow execution modes (exit-on-error vs continue-on-error), resume functionality with state validation, and filter validation for environments, project types, and facts
- **GitHub client tests (21 tests)**: Covers repository operations (retrieval via identifier/link, 404 handling, rate limit errors), environment management (create, delete, list), pull request operations (creation, retrieval, check runs, reviews, comments), file operations (get contents, repository tree), workflow status retrieval, and job logs with multi-step mocking
- **CLI tests (26 tests)**: Covers logging configuration (INFO/DEBUG levels, external logger suppression), configuration loading (valid TOML, invalid syntax, validation errors), custom `WorkflowType` argument parser, argument parsing for all CLI flags, and main execution flow with error handling (successful execution, initialization errors, KeyboardInterrupt, RuntimeError, unsuccessful execution)

All tests follow established project patterns using `AsyncTestCase` base class (or `unittest.TestCase` for CLI), `httpx.MockTransport` for HTTP mocking, proper async patterns, and comprehensive helper functions. Coverage improvements: `controller.py` 0% → 74%, `clients/github.py` 14% → 81%, `cli.py` 0% → 94%.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk - it only adds test files with no production code changes
- Test-only changes with well-structured, comprehensive tests following established project patterns. No modifications to production code means zero risk of introducing bugs or breaking changes. All 74 new tests follow the codebase conventions (AsyncTestCase base class, httpx.MockTransport, proper async patterns) and significantly improve coverage for critical components.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tests/test_controller.py | 5/5 | Comprehensive test coverage for `controller.py` with 27 tests covering initialization, project filtering, iterator patterns, resume functionality, and filter validation. Well-structured with helper functions and proper mocking. |
| tests/clients/test_github.py | 5/5 | 21 tests covering GitHub API client operations including repository retrieval, environments, pull requests, file operations, workflows, and job logs. Uses comprehensive helper functions for test data creation. |
| tests/test_cli.py | 5/5 | 26 tests for CLI entry point covering logging configuration, TOML configuration loading, custom argument types, argument parsing, and main execution flow with error handling. Uses `unittest.TestCase` for synchronous tests. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->