### PR TITLE
Add configurable timeout support for actions

### DIFF
--- a/docs/actions/shell.md
+++ b/docs/actions/shell.md
@@ -410,6 +410,7 @@ Not recommended - commands block until completion. For long-running operations, 
 - Working directory resolved before command execution via `utils.resolve_path()`
 - Template rendering occurs before command execution
 - Commands are parsed as shell-like arguments (respecting quotes and escapes)
-- No timeout configured (commands run until completion)
+- Default timeout of 1 hour (configurable via `timeout` field, see [Action Timeouts](../workflow-configuration.md#timeout-optional))
+- On timeout: Process terminated gracefully (SIGTERM → SIGKILL)
 - stdout and stderr captured and logged at DEBUG level
 - Non-zero exit codes raise `subprocess.CalledProcessError` (unless `ignore_errors=true`)

--- a/docs/workflow-configuration.md
+++ b/docs/workflow-configuration.md
@@ -764,19 +764,29 @@ destination = "repository:///src/"
 
 #### timeout (optional)
 
-Maximum execution time for action in seconds.
+Maximum execution time for action in Go time.Duration format.
 
-**Type:** `integer`  
+**Type:** `string`
 
-**Default:** `3600` (1 hour)  
+**Default:** `"1h"` (1 hour)
 
+**Supported formats:**
+- Minutes: `"5m"`, `"30m"`
+- Hours: `"1h"`, `"2h30m"`
+- Seconds: `"90s"`
+- Combined: `"1h30m45s"`
+
+**Behavior:**
+- **Claude actions**: Timeout applies per-cycle (each planning/task/validation gets the full duration)
+- **Shell/Docker actions**: Timeout applies to single execution
+- On timeout: Process terminated gracefully (SIGTERM → SIGKILL), workflow fails with error
 
 ```toml
 [[actions]]
 name = "long-running-build"
 type = "shell"
 command = "make build"
-timeout = 7200  # 2 hours
+timeout = "2h"  # 2 hours
 ```
 
 #### filter (optional)
@@ -928,7 +938,7 @@ name = "run-tests"
 type = "shell"
 command = "pytest tests/ -v"
 working_directory = "repository:///"
-timeout = 600
+timeout = "10m"
 
 [[actions.conditions]]
 file_exists = "tests/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "msgpack>=1.0.0",
   "pydantic",
   "pydantic-settings",
+  "pytimeparse2>=1.7.1",
   "rich",
   "semver",
   "truststore",
@@ -121,8 +122,9 @@ select = [
   "B905",   # zip() without explicit strict parameter
 ]
 ignore = [
-  "ANN401", # There is a time and place for typing.Any
-  "RSE",    # contradicts Python Style Guide
+  "ANN401",   # There is a time and place for typing.Any
+  "ASYNC109", # async function with timeout parameter (false positive)
+  "RSE",      # contradicts Python Style Guide
 ]
 flake8-quotes = { inline-quotes = "single" }
 isort.split-on-trailing-comma = false

--- a/src/imbi_automations/models/workflow.py
+++ b/src/imbi_automations/models/workflow.py
@@ -185,6 +185,11 @@ class WorkflowAction(pydantic.BaseModel):
                     f'Use Go time.Duration format '
                     f'(e.g., "5m", "1h", "1h30m", "90s")'
                 )
+            if seconds <= 0:
+                raise ValueError(
+                    f'Invalid timeout value: {v}. '
+                    f'Timeout must be greater than zero'
+                )
         except ImportError:
             raise ValueError(
                 'pytimeparse2 required for timeout parsing'

--- a/tests/data/workflows/comprehensive-test-workflow.toml
+++ b/tests/data/workflows/comprehensive-test-workflow.toml
@@ -77,7 +77,7 @@ type = "claude"
 task_prompt = "prompts/main-prompt.md"
 validation_prompt = "prompts/validation-prompt.md"
 max_cycles = 5
-timeout = 1800
+timeout = "30m"
 
 # 3. Docker Actions - all command types
 
@@ -211,7 +211,7 @@ command = "sync_environments"
 name = "test-shell-action"
 type = "shell"
 command = "npm install && npm run build"
-timeout = 600
+timeout = "10m"
 
 # 8. Template Action
 [[actions]]


### PR DESCRIPTION
## Summary

- Adds timeout configuration using Go time.Duration format (e.g., "5m", "1h30m", "90s") with default of "1h"
- Implements timeout enforcement for Claude (per-cycle), Shell, and Docker actions with graceful process termination (SIGTERM → SIGKILL)
- Migrates existing `timeout` field from integer seconds to string format for better UX

## Test plan

- [x] All 752 existing tests pass
- [x] Field validation accepts valid Go duration formats ("5m", "1h", "1h30m", "90s")
- [x] Field validation rejects invalid formats with helpful error messages
- [x] Timeout enforced with asyncio.wait_for() wrapper
- [x] Graceful termination sequence implemented (SIGTERM with 5s timeout, then SIGKILL)
- [x] Test data migrated from integer to string format
- [x] Documentation updated in AGENTS.md with examples and behavior table
- [x] Linting passes with ASYNC109 properly ignored in pyproject.toml

## Breaking changes

**Field Type Change:** `WorkflowAction.timeout` changes from `int` (seconds) to `str` (Go duration format)

**Migration:**
- Old: `timeout = 3600`
- New: `timeout = "1h"` or `timeout = "60m"`
- Default remains 1 hour but format changes

**Impact:** Workflows with explicit integer timeouts will fail validation with clear error message pointing to correct format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds configurable timeout support for Claude, Shell, and Docker actions using Go duration format (e.g., "5m", "1h30m"). The implementation includes proper timeout enforcement with `asyncio.wait_for()` and graceful process termination (SIGTERM → SIGKILL after 5s).

**Key changes:**
- Migrated `WorkflowAction.timeout` from `int` (seconds) to `str` (Go duration format) with field validation
- Added per-cycle timeout enforcement for Claude actions
- Implemented subprocess termination for Shell and Docker actions with graceful shutdown sequence
- Updated documentation in AGENTS.md with comprehensive examples and behavior table
- Added `pytimeparse2>=1.7.1` dependency for duration parsing

**Issues found:**
- Validation in `workflow.py:181-187` doesn't reject zero or negative timeout values, which would cause runtime errors instead of early validation failures

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge after addressing the zero/negative timeout validation issue
- The implementation is well-structured with proper error handling and graceful shutdown logic. The breaking change is clearly documented and test data has been migrated. However, the missing validation for zero/negative timeouts in `workflow.py` could cause confusing runtime errors instead of early validation failures. All 752 existing tests pass according to the PR description.
- Pay attention to `src/imbi_automations/models/workflow.py` - validation logic needs enhancement to reject zero/negative timeouts

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/models/workflow.py | 4/5 | Changed `timeout` field from `int` to `str` with validation for Go duration format - missing validation for zero/negative values |
| src/imbi_automations/claude.py | 5/5 | Added timeout parameter to `agent_query` with proper timeout enforcement and graceful SDK shutdown |
| src/imbi_automations/actions/claude.py | 5/5 | Added per-cycle timeout handling with proper error propagation and logging |
| src/imbi_automations/actions/shell.py | 5/5 | Implemented timeout with graceful termination (SIGTERM → SIGKILL) for shell commands |
| src/imbi_automations/actions/docker.py | 5/5 | Added timeout handling with graceful process termination for docker commands |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->