### PR TITLE
Change default workflow config filename to workflow.toml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ CLI framework for executing workflows across repositories with Imbi project mana
 pip install -e .[dev] && pre-commit install
 
 # Run CLI
+# Note: Workflow directories should contain workflow.toml (config.toml supported as fallback)
 imbi-automations config.toml workflows/workflow-name --all-projects
 imbi-automations config.toml workflows/workflow-name --project-id 123
 imbi-automations config.toml workflows/workflow-name --resume ./errors/workflow/project-timestamp
@@ -64,6 +65,8 @@ pre-commit run --all-files      # All hooks
 | `template` | `template.py` | Jinja2 file generation |
 
 ## Workflow Configuration
+
+Each workflow directory should contain `workflow.toml` (or `config.toml` for backward compatibility):
 
 ```toml
 name = "Example Workflow"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Documentation is available at [https://aweber-imbi.github.io/imbi-automations/](
 
 ```bash
 # Run workflows
+# Note: Each workflow directory should contain workflow.toml (or config.toml for backward compatibility)
 imbi-automations config.toml workflows/workflow-name --all-projects
 
 # Resume from a specific project

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,11 +60,11 @@ imbi-automations /etc/imbi/prod.toml workflows/deploy --all-projects
 
 ### WORKFLOW
 
-Path to workflow directory containing `config.toml`.
+Path to workflow directory containing workflow configuration file.
 
 **Type:** Directory path
-**Required:** Yes  
-**Must Contain:** `config.toml` file
+**Required:** Yes
+**Must Contain:** `workflow.toml`
 
 **Example:**
 ```bash
@@ -75,7 +75,7 @@ imbi-automations config.toml ./my-workflow --project-id 123
 **Structure:**
 ```
 workflows/my-workflow/
-├── config.toml          # Required
+├── workflow.toml        # Required
 ├── prompts/             # Optional
 │   └── prompt.md
 └── templates/           # Optional

--- a/docs/workflow-configuration.md
+++ b/docs/workflow-configuration.md
@@ -1,6 +1,6 @@
 # Workflow Configuration Reference
 
-Complete field reference for workflow `config.toml` files with detailed descriptions, types, defaults, and examples.
+Complete field reference for workflow configuration files (`workflow.toml`) with detailed descriptions, types, defaults, and examples.
 
 **Tip:** Workflow configuration syntax is validated on startup
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -4,7 +4,7 @@ Workflows are the core automation units in Imbi Automations. Each workflow defin
 
 ## What is a Workflow?
 
-A workflow is a directory containing a `config.toml` file that defines:
+A workflow is a directory containing a workflow configuration file that defines:
 
 - **Actions**: Operations to perform (file manipulation, AI transformations, shell commands, etc.)
 - **Conditions**: Repository state checks to determine if workflow/actions should run
@@ -15,7 +15,7 @@ A workflow is a directory containing a `config.toml` file that defines:
 
 ```
 workflows/workflow-name/
-├── config.toml          # Required - workflow configuration
+├── workflow.toml        # Required - workflow configuration
 ├── prompts/             # Optional - Claude prompt templates
 │   ├── task.md.j2
 │   └── validator.md.j2

--- a/src/imbi_automations/models/validators.py
+++ b/src/imbi_automations/models/validators.py
@@ -41,6 +41,7 @@ class CommandRulesMixin:
     ignored_fields: typing.ClassVar[set[str]] = {
         'type',
         'name',
+        'stage',
         'ai_commit',
         'commit_message',
         'conditions',


### PR DESCRIPTION
## Summary

Changes the default workflow configuration filename from `config.toml` to `workflow.toml` while maintaining backward compatibility with existing workflows.

## Changes

### Implementation
- Updated `workflow()` parser to check `workflow.toml` first, then fall back to `config.toml`
- Refactored workflow loading logic into separate `_load_workflow()` helper function
- Added deprecation warning when `config.toml` is detected
- Updated CLI help text to reflect the new default filename

### Testing
- ✅ Added test for `config.toml` fallback behavior
- ✅ Added test verifying `workflow.toml` takes precedence when both exist
- ✅ Updated existing tests to use `workflow.toml` as default
- ✅ All 752 tests passing

### Documentation
- Updated `AGENTS.md` to document `workflow.toml` requirement
- Updated `README.md` with note about preferred filename
- Updated all mkdocs documentation to reference `workflow.toml` only
- Maintained backward compatibility notes in `AGENTS.md` and `README.md`

## Backward Compatibility

Existing workflows using `config.toml` will continue to work. When `config.toml` is detected, a deprecation warning is logged:

```
WARNING - config.toml is deprecated, use workflow.toml
```

## Migration Path

Users can migrate by simply renaming their workflow configuration files:
```bash
mv workflows/my-workflow/config.toml workflows/my-workflow/workflow.toml
```

## Test Results

```
752 passed, 11 subtests passed in 58.02s
```

All pre-commit hooks passed including ruff formatting and linting.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Changed default workflow configuration filename from `config.toml` to `workflow.toml` while maintaining full backward compatibility with existing workflows.

**Key Changes:**
- Workflow parser now checks `workflow.toml` first, then falls back to `config.toml`
- Deprecation warning logged when `config.toml` is detected
- Refactored workflow loading into separate `_load_workflow()` helper function for cleaner code
- Added `stage` to ignored fields in validators
- Comprehensive test coverage including fallback behavior and precedence tests
- All documentation updated to reference `workflow.toml` as the standard

**Quality:**
- All 752 tests passing with new tests for both fallback scenarios
- Clean refactoring with improved error handling
- Proper backward compatibility ensures no breaking changes for existing users

<h3>Confidence Score: 5/5</h3>


- Safe to merge - well-tested backward-compatible change with comprehensive documentation updates
- Clean implementation with proper error handling, full test coverage including edge cases, and maintains backward compatibility with deprecation warning. All 752 tests passing.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/cli.py | 5/5 | Refactored workflow loading to check `workflow.toml` first, then fallback to `config.toml` with deprecation warning. Clean implementation with proper error handling. |
| src/imbi_automations/models/validators.py | 5/5 | Added `stage` to ignored fields for command-specific validation checks - ensures stage field is properly excluded from validation rules. |
| tests/test_cli.py | 5/5 | Updated tests to use `workflow.toml`, added comprehensive tests for `config.toml` fallback and precedence behavior. All edge cases covered. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->