### PR TITLE
Fix Claude Code structured output failures with tool-based response system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,6 @@ RUN apt-get update \
 
 USER imbi-automations
 
-RUN curl -fsSL https://claude.ai/install.sh | bash
-
 WORKDIR /opt
 
 VOLUME /opt/config /opt/dry-runs /opt/errors /opt/workflows /docker-entrypoint-init.d

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "imbi-automations"
-version = "1.0.0b3"
+version = "1.0.0b4"
 description = "CLI tool for executing automated workflows across Imbi projects with AI-powered transformations and GitHub PR integration."
 authors = [
   {name = "Gavin M. Roy", email = "gavinr@aweber.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "imbi-automations"
-version = "1.0.0-b4"
+version = "1.0.0b4"
 description = "CLI tool for executing automated workflows across Imbi projects with AI-powered transformations and GitHub PR integration."
 authors = [
   {name = "Gavin M. Roy", email = "gavinr@aweber.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "imbi-automations"
-version = "1.0.0b4"
+version = "1.0.0-b4"
 description = "CLI tool for executing automated workflows across Imbi projects with AI-powered transformations and GitHub PR integration."
 authors = [
   {name = "Gavin M. Roy", email = "gavinr@aweber.com"},

--- a/src/imbi_automations/claude-code/CLAUDE.md
+++ b/src/imbi_automations/claude-code/CLAUDE.md
@@ -8,8 +8,8 @@ Do not ask for context keywords or session setup. Proceed directly with the task
 
 The work you will be performing will primarily be in the `repository` directory. It is a git clone of the repository you are working on.
 
-## Output Format
+## Response Submission
 
-Your response MUST be structured JSON output matching the schema provided via output_format. The agent instructions specify the expected fields.
+You MUST submit your response using the `mcp__agent_tools__submit_agent_response` tool. The agent instructions specify which fields to populate based on your agent type.
 
-Output the raw JSON directly as your final message content. Do not wrap the JSON in markdown code blocks.
+Do NOT output JSON directly - always call the tool to submit your response.

--- a/src/imbi_automations/claude-code/CLAUDE.md
+++ b/src/imbi_automations/claude-code/CLAUDE.md
@@ -10,4 +10,8 @@ The work you will be performing will primarily be in the `repository` directory.
 
 ## Output Format
 
-Your response MUST be structured JSON output matching the schema provided via output_format. The agent instructions specify the expected fields. Do not wrap the JSON in markdown code blocks - output the raw JSON directly as your final response.
+Your response MUST be structured JSON output matching the schema provided via output_format. The agent instructions specify the expected fields.
+
+**CRITICAL: Do NOT use the StructuredOutput tool.** Output the raw JSON directly as your final message content. Do not wrap the JSON in markdown code blocks.
+
+The StructuredOutput tool is disabled for this workflow. You must output JSON directly in your message, not via a tool call.

--- a/src/imbi_automations/claude-code/CLAUDE.md
+++ b/src/imbi_automations/claude-code/CLAUDE.md
@@ -12,6 +12,4 @@ The work you will be performing will primarily be in the `repository` directory.
 
 Your response MUST be structured JSON output matching the schema provided via output_format. The agent instructions specify the expected fields.
 
-**CRITICAL: Do NOT use the StructuredOutput tool.** Output the raw JSON directly as your final message content. Do not wrap the JSON in markdown code blocks.
-
-The StructuredOutput tool is disabled for this workflow. You must output JSON directly in your message, not via a tool call.
+Output the raw JSON directly as your final message content. Do not wrap the JSON in markdown code blocks.

--- a/src/imbi_automations/claude-code/agents/planning.md.j2
+++ b/src/imbi_automations/claude-code/agents/planning.md.j2
@@ -11,8 +11,6 @@ Analyze the codebase and create an execution plan. Use Read, Glob, Grep, Bash to
 
 ## OUTPUT FORMAT
 
-**CRITICAL: Output JSON directly in your message content. Do NOT use the StructuredOutput tool.**
-
 Your final message must contain JSON with these fields:
 - `plan`: list of strings (tasks for the task agent)
 - `analysis`: string (your findings)

--- a/src/imbi_automations/claude-code/agents/planning.md.j2
+++ b/src/imbi_automations/claude-code/agents/planning.md.j2
@@ -1,7 +1,7 @@
 ---
 name: planning
 description: Automation engine planning agent that analyzes codebase and creates structured task plans
-tools: Read, Glob, Grep, Bash
+tools: Read, Glob, Grep, Bash, mcp__agent_tools__submit_agent_response
 model: inherit
 ---
 
@@ -9,27 +9,29 @@ model: inherit
 
 Analyze the codebase and create an execution plan. Use Read, Glob, Grep, Bash to explore.
 
-## OUTPUT FORMAT
+## SUBMIT YOUR PLAN
 
-Your final message must contain JSON with these fields:
-- `plan`: list of strings (tasks for the task agent)
-- `analysis`: string (your findings)
-- `skip_task`: boolean (default False) - set to True if no work is needed
+When done analyzing, call this tool:
 
-Example:
-```json
-{
-  "plan": ["Task 1", "Task 2"],
-  "analysis": "Found X issues...",
-  "skip_task": false
-}
 ```
+mcp__agent_tools__submit_agent_response(
+    plan=["First task", "Second task"],
+    analysis="Your findings and observations",
+    skip_task=False
+)
+```
+
+**IMPORTANT:**
+- `plan` = list of strings (tasks for the task agent)
+- `analysis` = string (your findings and observations)
+- `skip_task` = boolean (default False) - set True if no work needed
+- Call the tool - do NOT output JSON
 
 ### When to Skip Task Execution
 
-If your analysis determines that **no changes are needed**, set `skip_task=true`:
+If your analysis determines that **no changes are needed**, set `skip_task=True`:
 
-**Use skip_task=true when:**
+**Use skip_task=True when:**
 - Repository already in desired state
 - Required changes already implemented
 - Action not applicable to this project

--- a/src/imbi_automations/claude-code/agents/planning.md.j2
+++ b/src/imbi_automations/claude-code/agents/planning.md.j2
@@ -11,10 +11,21 @@ Analyze the codebase and create an execution plan. Use Read, Glob, Grep, Bash to
 
 ## OUTPUT FORMAT
 
-Your response will be structured as JSON with these fields:
+**CRITICAL: Output JSON directly in your message content. Do NOT use the StructuredOutput tool.**
+
+Your final message must contain JSON with these fields:
 - `plan`: list of strings (tasks for the task agent)
 - `analysis`: string (your findings)
 - `skip_task`: boolean (default False) - set to True if no work is needed
+
+Example:
+```json
+{
+  "plan": ["Task 1", "Task 2"],
+  "analysis": "Found X issues...",
+  "skip_task": false
+}
+```
 
 ### When to Skip Task Execution
 

--- a/src/imbi_automations/claude-code/agents/task.md.j2
+++ b/src/imbi_automations/claude-code/agents/task.md.j2
@@ -11,8 +11,17 @@ Execute the assigned tasks. Make all required changes without asking for confirm
 
 ## OUTPUT FORMAT
 
-Your response will be structured as JSON with this field:
+**CRITICAL: Output JSON directly in your message content. Do NOT use the StructuredOutput tool.**
+
+Your final message must contain JSON with this field:
 - `message`: string (brief summary of changes made)
+
+Example:
+```json
+{
+  "message": "Updated Dockerfile to use Python 3.12 base image"
+}
+```
 
 ## KEY DIRECTIVES
 

--- a/src/imbi_automations/claude-code/agents/task.md.j2
+++ b/src/imbi_automations/claude-code/agents/task.md.j2
@@ -11,8 +11,6 @@ Execute the assigned tasks. Make all required changes without asking for confirm
 
 ## OUTPUT FORMAT
 
-**CRITICAL: Output JSON directly in your message content. Do NOT use the StructuredOutput tool.**
-
 Your final message must contain JSON with this field:
 - `message`: string (brief summary of changes made)
 

--- a/src/imbi_automations/claude-code/agents/task.md.j2
+++ b/src/imbi_automations/claude-code/agents/task.md.j2
@@ -1,7 +1,7 @@
 ---
 name: task
 description: Automation engine task agent that modifies files according to specifications
-tools: Read, Write, Edit, Bash
+tools: Read, Write, Edit, Bash, mcp__agent_tools__submit_agent_response
 model: inherit
 ---
 
@@ -9,17 +9,19 @@ model: inherit
 
 Execute the assigned tasks. Make all required changes without asking for confirmation.
 
-## OUTPUT FORMAT
+## SUBMIT YOUR RESULT
 
-Your final message must contain JSON with this field:
-- `message`: string (brief summary of changes made)
+When done, call this tool:
 
-Example:
-```json
-{
-  "message": "Updated Dockerfile to use Python 3.12 base image"
-}
 ```
+mcp__agent_tools__submit_agent_response(
+    message="Brief summary of changes made"
+)
+```
+
+**IMPORTANT:**
+- `message` = string (summary of what you did)
+- Call the tool - do NOT output JSON
 
 ## KEY DIRECTIVES
 

--- a/src/imbi_automations/claude-code/agents/validation.md.j2
+++ b/src/imbi_automations/claude-code/agents/validation.md.j2
@@ -11,9 +11,19 @@ Check if the generated content meets validation rules.
 
 ## OUTPUT FORMAT
 
-Your response will be structured as JSON with these fields:
+**CRITICAL: Output JSON directly in your message content. Do NOT use the StructuredOutput tool.**
+
+Your final message must contain JSON with these fields:
 - `validated`: boolean (true if all checks pass)
 - `errors`: list of strings (empty if validated=true, specific error messages if false)
+
+Example:
+```json
+{
+  "validated": true,
+  "errors": []
+}
+```
 
 ## VALIDATION PRINCIPLES
 

--- a/src/imbi_automations/claude-code/agents/validation.md.j2
+++ b/src/imbi_automations/claude-code/agents/validation.md.j2
@@ -11,8 +11,6 @@ Check if the generated content meets validation rules.
 
 ## OUTPUT FORMAT
 
-**CRITICAL: Output JSON directly in your message content. Do NOT use the StructuredOutput tool.**
-
 Your final message must contain JSON with these fields:
 - `validated`: boolean (true if all checks pass)
 - `errors`: list of strings (empty if validated=true, specific error messages if false)

--- a/src/imbi_automations/claude-code/agents/validation.md.j2
+++ b/src/imbi_automations/claude-code/agents/validation.md.j2
@@ -1,7 +1,7 @@
 ---
 name: validation
 description: Validates generated content and provides feedback
-tools: Read, Bash
+tools: Read, Bash, mcp__agent_tools__submit_agent_response
 model: inherit
 ---
 
@@ -9,19 +9,30 @@ model: inherit
 
 Check if the generated content meets validation rules.
 
-## OUTPUT FORMAT
+## SUBMIT YOUR RESULT
 
-Your final message must contain JSON with these fields:
-- `validated`: boolean (true if all checks pass)
-- `errors`: list of strings (empty if validated=true, specific error messages if false)
+When done validating, call this tool:
 
-Example:
-```json
-{
-  "validated": true,
-  "errors": []
-}
+**Success:**
 ```
+mcp__agent_tools__submit_agent_response(
+    validated=True,
+    errors=[]
+)
+```
+
+**Failure:**
+```
+mcp__agent_tools__submit_agent_response(
+    validated=False,
+    errors=["Line 5: Expected Python 3.12, found 3.9", "Missing dependency X"]
+)
+```
+
+**IMPORTANT:**
+- `validated` = boolean (true if all checks pass)
+- `errors` = list of strings (empty if validated=True)
+- Call the tool - do NOT output JSON
 
 ## VALIDATION PRINCIPLES
 

--- a/src/imbi_automations/claude.py
+++ b/src/imbi_automations/claude.py
@@ -131,11 +131,7 @@ def _merge_plugin_configs(
     )
 
 
-AgentResult = (
-    models.ClaudeAgentPlanningResult
-    | models.ClaudeAgentTaskResult
-    | models.ClaudeAgentValidationResult
-)
+AgentResult = models.ClaudeAgentResponse
 
 
 class Claude(mixins.WorkflowLoggerMixin):
@@ -175,7 +171,7 @@ class Claude(mixins.WorkflowLoggerMixin):
         }
         self.tracker = tracker.Tracker.get_instance()
         self._set_workflow_logger(self.context.workflow)
-        self._structured_output: dict[str, typing.Any] | None = None
+        self._submitted_response: AgentResult | None = None
         self._merged_local_plugins: list[models.ClaudeLocalPlugin] = []
         self.client = self._create_client()
 
@@ -198,24 +194,20 @@ class Claude(mixins.WorkflowLoggerMixin):
         return agent_def.prompt
 
     async def agent_query(
-        self,
-        prompt: str,
-        response_model: type[AgentResult] | None = None,
-        timeout: str = '1h',
+        self, prompt: str, timeout: str = '1h'
     ) -> AgentResult | None:
-        """Execute an agent query and return structured output.
+        """Execute an agent query and return unified response via MCP tool.
 
         Args:
             prompt: The prompt to send to the agent
-            response_model: Pydantic model for structured output validation
             timeout: Maximum execution time in Go duration format (e.g., "30m",
                 "1h", "90s")
 
         Returns:
-            Validated response model instance, or None if no response
+            ClaudeAgentResponse with fields populated by the agent
 
         Raises:
-            RuntimeError: If no response received or structured output missing
+            RuntimeError: If agent didn't call submit_agent_response tool
             TimeoutError: If execution exceeds the specified timeout
 
         """
@@ -229,8 +221,7 @@ class Claude(mixins.WorkflowLoggerMixin):
         # Execute SDK interaction with timeout wrapper
         try:
             result = await asyncio.wait_for(
-                self._execute_sdk_query(prompt, response_model),
-                timeout=timeout_seconds,
+                self._execute_sdk_query(prompt), timeout=timeout_seconds
             )
             return result
         except TimeoutError:
@@ -260,38 +251,20 @@ class Claude(mixins.WorkflowLoggerMixin):
                 f'({timeout_seconds}s)'
             ) from None
 
-    async def _execute_sdk_query(
-        self, prompt: str, response_model: type[AgentResult] | None = None
-    ) -> AgentResult | None:
-        """Execute SDK query without timeout wrapper.
+    async def _execute_sdk_query(self, prompt: str) -> AgentResult | None:
+        """Execute SDK query and capture tool-based response.
 
         Args:
             prompt: The prompt to send to the agent
-            response_model: Pydantic model for structured output validation
 
         Returns:
-            Validated response model instance, or None if no response
+            ClaudeAgentResponse populated by the agent via MCP tool
 
         Raises:
-            RuntimeError: If no response received or structured output missing
+            RuntimeError: If agent didn't call submit_agent_response tool
 
         """
-        self._structured_output: dict[str, typing.Any] | None = None
-
-        # Set output format BEFORE connecting - SDK reads it at connect time
-        if response_model is not None:
-            output_format = {
-                'type': 'json_schema',
-                'schema': response_model.model_json_schema(),
-            }
-            self.client.options.output_format = output_format
-            LOGGER.debug(
-                'Setting output_format for %s: %r',
-                response_model.__name__,
-                output_format,
-            )
-        else:
-            self.client.options.output_format = None
+        self._submitted_response: AgentResult | None = None
 
         await self.client.connect()
         await self.client.query(prompt)
@@ -299,14 +272,13 @@ class Claude(mixins.WorkflowLoggerMixin):
             self._parse_message(message)
         await self.client.disconnect()
 
-        if self._structured_output is None:
+        if self._submitted_response is None:
             raise RuntimeError(
-                'No structured output received from Claude Code'
+                'No response received from Claude Code - agent must call '
+                'submit_agent_response tool'
             )
 
-        if response_model is not None:
-            return response_model.model_validate(self._structured_output)
-        return None
+        return self._submitted_response
 
     async def anthropic_query(
         self, prompt: str, model: str | None = None
@@ -332,6 +304,41 @@ class Claude(mixins.WorkflowLoggerMixin):
         settings = self._initialize_working_directory()
         LOGGER.debug('Claude Code settings: %s', settings)
 
+        # Create MCP tool for unified agent responses
+        @claude_agent_sdk.tool(
+            'submit_agent_response',
+            'Submit the final agent response (required)',
+            models.ClaudeAgentResponse.model_json_schema(),
+        )
+        async def submit_agent_response(
+            args: dict[str, typing.Any],
+        ) -> dict[str, typing.Any]:
+            """Submit unified agent response via MCP tool."""
+            LOGGER.debug('submit_agent_response tool invoked with: %r', args)
+            try:
+                self._submitted_response = (
+                    models.ClaudeAgentResponse.model_validate(args)
+                )
+            except pydantic.ValidationError as err:
+                return {
+                    'content': [
+                        {
+                            'type': 'text',
+                            'text': f'Error: invalid response - {err}',
+                        }
+                    ],
+                    'is_error': True,
+                }
+            return {
+                'content': [
+                    {'type': 'text', 'text': 'Response submitted successfully'}
+                ]
+            }
+
+        agent_tools = claude_agent_sdk.create_sdk_mcp_server(
+            'agent_tools', '1.0.0', [submit_agent_response]
+        )
+
         system_prompt = (BASE_PATH / 'claude-code' / 'CLAUDE.md').read_text()
         if self.context.workflow.configuration.prompt:
             system_prompt += '\n\n---\n\n'
@@ -347,7 +354,7 @@ class Claude(mixins.WorkflowLoggerMixin):
                 raise RuntimeError
 
         # Build MCP servers dict with workflow-defined servers
-        mcp_servers: dict[str, typing.Any] = {}
+        mcp_servers: dict[str, typing.Any] = {'agent_tools': agent_tools}
         for (
             name,
             config,
@@ -378,6 +385,7 @@ class Claude(mixins.WorkflowLoggerMixin):
                 'WebFetch',
                 'WebSearch',
                 'SlashCommand',
+                'mcp__agent_tools__submit_agent_response',
             ],
             cwd=self.context.working_directory / 'repository',
             mcp_servers=mcp_servers,
@@ -627,10 +635,4 @@ class Claude(mixins.WorkflowLoggerMixin):
             else:
                 LOGGER.debug(
                     'Result (%s): %r', message.session_id, message.result
-                )
-            # Extract structured output if present
-            if message.structured_output is not None:
-                self._structured_output = message.structured_output
-                LOGGER.debug(
-                    'Structured output received: %r', message.structured_output
                 )

--- a/src/imbi_automations/claude.py
+++ b/src/imbi_automations/claude.py
@@ -427,6 +427,7 @@ class Claude(mixins.WorkflowLoggerMixin):
             'hooks': {},
             'outputStyle': 'json',
             'settingSources': ['project', 'local'],
+            'permissions': {'deny': ['StructuredOutput']},
         }
 
         # Add merged plugin configuration

--- a/src/imbi_automations/committer.py
+++ b/src/imbi_automations/committer.py
@@ -72,16 +72,19 @@ class Committer(mixins.WorkflowLoggerMixin):
             **client.prompt_kwargs,
         )
 
-        result = await client.agent_query(prompt, models.ClaudeAgentTaskResult)
+        result = await client.agent_query(prompt)
 
         # Check if agent indicated no changes to commit
-        for phrase in ['no changes to commit', 'working tree is clean']:
-            if phrase in result.message.lower():
-                return False
+        if result.message:
+            for phrase in ['no changes to commit', 'working tree is clean']:
+                if phrase in result.message.lower():
+                    return False
 
-        # Check if commit failed
-        if 'commit failed' in result.message.lower():
-            raise RuntimeError(f'Claude Code commit failed: {result.message}')
+            # Check if commit failed
+            if 'commit failed' in result.message.lower():
+                raise RuntimeError(
+                    f'Claude Code commit failed: {result.message}'
+                )
 
         # Otherwise assume success
         return True

--- a/src/imbi_automations/models/__init__.py
+++ b/src/imbi_automations/models/__init__.py
@@ -7,6 +7,7 @@ workflow definitions, git operations, and Claude Code integration models.
 from . import configuration, imbi, mcp
 from .claude import (
     ClaudeAgentPlanningResult,
+    ClaudeAgentResponse,
     ClaudeAgentTaskResult,
     ClaudeAgentType,
     ClaudeAgentValidationResult,
@@ -90,6 +91,7 @@ __all__ = [
     'AnthropicConfiguration',
     'ClaudeAgentConfiguration',
     'ClaudeAgentPlanningResult',
+    'ClaudeAgentResponse',
     'ClaudeAgentTaskResult',
     'ClaudeAgentType',
     'ClaudeAgentValidationResult',

--- a/src/imbi_automations/models/claude.py
+++ b/src/imbi_automations/models/claude.py
@@ -181,3 +181,34 @@ class ClaudeAgentValidationResult(pydantic.BaseModel):
 
     validated: bool
     errors: list[str] = []
+
+
+class ClaudeAgentResponse(pydantic.BaseModel):
+    """Unified response model for all Claude Code agents via MCP tool.
+
+    This single model replaces SDK's structured output system with a
+    tool-based approach. All fields are optional - agents populate fields
+    relevant to their type.
+
+    Field usage by agent type:
+    - Planning: plan, analysis, skip_task (all optional)
+    - Task: message (required)
+    - Validation: validated, errors (validated required)
+
+    The model uses extra='forbid' to catch typos and model_validate to convert
+    tool args into typed Python objects.
+    """
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    # Planning agent fields
+    plan: list[str] | None = None
+    analysis: str | None = None
+    skip_task: bool = False
+
+    # Task agent fields
+    message: str | None = None
+
+    # Validation agent fields
+    validated: bool | None = None
+    errors: list[str] = []

--- a/tests/actions/test_claude.py
+++ b/tests/actions/test_claude.py
@@ -159,11 +159,11 @@ class ClaudeActionTestCase(base.AsyncTestCase):
         mock_agent_query: mock.AsyncMock,
     ) -> None:
         """Test successful execution cycle."""
-        # Mock successful agent responses - task returns TaskResult,
-        # validation returns ValidationResult
+        # Mock successful agent responses - task returns response,
+        # validation returns response
         mock_agent_query.side_effect = [
-            models.ClaudeAgentTaskResult(message='Success'),
-            models.ClaudeAgentValidationResult(validated=True, errors=[]),
+            models.ClaudeAgentResponse(message='Success'),
+            models.ClaudeAgentResponse(validated=True, errors=[]),
         ]
         mock_get_agent_prompt.return_value = '# AGENT\n\nDo the work.'
 
@@ -209,10 +209,8 @@ class ClaudeActionTestCase(base.AsyncTestCase):
         """Test execution cycle with validation failure."""
         # Mock task agent completing, then validation failing
         mock_agent_query.side_effect = [
-            models.ClaudeAgentTaskResult(message='Task completed'),
-            models.ClaudeAgentValidationResult(
-                validated=False, errors=['Error 1']
-            ),
+            models.ClaudeAgentResponse(message='Task completed'),
+            models.ClaudeAgentResponse(validated=False, errors=['Error 1']),
         ]
         mock_get_agent_prompt.return_value = '# AGENT\n\nDo the work.'
 
@@ -256,7 +254,7 @@ class ClaudeActionTestCase(base.AsyncTestCase):
     ) -> None:
         """Test execute with successful first cycle."""
         # Task agent without validation returns True (success)
-        mock_agent_query.return_value = models.ClaudeAgentTaskResult(
+        mock_agent_query.return_value = models.ClaudeAgentResponse(
             message='Success'
         )
         mock_get_agent_prompt.return_value = '# AGENT\n\nDo the work.'
@@ -297,19 +295,15 @@ class ClaudeActionTestCase(base.AsyncTestCase):
         mock_agent_query: mock.AsyncMock,
     ) -> None:
         """Test execute with all cycles failing."""
-        # Task agent returns TaskResult (always succeeds at execution level).
+        # Task agent returns response (always succeeds at execution level).
         # Without validation, cycles succeed, so test needs validation
         mock_agent_query.side_effect = [
             # Cycle 1: task + validation fail
-            models.ClaudeAgentTaskResult(message='Task completed'),
-            models.ClaudeAgentValidationResult(
-                validated=False, errors=['Error']
-            ),
+            models.ClaudeAgentResponse(message='Task completed'),
+            models.ClaudeAgentResponse(validated=False, errors=['Error']),
             # Cycle 2: task + validation fail again
-            models.ClaudeAgentTaskResult(message='Task completed'),
-            models.ClaudeAgentValidationResult(
-                validated=False, errors=['Error']
-            ),
+            models.ClaudeAgentResponse(message='Task completed'),
+            models.ClaudeAgentResponse(validated=False, errors=['Error']),
         ]
         mock_get_agent_prompt.return_value = '# AGENT\n\nDo the work.'
 
@@ -360,13 +354,11 @@ class ClaudeActionTestCase(base.AsyncTestCase):
         # Second cycle: task + validation succeeds
         mock_agent_query.side_effect = [
             # Cycle 1
-            models.ClaudeAgentTaskResult(message='Task completed'),
-            models.ClaudeAgentValidationResult(
-                validated=False, errors=['Error']
-            ),
+            models.ClaudeAgentResponse(message='Task completed'),
+            models.ClaudeAgentResponse(validated=False, errors=['Error']),
             # Cycle 2
-            models.ClaudeAgentTaskResult(message='Task completed'),
-            models.ClaudeAgentValidationResult(validated=True, errors=[]),
+            models.ClaudeAgentResponse(message='Task completed'),
+            models.ClaudeAgentResponse(validated=True, errors=[]),
         ]
         mock_get_agent_prompt.return_value = '# AGENT\n\nDo the work.'
 
@@ -404,23 +396,8 @@ class ClaudeActionTestCase(base.AsyncTestCase):
         )  # 2 cycles * (task + validation)
 
 
-class GetResponseModelTestCase(unittest.TestCase):
-    """Test cases for the _get_response_model function."""
-
-    def test_get_response_model_planning(self) -> None:
-        """Test _get_response_model returns correct model for planning."""
-        result = claude._get_response_model(models.ClaudeAgentType.planning)
-        self.assertIs(result, models.ClaudeAgentPlanningResult)
-
-    def test_get_response_model_task(self) -> None:
-        """Test _get_response_model returns correct model for task."""
-        result = claude._get_response_model(models.ClaudeAgentType.task)
-        self.assertIs(result, models.ClaudeAgentTaskResult)
-
-    def test_get_response_model_validation(self) -> None:
-        """Test _get_response_model returns correct model for validation."""
-        result = claude._get_response_model(models.ClaudeAgentType.validation)
-        self.assertIs(result, models.ClaudeAgentValidationResult)
+# GetResponseModelTestCase removed - _get_response_model function no longer
+# exists with unified ClaudeAgentResponse model
 
 
 if __name__ == '__main__':

--- a/tests/test_committer.py
+++ b/tests/test_committer.py
@@ -2,7 +2,6 @@
 
 import pathlib
 import tempfile
-import typing
 import unittest
 from unittest import mock
 
@@ -233,10 +232,8 @@ class ClaudeCommitTestCase(base.AsyncTestCase):
         mock_render.return_value = 'Commit the changes'
 
         # Create a proper async mock for agent_query
-        async def mock_agent_query(
-            prompt: str, response_model: typing.Any
-        ) -> models.ClaudeAgentTaskResult:
-            return models.ClaudeAgentTaskResult(
+        async def mock_agent_query(prompt: str) -> models.ClaudeAgentResponse:
+            return models.ClaudeAgentResponse(
                 message='Committed changes successfully with SHA abc123'
             )
 
@@ -258,10 +255,8 @@ class ClaudeCommitTestCase(base.AsyncTestCase):
         mock_client.prompt_kwargs = {}
         mock_render.return_value = 'Commit the changes'
 
-        async def mock_agent_query(
-            prompt: str, response_model: typing.Any
-        ) -> models.ClaudeAgentTaskResult:
-            return models.ClaudeAgentTaskResult(
+        async def mock_agent_query(prompt: str) -> models.ClaudeAgentResponse:
+            return models.ClaudeAgentResponse(
                 message='There are no changes to commit.'
             )
 
@@ -283,10 +278,8 @@ class ClaudeCommitTestCase(base.AsyncTestCase):
         mock_client.prompt_kwargs = {}
         mock_render.return_value = 'Commit the changes'
 
-        async def mock_agent_query(
-            prompt: str, response_model: typing.Any
-        ) -> models.ClaudeAgentTaskResult:
-            return models.ClaudeAgentTaskResult(
+        async def mock_agent_query(prompt: str) -> models.ClaudeAgentResponse:
+            return models.ClaudeAgentResponse(
                 message='Nothing to commit, working tree is clean.'
             )
 
@@ -308,10 +301,8 @@ class ClaudeCommitTestCase(base.AsyncTestCase):
         mock_client.prompt_kwargs = {}
         mock_render.return_value = 'Commit the changes'
 
-        async def mock_agent_query(
-            prompt: str, response_model: typing.Any
-        ) -> models.ClaudeAgentTaskResult:
-            return models.ClaudeAgentTaskResult(
+        async def mock_agent_query(prompt: str) -> models.ClaudeAgentResponse:
+            return models.ClaudeAgentResponse(
                 message='Commit failed: pre-commit hook rejected changes'
             )
 
@@ -336,10 +327,8 @@ class ClaudeCommitTestCase(base.AsyncTestCase):
         mock_client.prompt_kwargs = {}
         mock_render.return_value = 'Commit the changes'
 
-        async def mock_agent_query(
-            prompt: str, response_model: typing.Any
-        ) -> models.ClaudeAgentTaskResult:
-            return models.ClaudeAgentTaskResult(
+        async def mock_agent_query(prompt: str) -> models.ClaudeAgentResponse:
+            return models.ClaudeAgentResponse(
                 message='NO CHANGES TO COMMIT in this repository'
             )
 
@@ -350,32 +339,8 @@ class ClaudeCommitTestCase(base.AsyncTestCase):
 
         self.assertFalse(result)
 
-    @mock.patch('imbi_automations.committer.prompts.render')
-    @mock.patch('imbi_automations.committer.claude.Claude')
-    async def test_passes_correct_response_model(
-        self, mock_claude_class: mock.MagicMock, mock_render: mock.MagicMock
-    ) -> None:
-        """Test _claude_commit passes ClaudeAgentTaskResult to agent_query."""
-        mock_client = mock.MagicMock()
-        mock_claude_class.return_value = mock_client
-        mock_client.prompt_kwargs = {}
-        mock_render.return_value = 'Commit the changes'
-
-        captured_response_model = None
-
-        async def mock_agent_query(
-            prompt: str, response_model: typing.Any
-        ) -> models.ClaudeAgentTaskResult:
-            nonlocal captured_response_model
-            captured_response_model = response_model
-            return models.ClaudeAgentTaskResult(message='Success')
-
-        mock_client.agent_query = mock_agent_query
-
-        c = committer.Committer(self.config, verbose=False)
-        await c._claude_commit(self.context, self.action)
-
-        self.assertIs(captured_response_model, models.ClaudeAgentTaskResult)
+    # test_passes_correct_response_model removed - agent_query no longer
+    # takes response_model parameter with unified ClaudeAgentResponse
 
 
 class ManualCommitTestCase(base.AsyncTestCase):


### PR DESCRIPTION
## Problem

The Claude Code SDK's `output_format` structured output mechanism has been causing intermittent failures with the error:

```
ERROR - account-status-notifier error executing action "generate-dockerfile": No structured output received from Claude Code
```

This was blocking workflows from completing successfully, requiring manual intervention and reruns.

## Solution

Replace the SDK's structured output system with a reliable tool-based approach using MCP (Model Context Protocol). This returns to the original pre-1.0.0b1 tool-based submission pattern but with an improved unified response model instead of three separate tools.

## What Was Done

### 1. Created Unified Response Model
- Added `ClaudeAgentResponse` with all agent fields (optional based on agent type)
- Planning agent: `plan`, `analysis`, `skip_task`
- Task agent: `message`
- Validation agent: `validated`, `errors`

### 2. Implemented Single MCP Tool
- Created `submit_agent_response` tool in `claude.py`
- Tool validates responses with Pydantic and stores in `_submitted_response`
- Replaced SDK's `output_format` configuration with tool-based submission

### 3. Updated All Agent Prompts
- Planning, task, and validation agents all use `mcp__agent_tools__submit_agent_response`
- Clear instructions on which fields each agent should populate
- Updated CLAUDE.md to document tool-based approach

### 4. Simplified Workflow Engine
- Removed `_get_response_model()` helper function
- Updated `_execute_cycle()` to detect agent type by checking populated fields
- Simplified type hints to use unified `ClaudeAgentResponse`

### 5. Updated All Tests
- Updated test mocks to use `ClaudeAgentResponse`
- Removed obsolete response model parameter passing
- All 748 tests passing

## Technical Details

**Previous approach (unreliable):**
```python
# SDK sets output_format before connect
self.client.options.output_format = {'type': 'json_schema', 'schema': ...}
# Agent returns structured output via SDK mechanism
```

**New approach (reliable):**
```python
# Agent explicitly calls MCP tool
mcp__agent_tools__submit_agent_response(
    message="Task completed"  # or other fields
)
# Tool stores response in _submitted_response
```

## Benefits

1. **Reliability**: Tool-based approach eliminates "No structured output received" errors
2. **Simplicity**: Single unified model instead of three separate response types
3. **Maintainability**: One tool to manage instead of three
4. **Debugging**: Clearer error messages when agents fail to call the tool
5. **Type Safety**: Pydantic validation at tool invocation time

## Testing

- All 748 tests pass
- Code quality checks pass (ruff)
- Pre-commit hooks pass

## Files Changed

14 files changed, +203/-234 lines:
- Core: `claude.py`, `actions/claude.py`, `committer.py`, `models/claude.py`
- Prompts: All 3 agent prompts + `CLAUDE.md`
- Tests: `test_claude.py`, `test_committer.py`, `actions/test_claude.py`
- Version: `pyproject.toml` → 1.0.0b4

## Rollout

No configuration changes required. This is a drop-in replacement that maintains the same external API while fixing the internal submission mechanism.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR successfully addresses intermittent Claude Code SDK failures by replacing the unreliable `output_format` structured output mechanism with a robust tool-based approach using MCP.

**Key improvements:**
- Unified `ClaudeAgentResponse` model replaces three separate response types, simplifying the codebase
- MCP tool `submit_agent_response` provides explicit, validated response submission instead of implicit SDK extraction
- Agent type detection now uses field presence checks (`run.plan`, `run.message`, `run.validated`) rather than type checking
- All 748 tests updated and passing, demonstrating thorough validation
- Clean removal of obsolete code (`_get_response_model`, structured output extraction logic)

**Technical quality:**
- Proper error handling in the MCP tool with Pydantic validation
- Defensive null checking added in `committer.py` for `result.message`
- Clear documentation updates in all three agent prompt files
- StructuredOutput tool explicitly denied in settings to prevent conflicts

The implementation is well-architected and maintains backward compatibility by keeping legacy response models exported. This is a solid refactoring that improves reliability without changing the external API.

<h3>Confidence Score: 4/5</h3>


- Safe to merge after addressing the version format issue in `pyproject.toml`
- The implementation is solid with comprehensive test coverage (748 tests passing) and clean architectural changes. The unified response model simplifies the codebase while fixing the reliability issue. Score reflects one style issue with version formatting that should be corrected per project standards before merging.
- `pyproject.toml` requires version format correction to match project standard (`1.0.0-b4` not `1.0.0b4`)

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/models/claude.py | 5/5 | Added `ClaudeAgentResponse` unified model with all agent fields as optional. Clean design enables tool-based response submission. |
| src/imbi_automations/claude.py | 4/5 | Replaced SDK structured output with MCP tool `submit_agent_response`. Removed `response_model` parameter from `agent_query`. Added StructuredOutput tool deny rule. |
| src/imbi_automations/actions/claude.py | 4/5 | Simplified agent type detection using field presence checks (`run.plan`, `run.message`, `run.validated`). Removed `_get_response_model` helper function. |
| src/imbi_automations/committer.py | 5/5 | Updated to use unified response model. Added null check for `result.message` before string operations. |
| tests/test_claude.py | 5/5 | Removed structured output extraction tests. Updated test names to reflect new behavior. |
| tests/actions/test_claude.py | 5/5 | Updated all mocks to use `ClaudeAgentResponse`. Removed `GetResponseModelTestCase` class as `_get_response_model` function no longer exists. |

</details>



<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=f01b7d24-6f7b-4477-a7e0-a2e5f296be47))

<!-- /greptile_comment -->