### PR TITLE
Add fallback parsing for Claude agent structured output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,11 @@ ai_commit = true
 
 Planning agent can set `skip_task=True` to skip task/validation when no work needed.
 
+**Structured Output:**
+- Agents must return raw JSON matching their schema (not wrapped in code blocks or XML)
+- Fallback parser extracts JSON/XML if SDK doesn't populate `structured_output`
+- Supports both native API structured output and text-based extraction
+
 ### MCP Servers
 
 ```toml

--- a/src/imbi_automations/claude-code/agents/planning.md.j2
+++ b/src/imbi_automations/claude-code/agents/planning.md.j2
@@ -11,7 +11,16 @@ Analyze the codebase and create an execution plan. Use Read, Glob, Grep, Bash to
 
 ## OUTPUT FORMAT
 
-Your response will be structured as JSON with these fields:
+After completing your analysis, you MUST end your response with raw JSON (not wrapped in code blocks, not in XML/tool format):
+```
+{
+  "plan": ["task 1", "task 2"],
+  "analysis": "your findings",
+  "skip_task": false
+}
+```
+
+Fields:
 - `plan`: list of strings (tasks for the task agent)
 - `analysis`: string (your findings)
 - `skip_task`: boolean (default False) - set to True if no work is needed

--- a/src/imbi_automations/claude-code/agents/task.md.j2
+++ b/src/imbi_automations/claude-code/agents/task.md.j2
@@ -11,8 +11,17 @@ Execute the assigned tasks. Make all required changes without asking for confirm
 
 ## OUTPUT FORMAT
 
-Your response will be structured as JSON with this field:
-- `message`: string (brief summary of changes made)
+After completing all work, you MUST end your response with raw JSON (not wrapped in code blocks, not in XML/tool format):
+```
+{"message": "brief summary of changes made"}
+```
+
+Example of correct output:
+```
+I've updated the files as requested.
+
+{"message": "Updated configuration files with new settings"}
+```
 
 ## KEY DIRECTIVES
 

--- a/src/imbi_automations/claude-code/agents/validation.md.j2
+++ b/src/imbi_automations/claude-code/agents/validation.md.j2
@@ -11,7 +11,15 @@ Check if the generated content meets validation rules.
 
 ## OUTPUT FORMAT
 
-Your response will be structured as JSON with these fields:
+After completing validation checks, you MUST end your response with raw JSON (not wrapped in code blocks, not in XML/tool format):
+```
+{
+  "validated": true,
+  "errors": []
+}
+```
+
+Fields:
 - `validated`: boolean (true if all checks pass)
 - `errors`: list of strings (empty if validated=true, specific error messages if false)
 


### PR DESCRIPTION
Fixes issue where Claude agents return structured output in XML format (<StructuredOutput> tags) or raw JSON that the SDK doesn't automatically extract. This was causing "No structured output received from Claude Code" errors even when Claude successfully returned the data.

Changes:
- Add _try_extract_json_from_text() method to extract structured output from both XML tags and raw JSON in result text
- Modify _parse_message() to call fallback extractor when SDK's structured_output field is None
- Enhance error messages to include preview of received content
- Clarify output format requirements in all agent prompt files (task.md.j2, planning.md.j2, validation.md.j2)
- Add comprehensive tests for XML and JSON fallback extraction
- Update AGENTS.md documentation with structured output behavior

The fallback parser handles two formats:
1. XML: <StructuredOutput><parameter name="key">value</parameter></StructuredOutput>
2. JSON: Raw JSON objects in the text (e.g., {"message": "..."})

All 40 tests pass including 2 new tests for fallback extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds fallback parsing for Claude agent structured output when the SDK doesn't automatically extract it. The changes address a real production issue where Claude returns structured data in XML (`<StructuredOutput>` tags) or raw JSON that the SDK's `structured_output` field doesn't capture.

- Added `_try_extract_json_from_text()` method that parses both XML parameter tags and raw JSON from response text
- Modified `_parse_message()` to invoke fallback extraction when `structured_output` is None
- Enhanced error messages with result previews for easier debugging
- Updated all agent prompt files to clarify output format requirements
- Added comprehensive test coverage for both XML and JSON extraction paths

The implementation is pragmatic - the JSON regex handles one level of nesting which aligns with the flat schema definitions used by the agents (`ClaudeAgentPlanningResult`, `ClaudeAgentTaskResult`, `ClaudeAgentValidationResult`).

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge - it adds a fallback parser that only activates when the SDK fails to extract structured output, preserving existing behavior.
- Score reflects well-tested changes with clear purpose. The regex has known limitations with deeply nested JSON (3+ levels) and XML values containing '<', but these edge cases are unlikely given the flat schemas used. The fallback is additive and doesn't modify existing success paths.
- No files require special attention - the core logic in `claude.py` is straightforward and well-tested.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/claude.py | 4/5 | Added fallback JSON/XML extraction when SDK doesn't populate structured_output. The regex handles most practical cases but has edge cases with deeply nested JSON (3+ levels) and XML values containing '<'. These are unlikely in practice given the flat schema definitions. |
| tests/test_claude.py | 5/5 | Added two new tests for XML and JSON fallback extraction scenarios. Tests cover the primary use cases but don't test edge cases like nested JSON or special characters in XML values. |
| src/imbi_automations/claude-code/agents/task.md.j2 | 5/5 | Clarified output format requirements to help Claude produce raw JSON at the end of responses instead of wrapped in code blocks or XML. |
| src/imbi_automations/claude-code/agents/planning.md.j2 | 5/5 | Clarified output format requirements with explicit JSON example to guide Claude agents. |
| src/imbi_automations/claude-code/agents/validation.md.j2 | 5/5 | Clarified output format requirements with explicit JSON example for validation results. |
| AGENTS.md | 5/5 | Added documentation about structured output behavior and fallback parsing for agent reference. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->