### PR TITLE
Add error recovery actions to workflow engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,74 @@ committable = true
 |-------|------|----------|
 | `primary` | Before PR creation | Standard transformations |
 | `followup` | After PR creation | CI monitoring, review feedback |
+| `on_error` | When another action fails | Error recovery, cleanup |
 
 Followup actions cycle if they commit (up to `max_followup_cycles`). They receive PR context: `{{ pull_request.number }}`, `{{ pull_request.html_url }}`, `{{ pr_branch }}`.
+
+### Error Recovery
+
+Actions with `stage = "on_error"` handle failures from other actions.
+They can be attached action-specifically or globally with filters.
+
+**Action-specific handler:**
+```toml
+[[actions]]
+name = "deploy"
+type = "shell"
+command = "kubectl apply -f deployment.yaml"
+on_failure = "rollback-deployment"
+
+[[actions]]
+name = "rollback-deployment"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "retry"  # or "skip", "fail"
+max_retry_attempts = 2
+command = "kubectl rollout undo"
+```
+
+**Global handler with filter:**
+```toml
+[[actions]]
+name = "handle-claude-errors"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "skip"
+command = "echo 'Claude action failed'"
+
+[actions.error_filter]
+action_types = ["claude"]
+stages = ["primary"]
+exception_types = ["TimeoutError"]
+```
+
+**Recovery behaviors:**
+- `retry`: Re-execute the failed action (respects `max_retry_attempts`)
+- `skip`: Continue to next action after recovery
+- `fail`: Fail workflow (for cleanup-only handlers)
+
+**Error filter fields:**
+- `action_types`: Match by action type (`["claude", "shell"]`)
+- `action_names`: Match by action name (`["deploy", "test"]`)
+- `stages`: Match by stage (`["primary", "followup"]`)
+- `exception_types`: Match by exception class name (`["TimeoutError"]`)
+- `condition`: Custom Jinja2 expression
+
+**Error context variables:**
+Available in error handler templates:
+- `{{ failed_action }}`: The failed action object
+- `{{ exception }}`: Exception message string
+- `{{ exception_type }}`: Exception class name
+- `{{ retry_attempt }}`: Current retry attempt (1-indexed)
+- `{{ max_retries }}`: Maximum retry attempts configured
+
+**Constraints:**
+- Error actions cannot have `on_failure`, `ignore_errors`, or
+`committable=true`
+- Error actions must be referenced by `on_failure` OR have
+`error_filter`
+- If handler fails, workflow fails immediately (fail-fast)
+- Retry counts persist across resume operations
 
 ## Action Timeouts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ They can be attached action-specifically or globally with filters.
 name = "deploy"
 type = "shell"
 command = "kubectl apply -f deployment.yaml"
-on_failure = "rollback-deployment"
+on_error = "rollback-deployment"
 
 [[actions]]
 name = "rollback-deployment"
@@ -166,9 +166,9 @@ Available in error handler templates:
 - `{{ max_retries }}`: Maximum retry attempts configured
 
 **Constraints:**
-- Error actions cannot have `on_failure`, `ignore_errors`, or
+- Error actions cannot have `on_error`, `ignore_errors`, or
 `committable=true`
-- Error actions must be referenced by `on_failure` OR have
+- Error actions must be referenced by `on_error` OR have
 `error_filter`
 - If handler fails, workflow fails immediately (fail-fast)
 - Retry counts persist across resume operations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ exception_types = ["TimeoutError"]
 - `action_names`: Match by action name (`["deploy", "test"]`)
 - `stages`: Match by stage (`["primary", "followup"]`)
 - `exception_types`: Match by exception class name (`["TimeoutError"]`)
+- `exception_message_contains`: Match by text in exception message (`"ruff.....Failed"`)
 - `condition`: Custom Jinja2 expression
 
 **Error context variables:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,17 @@
 
 ## Versioning
 
+**pyproject.toml (PyPI format):**
+- Pre-release versions MUST NOT use a hyphen before the pre-release identifier
+- Examples: `1.0.0b5`, `1.0.0a13`, `1.0.0rc1`
+- NOT: `1.0.0-b5`, `1.0.0-a13` (hyphen is incorrect for PyPI)
+
+**Git Tags and GitHub Releases:**
 - Pre-release versions MUST use a hyphen before the pre-release identifier
-- Examples: `1.0.0-a13`, `1.0.0-b1`, `1.0.0-rc1`
-- NOT: `1.0.0a13`, `1.0.0b1` (no hyphen is incorrect)
+- Examples: `v1.0.0-b5`, `v1.0.0-a13`, `v1.0.0-rc1`
+- NOT: `v1.0.0b5`, `v1.0.0a13` (no hyphen breaks Docker workflow)
+
+**Why the difference:**
+- PyPI requires no hyphen in version strings (PEP 440)
+- GitHub Docker workflow expects hyphenated versions in tags/releases
+- When bumping versions, update pyproject.toml first, then tag with hyphenated format

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -83,6 +83,11 @@ if [ -d "$INIT_DIR" ] && [ "$(ls -A $INIT_DIR 2>/dev/null)" ]; then
     echo "Initialization complete."
 fi
 
+# Re-source .profile if init scripts modified it (e.g., PATH updates)
+if [ -f ~/.profile ]; then
+    source ~/.profile
+fi
+
 # --- Git Configuration ---
 # Configure git user identity from environment variables
 if [ -n "$GIT_USER_NAME" ]; then

--- a/docs/actions/claude.md
+++ b/docs/actions/claude.md
@@ -12,7 +12,7 @@ planning_prompt = "prompts/planning.md"         # Optional - enables planning ph
 task_prompt = "prompts/task.md"                 # Required (formerly 'prompt')
 validation_prompt = "prompts/validate.md"       # Optional
 max_cycles = 3                                  # Optional, default: 3
-on_failure = "cleanup-action"                   # Optional
+on_error = "cleanup-action"                   # Optional
 ai_commit = true                                # Optional, default: true
 ```
 
@@ -88,11 +88,11 @@ Maximum number of retry cycles if transformation fails validation.
 
 - Each cycle runs: Planning (if enabled) → Task → Validation (if enabled)
 - Logs warning at 60% of max cycles (e.g., "Cycle 3 of 5, approaching max_cycles limit")
-- If all cycles exhausted, triggers `on_failure` action (if configured)
+- If all cycles exhausted, triggers `on_error` action (if configured)
 - Error context from validation failures passed to subsequent cycles
 
 
-### on_failure (optional)
+### on_error (optional)
 
 Action name to restart from if this action fails after all retry cycles.
 
@@ -300,7 +300,7 @@ name = "refactor-codebase"
 type = "claude"
 task_prompt = "prompts/refactor.md"
 max_cycles = 5
-on_failure = "create-issue"  # Create GitHub issue if fails
+on_error = "create-issue"  # Create GitHub issue if fails
 ```
 
 ### With Validator (No Planning)
@@ -511,7 +511,7 @@ name = "fragile-transformation"
 type = "claude"
 prompt = "prompts/transform.md"
 max_cycles = 5        # Try up to 5 times
-on_failure = "cleanup" # Run cleanup action if all cycles fail
+on_error = "cleanup" # Run cleanup action if all cycles fail
 ```
 
 **Cycle behavior:**  
@@ -519,7 +519,7 @@ on_failure = "cleanup" # Run cleanup action if all cycles fail
 1. Execute transformation
 2. Check for failure files
 3. If failure detected and cycles remaining, retry
-4. If all cycles exhausted, trigger `on_failure` action
+4. If all cycles exhausted, trigger `on_error` action
 5. Pass error context to retry attempts
 
 ### Error Context in Retries
@@ -586,7 +586,7 @@ destination = "repository:///src.backup/"
 name = "ai-refactor"
 type = "claude"
 task_prompt = "prompts/refactor.md"
-on_failure = "restore-backup"
+on_error = "restore-backup"
 
 [[actions]]
 name = "run-tests"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -293,7 +293,7 @@ Actions support automatic restart on failure:
 ```toml
 [[actions]]
 name = "fragile-operation"
-on_failure = "cleanup-action"  # Restart from this action
+on_error = "cleanup-action"  # Restart from this action
 max_retries = 3
 ```
 
@@ -301,7 +301,7 @@ max_retries = 3
 
 - **Failure Files**: Create specific failure files to signal workflow abortion
 - **Detailed Logging**: Include actionable error information
-- **Recovery Strategies**: Configurable retry mechanisms and `on_failure` action chains
+- **Recovery Strategies**: Configurable retry mechanisms and `on_error` action chains
 
 ### Resource Management
 

--- a/docs/error-handlers.md
+++ b/docs/error-handlers.md
@@ -1,0 +1,702 @@
+# Error Recovery Actions
+
+Error recovery actions provide automated failure handling within workflows. When an action fails, the workflow engine can invoke recovery actions that diagnose issues, apply fixes, and optionally retry the failed operation.
+
+**Tip:** Error handlers use `stage = "on_error"` and can be attached to specific actions or globally with filters.
+
+## Overview
+
+Error recovery supports two attachment mechanisms:
+
+1. **Action-specific handlers**: Attached via `on_failure` field to individual actions
+2. **Global handlers**: Attached via `error_filter` to match failed actions by type, stage, or exception
+
+After successful recovery, handlers can:
+
+- **Retry** the failed action (up to a configurable limit)
+- **Skip** to the next action (continue workflow)
+- **Fail** the workflow (for cleanup-only handlers)
+
+## Quick Example
+
+```toml
+[[actions]]
+name = "run-tests"
+type = "shell"
+command = "pytest tests/"
+on_failure = "cleanup-and-retry"
+
+[[actions]]
+name = "cleanup-and-retry"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "retry"
+max_retry_attempts = 2
+command = """
+rm -rf .pytest_cache __pycache__
+pip install --force-reinstall -e .
+"""
+```
+
+When `run-tests` fails, `cleanup-and-retry` executes, cleans up state, and retries the tests up to 2 times.
+
+## Configuration
+
+### stage (required for error handlers)
+
+Must be set to `"on_error"` to designate an action as an error handler.
+
+**Type:** `string`
+
+**Valid values:** `"on_error"`
+
+```toml
+[[actions]]
+name = "my-error-handler"
+type = "shell"
+stage = "on_error"
+command = "echo 'Handling error'"
+```
+
+### recovery_behavior
+
+Determines what happens after the error handler executes successfully.
+
+**Type:** `string`
+
+**Default:** `"skip"`
+
+**Valid values:**
+
+- `"retry"`: Re-execute the failed action (respects `max_retry_attempts`)
+- `"skip"`: Continue to the next action after recovery
+- `"fail"`: Fail the workflow (useful for cleanup-only handlers)
+
+```toml
+[[actions]]
+name = "diagnostic-handler"
+type = "claude"
+stage = "on_error"
+recovery_behavior = "retry"
+task_prompt = "prompts/diagnose-and-fix.md.j2"
+```
+
+### max_retry_attempts
+
+Maximum number of times to retry the failed action when `recovery_behavior = "retry"`.
+
+**Type:** `integer`
+
+**Default:** `3`
+
+**Note:** After exhausting retries, the workflow fails.
+
+```toml
+[[actions]]
+name = "persistent-handler"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "retry"
+max_retry_attempts = 5
+command = "scripts/reset-environment.sh"
+```
+
+### error_filter
+
+Filter specification for global error handlers. Defines which failed actions this handler matches.
+
+**Type:** `object`
+
+**Default:** `None` (must be specified for global handlers)
+
+**Fields:**
+
+- `action_types`: List of action types to match (`["claude", "shell"]`)
+- `action_names`: List of action names to match (`["deploy", "test"]`)
+- `stages`: List of stages to match (`["primary", "followup"]`)
+- `exception_types`: List of exception class names (`["TimeoutError"]`)
+- `condition`: Custom Jinja2 expression (advanced)
+
+```toml
+[[actions]]
+name = "handle-claude-timeouts"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "skip"
+command = "echo 'Claude action timed out, continuing...'"
+
+[actions.error_filter]
+action_types = ["claude"]
+exception_types = ["TimeoutError", "asyncio.TimeoutError"]
+```
+
+**Filter matching:** All specified filters must match for the handler to trigger.
+
+## Attachment Mechanisms
+
+### Action-Specific Handlers
+
+Attach handlers to specific actions using the `on_failure` field.
+
+```toml
+[[actions]]
+name = "deploy-service"
+type = "shell"
+command = "kubectl apply -f deployment.yaml"
+on_failure = "rollback-deployment"
+
+[[actions]]
+name = "rollback-deployment"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "fail"
+command = """
+kubectl rollout undo deployment/my-service
+kubectl wait --for=condition=available deployment/my-service
+"""
+```
+
+**Priority:** Action-specific handlers always take precedence over global handlers.
+
+### Global Handlers with Filters
+
+Global handlers match failed actions based on filter criteria.
+
+**Match by action type:**
+
+```toml
+[[actions]]
+name = "handle-git-failures"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "skip"
+command = "git reset --hard HEAD"
+
+[actions.error_filter]
+action_types = ["git"]
+```
+
+**Match by stage:**
+
+```toml
+[[actions]]
+name = "followup-error-reporter"
+type = "template"
+stage = "on_error"
+recovery_behavior = "fail"
+source = "workflow:///templates/error-report.md.j2"
+destination = "ERROR_REPORT.md"
+
+[actions.error_filter]
+stages = ["followup"]
+```
+
+**Match by exception type:**
+
+```toml
+[[actions]]
+name = "timeout-handler"
+type = "claude"
+stage = "on_error"
+recovery_behavior = "skip"
+task_prompt = "workflow:///prompts/timeout-diagnosis.md.j2"
+
+[actions.error_filter]
+exception_types = ["TimeoutError", "asyncio.TimeoutError"]
+```
+
+**Combine multiple filters:**
+
+```toml
+[[actions]]
+name = "primary-claude-timeout-handler"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "retry"
+max_retry_attempts = 1
+command = "echo 'Retrying Claude action after timeout'"
+
+[actions.error_filter]
+action_types = ["claude"]
+stages = ["primary"]
+exception_types = ["TimeoutError"]
+```
+
+## Template Variables
+
+Error handlers have access to special template variables describing the failure:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `failed_action` | `object` | The failed action object (includes `.name`, `.type`) |
+| `exception` | `string` | Exception message |
+| `exception_type` | `string` | Exception class name |
+| `retry_attempt` | `integer` | Current retry attempt (1-indexed) |
+| `max_retries` | `integer` | Maximum retry attempts configured |
+
+**Example prompt template:**
+
+```markdown
+# Diagnose and Fix Error
+
+Action "{{ failed_action.name }}" (type: {{ failed_action.type }}) failed:
+
+**Error:** {{ exception }}
+**Type:** {{ exception_type }}
+**Retry:** {{ retry_attempt }}/{{ max_retries }}
+
+Analyze the error and make targeted fixes. If the issue is environmental
+(missing dependencies, API limits, network issues), explain the problem
+so the workflow can fail gracefully.
+```
+
+## Use Cases and Patterns
+
+### 1. AI-Powered Error Diagnosis
+
+Use Claude to analyze and fix errors automatically.
+
+```toml
+[[actions]]
+name = "migrate-codebase"
+type = "claude"
+task_prompt = "prompts/migration.md.j2"
+max_cycles = 5
+on_failure = "ai-diagnose-and-fix"
+
+[[actions]]
+name = "ai-diagnose-and-fix"
+type = "claude"
+stage = "on_error"
+recovery_behavior = "retry"
+max_retry_attempts = 3
+task_prompt = "prompts/error-diagnosis.md.j2"
+max_cycles = 2
+```
+
+### 2. Environment Reset and Retry
+
+Reset state before retrying flaky operations.
+
+```toml
+[[actions]]
+name = "integration-tests"
+type = "shell"
+command = "pytest tests/integration/"
+on_failure = "reset-test-environment"
+
+[[actions]]
+name = "reset-test-environment"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "retry"
+max_retry_attempts = 2
+command = """
+docker-compose down -v
+docker-compose up -d
+sleep 10
+"""
+```
+
+### 3. Type-Specific Global Handlers
+
+Handle all failures of a specific type consistently.
+
+```toml
+# Multiple Claude actions in workflow
+[[actions]]
+name = "update-code"
+type = "claude"
+task_prompt = "prompts/update.md.j2"
+
+[[actions]]
+name = "update-tests"
+type = "claude"
+task_prompt = "prompts/tests.md.j2"
+
+# Global handler for any Claude failures
+[[actions]]
+name = "claude-error-reporter"
+type = "template"
+stage = "on_error"
+recovery_behavior = "skip"
+source = "workflow:///templates/claude-failure.md.j2"
+destination = "CLAUDE_ERROR.md"
+
+[actions.error_filter]
+action_types = ["claude"]
+```
+
+### 4. Graceful Cleanup on Failure
+
+Ensure resources are cleaned up before failing.
+
+```toml
+[[actions]]
+name = "deploy-to-staging"
+type = "shell"
+command = "terraform apply -auto-approve"
+on_failure = "cleanup-partial-deployment"
+
+[[actions]]
+name = "cleanup-partial-deployment"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "fail"
+command = """
+terraform destroy -auto-approve -target=aws_instance.failed
+aws s3 rm s3://staging-bucket/temp/ --recursive
+"""
+```
+
+### 5. Timeout-Specific Recovery
+
+Handle timeouts differently from other errors.
+
+```toml
+[[actions]]
+name = "slow-operation"
+type = "shell"
+command = "scripts/data-processing.sh"
+timeout = "1h"
+
+[[actions]]
+name = "timeout-reporter"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "skip"
+command = """
+echo 'Operation timed out after 1 hour' &gt;&gt; timeout.log
+curl -X POST https://monitoring.example.com/alert \
+  -d '{"type": "timeout", "action": "slow-operation"}'
+"""
+
+[actions.error_filter]
+exception_types = ["TimeoutError"]
+```
+
+## Validation Rules
+
+The workflow engine enforces these constraints on error actions:
+
+### Error Actions Cannot:
+
+- **Have `on_failure` field**: Error handlers cannot have their own error handlers
+- **Have `ignore_errors = true`**: Would create ambiguous behavior
+- **Have `committable = true`**: Error recovery should not create commits
+
+```toml
+# INVALID - will fail validation
+[[actions]]
+name = "bad-error-handler"
+type = "shell"
+stage = "on_error"
+on_failure = "another-handler"  # ERROR: not allowed
+committable = true               # ERROR: not allowed
+command = "echo 'bad'"
+```
+
+### Error Actions Must:
+
+- **Be referenced OR have filter**: Every error action must be attached to the workflow either via another action's `on_failure` field or by having an `error_filter`
+
+```toml
+# INVALID - orphan error handler
+[[actions]]
+name = "orphan-handler"
+type = "shell"
+stage = "on_error"
+command = "echo 'orphan'"
+# ERROR: Not referenced by on_failure and no error_filter
+
+# VALID - has filter
+[[actions]]
+name = "global-handler"
+type = "shell"
+stage = "on_error"
+command = "echo 'global'"
+
+[actions.error_filter]
+action_types = ["shell"]
+```
+
+### References Must Be Valid:
+
+- **`on_failure` must reference existing action**: The referenced action name must exist
+- **Referenced action must have `stage = "on_error"`**: Cannot reference regular actions
+
+```toml
+# INVALID - references non-existent handler
+[[actions]]
+name = "bad-reference"
+type = "shell"
+command = "echo 'test'"
+on_failure = "does-not-exist"  # ERROR: handler not found
+
+# INVALID - references wrong stage
+[[actions]]
+name = "bad-stage-reference"
+type = "shell"
+command = "echo 'test'"
+on_failure = "not-an-error-handler"
+
+[[actions]]
+name = "not-an-error-handler"
+type = "shell"
+stage = "primary"  # ERROR: must be stage = "on_error"
+command = "echo 'handler'"
+```
+
+## Error Handler Execution
+
+### Handler Matching Priority
+
+When an action fails, the engine searches for handlers in this order:
+
+1. **Action-specific handler**: Check if failed action has `on_failure` field
+2. **First matching global handler**: Check global handlers with `error_filter` in order
+
+**Example with priority:**
+
+```toml
+[[actions]]
+name = "deploy"
+type = "shell"
+command = "kubectl apply -f deployment.yaml"
+on_failure = "specific-rollback"  # This takes priority
+
+[[actions]]
+name = "specific-rollback"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "fail"
+command = "kubectl rollout undo"
+
+[[actions]]
+name = "global-shell-handler"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "skip"
+command = "echo 'This never runs for deploy action'"
+
+[actions.error_filter]
+action_types = ["shell"]  # Matches but lower priority
+```
+
+### Handler Failure Behavior
+
+If an error handler itself fails:
+
+1. Workflow **fails immediately** (fail-fast semantics)
+2. Both exceptions are logged (original + handler failure)
+3. Working directory is preserved for resumability
+4. Resume state includes `handler_failed = true`
+
+**Important:** Error handlers cannot have their own error handlers. Design them to be robust.
+
+### Retry Limit Enforcement
+
+When `recovery_behavior = "retry"`:
+
+```toml
+[[actions]]
+name = "flaky-test"
+type = "shell"
+command = "pytest tests/integration/test_flaky.py"
+on_failure = "retry-handler"
+
+[[actions]]
+name = "retry-handler"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "retry"
+max_retry_attempts = 3
+command = "sleep 5"
+```
+
+**Execution flow:**
+
+1. `flaky-test` fails (attempt 1)
+2. `retry-handler` runs successfully
+3. `flaky-test` retries (attempt 2)
+4. If fails again, repeat up to `max_retry_attempts`
+5. After 3 retry attempts exhausted, workflow fails
+
+**Logging:** Each retry attempt is logged with current/max count.
+
+## Resumability
+
+Error handler state persists across resume operations:
+
+### Retry Counts Persist
+
+```bash
+# First run - fails after 2 retries
+imbi-automations config.toml workflow --project-id 123
+
+# Resume - continues from retry count 2
+imbi-automations config.toml workflow --resume ./errors/workflow/project-123
+```
+
+### Resume State Fields
+
+The `.state` file includes:
+
+- `retry_counts`: Map of action name to current retry count
+- `active_error_handler`: Name of handler that was running
+- `handler_failed`: Whether handler itself failed
+- `original_exception_type`: Exception class name from original failure
+- `original_exception_message`: Original exception message
+
+**Note:** You cannot resume through a failed error handler. Fix the issue and resume from the failed action.
+
+## Best Practices
+
+### 1. Keep Handlers Simple and Robust
+
+Error handlers should be more reliable than the actions they recover.
+
+**Good:**
+
+```toml
+[[actions]]
+name = "cleanup-handler"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "skip"
+command = "rm -rf /tmp/workflow-temp || true"
+```
+
+**Avoid:** Complex handlers that could fail themselves.
+
+### 2. Use Appropriate Recovery Behavior
+
+- `retry`: For transient failures (network, rate limits, flaky tests)
+- `skip`: For non-critical failures where workflow can continue
+- `fail`: For cleanup before failing (resource deallocation)
+
+### 3. Set Reasonable Retry Limits
+
+```toml
+# Good for flaky tests
+max_retry_attempts = 3
+
+# Good for rate-limited APIs
+max_retry_attempts = 5
+
+# Avoid - too many retries
+max_retry_attempts = 20
+```
+
+### 4. Provide Context in AI Handlers
+
+Give Claude enough information to diagnose issues:
+
+```markdown
+# Error Diagnosis Prompt
+
+## Failed Action
+- **Name:** {{ failed_action.name }}
+- **Type:** {{ failed_action.type }}
+- **Stage:** {{ failed_action.stage }}
+
+## Error Details
+- **Exception:** {{ exception_type }}
+- **Message:** {{ exception }}
+- **Retry:** {{ retry_attempt }}/{{ max_retries }}
+
+## Task
+Analyze the error and determine if it's fixable. If it's a code issue,
+make targeted fixes. If it's environmental (missing deps, API limits),
+explain why it cannot be fixed automatically.
+```
+
+### 5. Use Global Handlers for Common Patterns
+
+Instead of duplicating error handlers:
+
+```toml
+# Bad - repetitive
+[[actions]]
+name = "update-code"
+type = "claude"
+on_failure = "claude-handler-1"
+
+[[actions]]
+name = "update-tests"
+type = "claude"
+on_failure = "claude-handler-2"
+
+# Good - single global handler
+[[actions]]
+name = "update-code"
+type = "claude"
+task_prompt = "prompts/update.md.j2"
+
+[[actions]]
+name = "update-tests"
+type = "claude"
+task_prompt = "prompts/tests.md.j2"
+
+[[actions]]
+name = "claude-error-handler"
+type = "claude"
+stage = "on_error"
+recovery_behavior = "skip"
+task_prompt = "prompts/diagnose.md.j2"
+
+[actions.error_filter]
+action_types = ["claude"]
+```
+
+## Troubleshooting
+
+### Error Handler Never Triggers
+
+**Check:**
+
+1. Handler has correct `stage = "on_error"`
+2. Handler is referenced by `on_failure` OR has `error_filter`
+3. Filter criteria match the failed action
+4. Failed action does not have `ignore_errors = true`
+
+### Infinite Retry Loop
+
+**Cause:** Handler succeeds but underlying issue persists.
+
+**Solution:** Lower `max_retry_attempts` or change `recovery_behavior` to `"skip"`.
+
+### Handler Fails Immediately
+
+**Check:**
+
+1. Handler command/script is valid
+2. Required environment variables are set
+3. Handler has access to necessary resources
+
+**Tip:** Test handlers independently before adding to workflow.
+
+### Validation Errors
+
+**Common issues:**
+
+```
+Error: Error action "X" cannot have on_failure
+→ Remove on_failure from error actions
+
+Error: Error action "X" cannot be committable
+→ Set committable = false or remove field
+
+Error: Action "Y" references non-existent error handler "X"
+→ Ensure handler exists and has stage = "on_error"
+
+Error: Error action "X" must be either referenced or have error_filter
+→ Add on_failure reference or error_filter
+```
+
+## See Also
+
+- [Workflow Configuration](workflow-configuration.md) - Complete workflow config reference
+- [Templating](templating.md) - Jinja2 template syntax and variables
+- [CLI Reference](cli.md) - Resume and preserve-on-error options
+- [Debugging](debugging.md) - Debugging failed workflows

--- a/docs/error-handlers.md
+++ b/docs/error-handlers.md
@@ -115,6 +115,7 @@ Filter specification for global error handlers. Defines which failed actions thi
 - `action_names`: List of action names to match (`["deploy", "test"]`)
 - `stages`: List of stages to match (`["primary", "followup"]`)
 - `exception_types`: List of exception class names (`["TimeoutError"]`)
+- `exception_message_contains`: Text that must be present in exception message (e.g., `"ruff.....Failed"`)
 - `condition`: Custom Jinja2 expression (advanced)
 
 ```toml
@@ -298,7 +299,35 @@ sleep 10
 """
 ```
 
-### 3. Type-Specific Global Handlers
+### 3. Pre-commit Hook Auto-fix
+
+Auto-fix lint/format issues caught by pre-commit hooks.
+
+```toml
+[[actions]]
+name = "update-code"
+type = "claude"
+task_prompt = "prompts/update.md.j2"
+committable = true
+
+[[actions]]
+name = "fix-precommit-errors"
+type = "shell"
+stage = "on_error"
+recovery_behavior = "retry"
+max_retry_attempts = 1
+command = """
+cd repository
+ruff check --fix --unsafe-fixes .
+ruff format .
+"""
+
+[actions.error_filter]
+exception_message_contains = "ruff.....Failed"
+stages = ["primary"]
+```
+
+### 4. Type-Specific Global Handlers
 
 Handle all failures of a specific type consistently.
 
@@ -327,7 +356,7 @@ destination = "CLAUDE_ERROR.md"
 action_types = ["claude"]
 ```
 
-### 4. Graceful Cleanup on Failure
+### 5. Graceful Cleanup on Failure
 
 Ensure resources are cleaned up before failing.
 
@@ -349,7 +378,7 @@ aws s3 rm s3://staging-bucket/temp/ --recursive
 """
 ```
 
-### 5. Timeout-Specific Recovery
+### 6. Timeout-Specific Recovery
 
 Handle timeouts differently from other errors.
 

--- a/docs/error-handlers.md
+++ b/docs/error-handlers.md
@@ -366,7 +366,7 @@ type = "shell"
 stage = "on_error"
 recovery_behavior = "skip"
 command = """
-echo 'Operation timed out after 1 hour' &gt;&gt; timeout.log
+echo 'Operation timed out after 1 hour' >> timeout.log
 curl -X POST https://monitoring.example.com/alert \
   -d '{"type": "timeout", "action": "slow-operation"}'
 """

--- a/docs/error-handlers.md
+++ b/docs/error-handlers.md
@@ -723,6 +723,51 @@ Error: Error action "X" must be either referenced or have error_filter
 → Add on_error reference or error_filter
 ```
 
+## Metrics and Tracking
+
+The workflow engine automatically tracks error handler invocations and includes them in the final run summary. This helps you understand:
+
+- How often error handlers are being triggered
+- Which specific handlers are most active
+- Success vs. failure rates for recovery attempts
+
+### Tracked Metrics
+
+**Global Counters:**
+- `Error Handlers Invoked`: Total number of times any error handler was triggered
+- `Error Handlers Succeeded`: Number of handlers that completed successfully
+- `Error Handlers Failed`: Number of handlers that failed during execution
+
+**Per-Handler Counters:**
+- `Error Handler Invoked {name}`: Number of times a specific handler was triggered
+- `Error Handler Succeeded {name}`: Number of times a specific handler succeeded
+- `Error Handler Failed {name}`: Number of times a specific handler failed
+
+### Example Output
+
+```
+Automation Engine Run Details:
+Actions Executed: 25
+Actions Committed: 18
+Error Handlers Invoked: 3
+Error Handler Invoked Fix Precommit Errors: 3
+Error Handlers Succeeded: 2
+Error Handler Succeeded Fix Precommit Errors: 2
+Error Handlers Failed: 1
+Error Handler Failed Fix Precommit Errors: 1
+```
+
+This shows that the `fix-precommit-errors` handler was triggered 3 times, succeeded twice, and failed once.
+
+### Using Metrics
+
+These metrics help you:
+
+1. **Identify problematic actions**: If a handler runs frequently, the underlying action may need improvement
+2. **Tune retry limits**: Adjust `max_retry_attempts` based on actual success rates
+3. **Validate handlers**: Ensure handlers are working as expected
+4. **Track workflow health**: Monitor error recovery trends across runs
+
 ## See Also
 
 - [Workflow Configuration](workflow-configuration.md) - Complete workflow config reference

--- a/docs/workflow-configuration.md
+++ b/docs/workflow-configuration.md
@@ -731,7 +731,7 @@ name = "skip-slow-method"
 # Execution resumes here
 ```
 
-#### on_failure (optional)
+#### on_error (optional)
 
 Action name to restart from if this action fails after all retry cycles.
 
@@ -752,7 +752,7 @@ destination = "extracted:///src.backup/"
 name = "risky-transformation"
 type = "claude"
 prompt = "prompts/transform.md"
-on_failure = "restore-backup"
+on_error = "restore-backup"
 
 [[actions]]
 name = "restore-backup"
@@ -930,7 +930,7 @@ type = "claude"
 prompt = "prompts/update-python-version.md"
 validation_prompt = "prompts/validate-python-version.md"
 max_cycles = 3
-on_failure = "restore-backup"
+on_error = "restore-backup"
 ai_commit = true
 
 [[actions]]

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -238,7 +238,7 @@ name = "migrate-pydantic"
 type = "claude"
 prompt = "workflow:///prompts/pydantic-v2.md"
 max_cycles = 5
-on_failure = "restore-backup"
+on_error = "restore-backup"
 ai_commit = true
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "imbi-automations"
-version = "1.0.0b5"
+version = "1.0.0-b5"
 description = "CLI tool for executing automated workflows across Imbi projects with AI-powered transformations and GitHub PR integration."
 authors = [
   {name = "Gavin M. Roy", email = "gavinr@aweber.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "imbi-automations"
-version = "1.0.0b4"
+version = "1.0.0b5"
 description = "CLI tool for executing automated workflows across Imbi projects with AI-powered transformations and GitHub PR integration."
 authors = [
   {name = "Gavin M. Roy", email = "gavinr@aweber.com"},

--- a/src/imbi_automations/errors.py
+++ b/src/imbi_automations/errors.py
@@ -2,7 +2,7 @@
 
 
 class ActionFailureException(Exception):
-    """Exception raised when an action fails with on_failure configuration."""
+    """Exception raised when an action fails with on_error configuration."""
 
     def __init__(
         self, action_name: str, restart_from: str, failure_details: str

--- a/src/imbi_automations/models/__init__.py
+++ b/src/imbi_automations/models/__init__.py
@@ -52,6 +52,8 @@ from .imbi import (
 from .mcp import McpHttpServer, McpServerConfig, McpSSEServer, McpStdioServer
 from .resume_state import ResumeState
 from .workflow import (
+    ErrorFilter,
+    ErrorRecoveryBehavior,
     ResourceUrl,
     Workflow,
     WorkflowAction,
@@ -90,6 +92,8 @@ __all__ = [
     'mcp',
     'AnthropicConfiguration',
     'ClaudeAgentConfiguration',
+    'ErrorFilter',
+    'ErrorRecoveryBehavior',
     'ClaudeAgentPlanningResult',
     'ClaudeAgentResponse',
     'ClaudeAgentTaskResult',

--- a/src/imbi_automations/models/resume_state.py
+++ b/src/imbi_automations/models/resume_state.py
@@ -57,6 +57,13 @@ class ResumeState(pydantic.BaseModel):
     # Configuration snapshot
     configuration_hash: str  # To detect config changes
 
+    # Error handler tracking
+    retry_counts: dict[str, int] = {}
+    active_error_handler: str | None = None
+    handler_failed: bool = False
+    original_exception_type: str | None = None
+    original_exception_message: str | None = None
+
     def to_msgpack(self) -> bytes:
         """Serialize to MessagePack binary format.
 

--- a/src/imbi_automations/models/validators.py
+++ b/src/imbi_automations/models/validators.py
@@ -49,7 +49,7 @@ class CommandRulesMixin:
         'committable',
         'filter',
         'on_success',
-        'on_failure',
+        'on_error',
         'timeout',
         'data',
     }

--- a/src/imbi_automations/models/workflow.py
+++ b/src/imbi_automations/models/workflow.py
@@ -177,6 +177,7 @@ class ErrorFilter(pydantic.BaseModel):
     action_names: list[str] | None = None
     stages: list[WorkflowActionStage] | None = None
     exception_types: list[str] | None = None
+    exception_message_contains: str | None = None
     condition: str | None = None
 
 

--- a/src/imbi_automations/prompts.py
+++ b/src/imbi_automations/prompts.py
@@ -87,6 +87,8 @@ def render(
             }
         )
         kwargs.update(context.model_dump())
+        # Flatten context.variables to top-level for template access
+        kwargs.update(context.variables)
 
     if isinstance(source, pathlib.Path) and not template:
         template = source.read_text(encoding='utf-8')

--- a/src/imbi_automations/workflow_engine.py
+++ b/src/imbi_automations/workflow_engine.py
@@ -60,7 +60,9 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
         self._set_workflow_logger(workflow)
 
         # Error handler infrastructure
-        self.retry_counts: dict[str, int] = {}
+        self.retry_counts: dict[str, int] = (
+            resume_state.retry_counts if resume_state else {}
+        )
         self.error_actions: list[models.WorkflowActions] = []
         self.error_handlers: dict[str, models.WorkflowActions] = {}
         self.global_handlers: list[models.WorkflowActions] = []
@@ -1001,6 +1003,7 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
                     pull_request_number=pr.number if pr else None,
                     pull_request_url=pr.html_url if pr else None,
                     pr_branch=context.pr_branch,
+                    retry_counts=self.retry_counts,
                 )
 
                 state_file = target_path / '.state'

--- a/src/imbi_automations/workflow_engine.py
+++ b/src/imbi_automations/workflow_engine.py
@@ -684,11 +684,9 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
 
         # Build map: action_name → error_action
         for action in self.workflow.configuration.actions:
-            if action.on_failure:
+            if action.on_error:
                 handler = next(
-                    a
-                    for a in self.error_actions
-                    if a.name == action.on_failure
+                    a for a in self.error_actions if a.name == action.on_error
                 )
                 self.error_handlers[action.name] = handler
 
@@ -706,7 +704,7 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
         """Find error handler for failed action.
 
         Priority:
-        1. Action-specific handler (on_failure field)
+        1. Action-specific handler (on_error field)
         2. Global handler matching filters
 
         Args:
@@ -718,7 +716,7 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
             Error handler action if found, None otherwise
 
         """
-        # Priority 1: Check action's on_failure
+        # Priority 1: Check action's on_error
         if failed_action.name in self.error_handlers:
             return self.error_handlers[failed_action.name]
 

--- a/src/imbi_automations/workflow_engine.py
+++ b/src/imbi_automations/workflow_engine.py
@@ -829,6 +829,10 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
             failed_action.name,
         )
 
+        # Track error handler invocation
+        self.tracker.incr('error_handlers_invoked')
+        self.tracker.incr(f'error_handler_invoked_{handler.name}')
+
         # Check retry limit
         retry_count = self.retry_counts.get(failed_action.name, 0)
         if (
@@ -864,6 +868,7 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
                 handler.name,
             )
             self.tracker.incr('error_handlers_succeeded')
+            self.tracker.incr(f'error_handler_succeeded_{handler.name}')
 
             # Handle recovery behavior
             if handler.recovery_behavior == models.ErrorRecoveryBehavior.retry:
@@ -900,6 +905,7 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
                 handler_exc,
             )
             self.tracker.incr('error_handlers_failed')
+            self.tracker.incr(f'error_handler_failed_{handler.name}')
 
             if self.configuration.preserve_on_error:
                 self.last_error_path = self._preserve_working_directory(

--- a/src/imbi_automations/workflow_engine.py
+++ b/src/imbi_automations/workflow_engine.py
@@ -59,6 +59,13 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
         )
         self._set_workflow_logger(workflow)
 
+        # Error handler infrastructure
+        self.retry_counts: dict[str, int] = {}
+        self.error_actions: list[models.WorkflowActions] = []
+        self.error_handlers: dict[str, models.WorkflowActions] = {}
+        self.global_handlers: list[models.WorkflowActions] = []
+        self._build_error_handler_maps()
+
         if not self.configuration.claude.enabled and (
             self._needs_claude_code
             or workflow.configuration.github.create_pull_request
@@ -180,8 +187,10 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
         else:
             primary_actions_to_run = primary_actions
 
-        # Execute PRIMARY stage actions
-        for idx, action in primary_actions_to_run:
+        # Execute PRIMARY stage actions with error recovery support
+        list_idx = 0
+        while list_idx < len(primary_actions_to_run):
+            idx, action = primary_actions_to_run[list_idx]
             # Update current action index for progress tracking
             context.current_action_index = idx + 1
 
@@ -199,35 +208,84 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
                         if committed:
                             context.has_repository_changes = True
                             self.tracker.incr('actions_committed')
+
+                # Success - clear retry count
+                self.retry_counts.pop(action.name, None)
+                list_idx += 1  # Move to next action
+
             except Exception as exc:  # noqa: BLE001 - preserve_on_error must handle all exceptions
-                self.logger.error(
-                    '%s error executing action "%s": %s',
-                    context.imbi_project.slug,
-                    action.name,
-                    exc,
-                )
-                if self.configuration.preserve_on_error:
-                    # Calculate completed indices for this execution
-                    if not self.resume_state:
-                        # First run: all actions before failure
-                        completed_indices = list(range(0, idx))
-                    else:
-                        # Resume: only actions from failed_action_index to idx
-                        # (don't accumulate from previous runs)
-                        completed_indices = list(
-                            range(self.resume_state.failed_action_index, idx)
-                        )
-                    self.last_error_path = self._preserve_working_directory(
-                        context,
-                        working_directory,
-                        self.configuration.error_dir,
-                        failed_action_index=idx,
-                        failed_action_name=action.name,
-                        completed_action_indices=completed_indices,
-                        error_message=str(exc),
+                # Check ignore_errors first
+                if action.ignore_errors:
+                    self.logger.warning(
+                        '%s action "%s" failed but ignore_errors=True',
+                        context.imbi_project.slug,
+                        action.name,
                     )
-                working_directory.cleanup()
-                raise exc
+                    list_idx += 1
+                    continue
+
+                # Try to find error handler
+                handler = self._find_error_handler(action, 'primary', exc)
+
+                if handler:
+                    # Execute error handler
+                    result = await self._execute_error_recovery(
+                        context,
+                        action,
+                        idx,
+                        handler,
+                        exc,
+                        working_directory,
+                        'primary',
+                    )
+
+                    if result == 'retry':
+                        # Don't increment list_idx - retry same action
+                        continue
+                    elif result == 'skip':
+                        # Skip to next action
+                        list_idx += 1
+                        continue
+                    else:  # 'failed'
+                        # Handler failed - fail workflow
+                        raise RuntimeError(
+                            f'Error handler "{handler.name}" failed '
+                            f'for action "{action.name}"'
+                        ) from exc
+                else:
+                    # No handler - use existing error handling
+                    self.logger.error(
+                        '%s error executing action "%s": %s',
+                        context.imbi_project.slug,
+                        action.name,
+                        exc,
+                    )
+                    if self.configuration.preserve_on_error:
+                        # Calculate completed indices for this execution
+                        if not self.resume_state:
+                            # First run: all actions before failure
+                            completed_indices = list(range(0, idx))
+                        else:
+                            # Resume: only actions from failed_action_index
+                            # to idx (don't accumulate from previous runs)
+                            completed_indices = list(
+                                range(
+                                    self.resume_state.failed_action_index, idx
+                                )
+                            )
+                        self.last_error_path = (
+                            self._preserve_working_directory(
+                                context,
+                                working_directory,
+                                self.configuration.error_dir,
+                                failed_action_index=idx,
+                                failed_action_name=action.name,
+                                completed_action_indices=completed_indices,
+                                error_message=str(exc),
+                            )
+                        )
+                    working_directory.cleanup()
+                    raise exc
 
         # Handle dry-run mode: preserve working directory and skip push/PR
         if self.configuration.dry_run:
@@ -404,7 +462,9 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
 
             cycle_made_commits = False
 
-            for idx, action in followup_actions:
+            list_idx = 0
+            while list_idx < len(followup_actions):
+                idx, action = followup_actions[list_idx]
                 context.current_action_index = idx + 1
 
                 try:
@@ -436,29 +496,74 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
                                 cycle_made_commits = True
                                 self.tracker.incr('followup_commits')
 
+                    # Success - clear retry count
+                    self.retry_counts.pop(action.name, None)
+                    list_idx += 1  # Move to next action
+
                 except Exception as exc:  # noqa: BLE001
-                    self.logger.error(
-                        '%s error in followup action "%s": %s',
-                        context.imbi_project.slug,
-                        action.name,
-                        exc,
-                    )
-                    if self.configuration.preserve_on_error:
-                        self.last_error_path = (
-                            self._preserve_working_directory(
-                                context,
-                                working_directory,
-                                self.configuration.error_dir,
-                                failed_action_index=idx,
-                                failed_action_name=action.name,
-                                completed_action_indices=[],
-                                error_message=str(exc),
-                                current_stage='followup',
-                                followup_cycle=cycle,
-                            )
+                    # Check ignore_errors first
+                    if action.ignore_errors:
+                        self.logger.warning(
+                            '%s followup action "%s" failed but '
+                            'ignore_errors=True',
+                            context.imbi_project.slug,
+                            action.name,
                         )
-                    working_directory.cleanup()
-                    raise
+                        list_idx += 1
+                        continue
+
+                    # Try to find error handler
+                    handler = self._find_error_handler(action, 'followup', exc)
+
+                    if handler:
+                        # Execute error handler
+                        result = await self._execute_error_recovery(
+                            context,
+                            action,
+                            idx,
+                            handler,
+                            exc,
+                            working_directory,
+                            'followup',
+                        )
+
+                        if result == 'retry':
+                            # Don't increment list_idx - retry same action
+                            continue
+                        elif result == 'skip':
+                            # Skip to next action
+                            list_idx += 1
+                            continue
+                        else:  # 'failed'
+                            # Handler failed - fail workflow
+                            raise RuntimeError(
+                                f'Error handler "{handler.name}" failed '
+                                f'for action "{action.name}"'
+                            ) from exc
+                    else:
+                        # No handler - use existing error handling
+                        self.logger.error(
+                            '%s error in followup action "%s": %s',
+                            context.imbi_project.slug,
+                            action.name,
+                            exc,
+                        )
+                        if self.configuration.preserve_on_error:
+                            self.last_error_path = (
+                                self._preserve_working_directory(
+                                    context,
+                                    working_directory,
+                                    self.configuration.error_dir,
+                                    failed_action_index=idx,
+                                    failed_action_name=action.name,
+                                    completed_action_indices=[],
+                                    error_message=str(exc),
+                                    current_stage='followup',
+                                    followup_cycle=cycle,
+                                )
+                            )
+                        working_directory.cleanup()
+                        raise
 
             # If no commits were made this cycle, followup is complete
             if not cycle_made_commits:
@@ -565,6 +670,246 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
 
         """
         return self.last_error_path
+
+    def _build_error_handler_maps(self) -> None:
+        """Build lookup structures for error handlers."""
+        # Separate error actions from regular actions
+        self.error_actions = [
+            a
+            for a in self.workflow.configuration.actions
+            if a.stage == models.WorkflowActionStage.on_error
+        ]
+
+        # Build map: action_name → error_action
+        for action in self.workflow.configuration.actions:
+            if action.on_failure:
+                handler = next(
+                    a
+                    for a in self.error_actions
+                    if a.name == action.on_failure
+                )
+                self.error_handlers[action.name] = handler
+
+        # Store global handlers separately
+        self.global_handlers = [
+            a for a in self.error_actions if a.error_filter is not None
+        ]
+
+    def _find_error_handler(
+        self,
+        failed_action: models.WorkflowActions,
+        stage_name: str,
+        exception: Exception,
+    ) -> models.WorkflowActions | None:
+        """Find error handler for failed action.
+
+        Priority:
+        1. Action-specific handler (on_failure field)
+        2. Global handler matching filters
+
+        Args:
+            failed_action: The action that failed
+            stage_name: Current stage name
+            exception: The exception that was raised
+
+        Returns:
+            Error handler action if found, None otherwise
+
+        """
+        # Priority 1: Check action's on_failure
+        if failed_action.name in self.error_handlers:
+            return self.error_handlers[failed_action.name]
+
+        # Priority 2: Check global handlers
+        for handler in self.global_handlers:
+            if self._matches_error_filter(
+                handler.error_filter, failed_action, stage_name, exception
+            ):
+                return handler
+
+        return None
+
+    def _matches_error_filter(
+        self,
+        error_filter: models.ErrorFilter | None,
+        failed_action: models.WorkflowActions,
+        stage_name: str,
+        exception: Exception,
+    ) -> bool:
+        """Check if error filter matches the failed action.
+
+        Args:
+            error_filter: The filter to check
+            failed_action: The action that failed
+            stage_name: Current stage name
+            exception: The exception that was raised
+
+        Returns:
+            True if filter matches, False otherwise
+
+        """
+        if error_filter is None:
+            return False
+
+        # Check action types
+        if (
+            error_filter.action_types
+            and failed_action.type not in error_filter.action_types
+        ):
+            return False
+
+        # Check action names
+        if (
+            error_filter.action_names
+            and failed_action.name not in error_filter.action_names
+        ):
+            return False
+
+        # Check stages
+        if error_filter.stages:
+            # Convert stage_name to WorkflowActionStage
+            try:
+                current_stage = models.WorkflowActionStage(stage_name)
+            except ValueError:
+                return False
+
+            if current_stage not in error_filter.stages:
+                return False
+
+        # Check exception types
+        if error_filter.exception_types:
+            exc_type = type(exception).__name__
+            if exc_type not in error_filter.exception_types:
+                return False
+
+        # TODO: Implement custom condition (Jinja2) evaluation
+        if error_filter.condition:
+            # For now, skip condition evaluation
+            pass
+
+        return True
+
+    async def _execute_error_recovery(
+        self,
+        context: models.WorkflowContext,
+        failed_action: models.WorkflowActions,
+        failed_idx: int,
+        handler: models.WorkflowActions,
+        exception: Exception,
+        working_directory: tempfile.TemporaryDirectory,
+        stage_name: str,
+    ) -> typing.Literal['retry', 'skip', 'failed']:
+        """Execute error recovery action.
+
+        Args:
+            context: Workflow execution context
+            failed_action: The action that failed
+            failed_idx: Index of the failed action
+            handler: The error handler action to execute
+            exception: The exception that was raised
+            working_directory: Temp directory for workflow
+            stage_name: Current stage name
+
+        Returns:
+            'retry': Retry the failed action
+            'skip': Skip to next action
+            'failed': Handler itself failed
+
+        """
+        self.logger.info(
+            '%s executing error handler "%s" for "%s"',
+            context.imbi_project.slug,
+            handler.name,
+            failed_action.name,
+        )
+
+        # Check retry limit
+        retry_count = self.retry_counts.get(failed_action.name, 0)
+        if (
+            handler.recovery_behavior == models.ErrorRecoveryBehavior.retry
+            and retry_count >= handler.max_retry_attempts
+        ):
+            self.logger.error(
+                '%s max retries (%d) exceeded for "%s"',
+                context.imbi_project.slug,
+                handler.max_retry_attempts,
+                failed_action.name,
+            )
+            return 'failed'
+
+        # Add error context to template variables
+        context.variables.update(
+            {
+                'failed_action': failed_action,
+                'exception': str(exception),
+                'exception_type': type(exception).__name__,
+                'retry_attempt': retry_count + 1,
+                'max_retries': handler.max_retry_attempts,
+            }
+        )
+
+        try:
+            # Execute the error handler action
+            await self._execute_action(context, handler)
+
+            self.logger.info(
+                '%s error handler "%s" succeeded',
+                context.imbi_project.slug,
+                handler.name,
+            )
+            self.tracker.incr('error_handlers_succeeded')
+
+            # Handle recovery behavior
+            if handler.recovery_behavior == models.ErrorRecoveryBehavior.retry:
+                self.retry_counts[failed_action.name] = retry_count + 1
+                self.logger.info(
+                    '%s retrying "%s" (attempt %d/%d)',
+                    context.imbi_project.slug,
+                    failed_action.name,
+                    retry_count + 2,
+                    handler.max_retry_attempts + 1,
+                )
+                return 'retry'
+            elif (
+                handler.recovery_behavior == models.ErrorRecoveryBehavior.skip
+            ):
+                self.retry_counts.pop(failed_action.name, None)
+                self.logger.info(
+                    '%s skipping to next action after recovery',
+                    context.imbi_project.slug,
+                )
+                return 'skip'
+            else:  # fail
+                self.logger.info(
+                    '%s cleanup handler completed, failing workflow',
+                    context.imbi_project.slug,
+                )
+                return 'failed'
+
+        except Exception as handler_exc:  # noqa: BLE001
+            self.logger.error(
+                '%s error handler "%s" failed: %s',
+                context.imbi_project.slug,
+                handler.name,
+                handler_exc,
+            )
+            self.tracker.incr('error_handlers_failed')
+
+            if self.configuration.preserve_on_error:
+                self.last_error_path = self._preserve_working_directory(
+                    context,
+                    working_directory,
+                    self.configuration.error_dir,
+                    failed_action_index=failed_idx,
+                    failed_action_name=failed_action.name,
+                    completed_action_indices=list(range(0, failed_idx)),
+                    error_message=(
+                        f'Original: {exception}\nHandler: {handler_exc}'
+                    ),
+                    current_stage=stage_name,
+                )
+
+            return 'failed'
 
     def _preserve_working_directory(
         self,

--- a/src/imbi_automations/workflow_engine.py
+++ b/src/imbi_automations/workflow_engine.py
@@ -782,6 +782,12 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
             if exc_type not in error_filter.exception_types:
                 return False
 
+        # Check exception message contains text
+        if error_filter.exception_message_contains:
+            exc_message = str(exception)
+            if error_filter.exception_message_contains not in exc_message:
+                return False
+
         # TODO: Implement custom condition (Jinja2) evaluation
         if error_filter.condition:
             # For now, skip condition evaluation

--- a/tests/data/workflows/comprehensive-test-workflow.toml
+++ b/tests/data/workflows/comprehensive-test-workflow.toml
@@ -220,7 +220,7 @@ type = "template"
 source = "templates/docker/Dockerfile.j2"
 destination = "Dockerfile"
 
-# Cleanup action (referenced by on_failure)
+# Cleanup action (referenced by on_error)
 [[actions]]
 name = "cleanup-action"
 type = "shell"

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -1,0 +1,345 @@
+"""Unit tests for error handler models and validation."""
+
+import pathlib
+import unittest
+
+from imbi_automations import models
+
+
+class ErrorHandlerModelTestCase(unittest.TestCase):
+    """Test error handler model validation."""
+
+    def test_error_recovery_behavior_enum_values(self) -> None:
+        """Test ErrorRecoveryBehavior enum has correct values."""
+        self.assertEqual(models.ErrorRecoveryBehavior.retry, 'retry')
+        self.assertEqual(models.ErrorRecoveryBehavior.skip, 'skip')
+        self.assertEqual(models.ErrorRecoveryBehavior.fail, 'fail')
+
+    def test_error_filter_action_types(self) -> None:
+        """Test ErrorFilter with action_types."""
+        error_filter = models.ErrorFilter(
+            action_types=[
+                models.WorkflowActionTypes.claude,
+                models.WorkflowActionTypes.shell,
+            ]
+        )
+        self.assertEqual(len(error_filter.action_types), 2)
+        self.assertIn(
+            models.WorkflowActionTypes.claude, error_filter.action_types
+        )
+
+    def test_error_filter_action_names(self) -> None:
+        """Test ErrorFilter with action_names."""
+        error_filter = models.ErrorFilter(action_names=['action1', 'action2'])
+        self.assertEqual(error_filter.action_names, ['action1', 'action2'])
+
+    def test_error_filter_stages(self) -> None:
+        """Test ErrorFilter with stages."""
+        error_filter = models.ErrorFilter(
+            stages=[
+                models.WorkflowActionStage.primary,
+                models.WorkflowActionStage.followup,
+            ]
+        )
+        self.assertEqual(len(error_filter.stages), 2)
+
+    def test_error_filter_exception_types(self) -> None:
+        """Test ErrorFilter with exception_types."""
+        error_filter = models.ErrorFilter(
+            exception_types=['TimeoutError', 'RuntimeError']
+        )
+        self.assertEqual(
+            error_filter.exception_types, ['TimeoutError', 'RuntimeError']
+        )
+
+    def test_error_filter_condition(self) -> None:
+        """Test ErrorFilter with Jinja2 condition."""
+        error_filter = models.ErrorFilter(
+            condition='{{ failed_action.type == "claude" }}'
+        )
+        self.assertIsNotNone(error_filter.condition)
+
+
+class WorkflowActionErrorConfigTestCase(unittest.TestCase):
+    """Test WorkflowAction error configuration validation."""
+
+    def test_action_with_on_failure_reference(self) -> None:
+        """Test action can reference error handler via on_failure."""
+        action = models.WorkflowShellAction(
+            name='test-action',
+            type='shell',
+            command='echo "test"',
+            on_failure='error-handler',
+        )
+        self.assertEqual(action.on_failure, 'error-handler')
+
+    def test_error_action_defaults(self) -> None:
+        """Test error action has correct defaults."""
+        action = models.WorkflowShellAction(
+            name='error-handler',
+            type='shell',
+            stage='on_error',
+            command='echo "error"',
+            committable=False,
+            error_filter=models.ErrorFilter(
+                action_types=[models.WorkflowActionTypes.shell]
+            ),
+        )
+        self.assertEqual(action.stage, models.WorkflowActionStage.on_error)
+        self.assertEqual(
+            action.recovery_behavior, models.ErrorRecoveryBehavior.skip
+        )
+        self.assertEqual(action.max_retry_attempts, 3)
+        self.assertFalse(action.committable)
+
+    def test_error_action_cannot_have_on_failure(self) -> None:
+        """Test error action cannot have on_failure field."""
+        with self.assertRaises(ValueError) as cm:
+            models.WorkflowShellAction(
+                name='error-handler',
+                type='shell',
+                stage='on_error',
+                command='echo "error"',
+                on_failure='another-handler',
+                error_filter=models.ErrorFilter(
+                    action_types=[models.WorkflowActionTypes.shell]
+                ),
+            )
+        self.assertIn('cannot have on_failure', str(cm.exception))
+
+    def test_error_action_cannot_have_ignore_errors(self) -> None:
+        """Test error action cannot have ignore_errors=True."""
+        with self.assertRaises(ValueError) as cm:
+            models.WorkflowShellAction(
+                name='error-handler',
+                type='shell',
+                stage='on_error',
+                command='echo "error"',
+                ignore_errors=True,
+                error_filter=models.ErrorFilter(
+                    action_types=[models.WorkflowActionTypes.shell]
+                ),
+            )
+        self.assertIn('cannot have ignore_errors', str(cm.exception))
+
+    def test_error_action_cannot_be_committable(self) -> None:
+        """Test error action cannot be committable."""
+        with self.assertRaises(ValueError) as cm:
+            models.WorkflowShellAction(
+                name='error-handler',
+                type='shell',
+                stage='on_error',
+                command='echo "error"',
+                committable=True,
+                error_filter=models.ErrorFilter(
+                    action_types=[models.WorkflowActionTypes.shell]
+                ),
+            )
+        self.assertIn('cannot be committable', str(cm.exception))
+
+    def test_non_error_action_cannot_have_recovery_behavior(self) -> None:
+        """Test non-error action cannot set recovery_behavior."""
+        with self.assertRaises(ValueError) as cm:
+            models.WorkflowShellAction(
+                name='test-action',
+                type='shell',
+                command='echo "test"',
+                recovery_behavior='retry',
+            )
+        self.assertIn('only valid for stage=on_error', str(cm.exception))
+
+    def test_non_error_action_cannot_have_max_retry_attempts(self) -> None:
+        """Test non-error action cannot set max_retry_attempts."""
+        with self.assertRaises(ValueError) as cm:
+            models.WorkflowShellAction(
+                name='test-action',
+                type='shell',
+                command='echo "test"',
+                max_retry_attempts=5,
+            )
+        self.assertIn('only valid for stage=on_error', str(cm.exception))
+
+    def test_non_error_action_cannot_have_error_filter(self) -> None:
+        """Test non-error action cannot have error_filter."""
+        with self.assertRaises(ValueError) as cm:
+            models.WorkflowShellAction(
+                name='test-action',
+                type='shell',
+                command='echo "test"',
+                error_filter=models.ErrorFilter(
+                    action_types=[models.WorkflowActionTypes.shell]
+                ),
+            )
+        self.assertIn('only valid for stage=on_error', str(cm.exception))
+
+
+class WorkflowErrorHandlerValidationTestCase(unittest.TestCase):
+    """Test workflow-level error handler validation."""
+
+    def test_on_failure_must_reference_existing_action(self) -> None:
+        """Test on_failure must reference existing action."""
+        with self.assertRaises(ValueError) as cm:
+            models.Workflow(
+                path=pathlib.Path('/mock/workflow'),
+                configuration=models.WorkflowConfiguration(
+                    name='test-workflow',
+                    actions=[
+                        models.WorkflowShellAction(
+                            name='test-action',
+                            type='shell',
+                            command='echo "test"',
+                            on_failure='nonexistent-handler',
+                        )
+                    ],
+                ),
+            )
+        self.assertIn('non-existent error handler', str(cm.exception))
+
+    def test_on_failure_must_reference_error_stage_action(self) -> None:
+        """Test on_failure must reference action with stage=on_error."""
+        with self.assertRaises(ValueError) as cm:
+            models.Workflow(
+                path=pathlib.Path('/mock/workflow'),
+                configuration=models.WorkflowConfiguration(
+                    name='test-workflow',
+                    actions=[
+                        models.WorkflowShellAction(
+                            name='test-action',
+                            type='shell',
+                            command='echo "test"',
+                            on_failure='not-an-error-handler',
+                        ),
+                        models.WorkflowShellAction(
+                            name='not-an-error-handler',
+                            type='shell',
+                            command='echo "handler"',
+                        ),
+                    ],
+                ),
+            )
+        self.assertIn('not stage=on_error', str(cm.exception))
+
+    def test_error_action_must_be_referenced_or_have_filter(self) -> None:
+        """Test error action must be referenced or have filter."""
+        with self.assertRaises(ValueError) as cm:
+            models.Workflow(
+                path=pathlib.Path('/mock/workflow'),
+                configuration=models.WorkflowConfiguration(
+                    name='test-workflow',
+                    actions=[
+                        models.WorkflowShellAction(
+                            name='orphan-handler',
+                            type='shell',
+                            stage='on_error',
+                            command='echo "error"',
+                            committable=False,
+                        )
+                    ],
+                ),
+            )
+        self.assertIn('must be either referenced', str(cm.exception))
+        self.assertIn('or have an error_filter', str(cm.exception))
+
+    def test_valid_workflow_with_action_specific_handler(self) -> None:
+        """Test valid workflow with action-specific error handler."""
+        workflow = models.Workflow(
+            path=pathlib.Path('/mock/workflow'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow',
+                actions=[
+                    models.WorkflowShellAction(
+                        name='test-action',
+                        type='shell',
+                        command='echo "test"',
+                        on_failure='error-handler',
+                    ),
+                    models.WorkflowShellAction(
+                        name='error-handler',
+                        type='shell',
+                        stage='on_error',
+                        command='echo "error"',
+                        committable=False,
+                        recovery_behavior='retry',
+                        max_retry_attempts=2,
+                    ),
+                ],
+            ),
+        )
+        self.assertEqual(len(workflow.configuration.actions), 2)
+
+    def test_valid_workflow_with_global_handler(self) -> None:
+        """Test valid workflow with global error handler."""
+        workflow = models.Workflow(
+            path=pathlib.Path('/mock/workflow'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow',
+                actions=[
+                    models.WorkflowShellAction(
+                        name='test-action', type='shell', command='echo "test"'
+                    ),
+                    models.WorkflowShellAction(
+                        name='global-handler',
+                        type='shell',
+                        stage='on_error',
+                        command='echo "error"',
+                        committable=False,
+                        error_filter=models.ErrorFilter(
+                            action_types=[models.WorkflowActionTypes.shell]
+                        ),
+                    ),
+                ],
+            ),
+        )
+        self.assertEqual(len(workflow.configuration.actions), 2)
+
+
+class ResumeStateErrorTrackingTestCase(unittest.TestCase):
+    """Test ResumeState error handler tracking fields."""
+
+    def test_resume_state_has_retry_counts(self) -> None:
+        """Test ResumeState includes retry_counts field."""
+        state = models.ResumeState(
+            workflow_slug='test-workflow',
+            workflow_path=pathlib.Path('/workflow'),
+            project_id=123,
+            project_slug='test-project',
+            failed_action_index=0,
+            failed_action_name='test-action',
+            completed_action_indices=[],
+            starting_commit='abc123',
+            has_repository_changes=False,
+            github_repository=None,
+            error_message='Test error',
+            error_timestamp='2025-01-01T00:00:00',
+            preserved_directory_path=pathlib.Path('/preserved'),
+            configuration_hash='hash123',
+            retry_counts={'action1': 2, 'action2': 1},
+        )
+        self.assertEqual(state.retry_counts, {'action1': 2, 'action2': 1})
+
+    def test_resume_state_has_handler_tracking(self) -> None:
+        """Test ResumeState includes handler tracking fields."""
+        state = models.ResumeState(
+            workflow_slug='test-workflow',
+            workflow_path=pathlib.Path('/workflow'),
+            project_id=123,
+            project_slug='test-project',
+            failed_action_index=0,
+            failed_action_name='test-action',
+            completed_action_indices=[],
+            starting_commit='abc123',
+            has_repository_changes=False,
+            github_repository=None,
+            error_message='Test error',
+            error_timestamp='2025-01-01T00:00:00',
+            preserved_directory_path=pathlib.Path('/preserved'),
+            configuration_hash='hash123',
+            active_error_handler='my-handler',
+            handler_failed=True,
+            original_exception_type='RuntimeError',
+            original_exception_message='Original error',
+        )
+        self.assertEqual(state.active_error_handler, 'my-handler')
+        self.assertTrue(state.handler_failed)
+        self.assertEqual(state.original_exception_type, 'RuntimeError')
+        self.assertEqual(state.original_exception_message, 'Original error')

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -52,6 +52,15 @@ class ErrorHandlerModelTestCase(unittest.TestCase):
             error_filter.exception_types, ['TimeoutError', 'RuntimeError']
         )
 
+    def test_error_filter_exception_message_contains(self) -> None:
+        """Test ErrorFilter with exception_message_contains."""
+        error_filter = models.ErrorFilter(
+            exception_message_contains='ruff.....Failed'
+        )
+        self.assertEqual(
+            error_filter.exception_message_contains, 'ruff.....Failed'
+        )
+
     def test_error_filter_condition(self) -> None:
         """Test ErrorFilter with Jinja2 condition."""
         error_filter = models.ErrorFilter(

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -63,15 +63,15 @@ class ErrorHandlerModelTestCase(unittest.TestCase):
 class WorkflowActionErrorConfigTestCase(unittest.TestCase):
     """Test WorkflowAction error configuration validation."""
 
-    def test_action_with_on_failure_reference(self) -> None:
-        """Test action can reference error handler via on_failure."""
+    def test_action_with_on_error_reference(self) -> None:
+        """Test action can reference error handler via on_error."""
         action = models.WorkflowShellAction(
             name='test-action',
             type='shell',
             command='echo "test"',
-            on_failure='error-handler',
+            on_error='error-handler',
         )
-        self.assertEqual(action.on_failure, 'error-handler')
+        self.assertEqual(action.on_error, 'error-handler')
 
     def test_error_action_defaults(self) -> None:
         """Test error action has correct defaults."""
@@ -92,20 +92,20 @@ class WorkflowActionErrorConfigTestCase(unittest.TestCase):
         self.assertEqual(action.max_retry_attempts, 3)
         self.assertFalse(action.committable)
 
-    def test_error_action_cannot_have_on_failure(self) -> None:
-        """Test error action cannot have on_failure field."""
+    def test_error_action_cannot_have_on_error(self) -> None:
+        """Test error action cannot have on_error field."""
         with self.assertRaises(ValueError) as cm:
             models.WorkflowShellAction(
                 name='error-handler',
                 type='shell',
                 stage='on_error',
                 command='echo "error"',
-                on_failure='another-handler',
+                on_error='another-handler',
                 error_filter=models.ErrorFilter(
                     action_types=[models.WorkflowActionTypes.shell]
                 ),
             )
-        self.assertIn('cannot have on_failure', str(cm.exception))
+        self.assertIn('cannot have on_error', str(cm.exception))
 
     def test_error_action_cannot_have_ignore_errors(self) -> None:
         """Test error action cannot have ignore_errors=True."""
@@ -176,8 +176,8 @@ class WorkflowActionErrorConfigTestCase(unittest.TestCase):
 class WorkflowErrorHandlerValidationTestCase(unittest.TestCase):
     """Test workflow-level error handler validation."""
 
-    def test_on_failure_must_reference_existing_action(self) -> None:
-        """Test on_failure must reference existing action."""
+    def test_on_error_must_reference_existing_action(self) -> None:
+        """Test on_error must reference existing action."""
         with self.assertRaises(ValueError) as cm:
             models.Workflow(
                 path=pathlib.Path('/mock/workflow'),
@@ -188,15 +188,15 @@ class WorkflowErrorHandlerValidationTestCase(unittest.TestCase):
                             name='test-action',
                             type='shell',
                             command='echo "test"',
-                            on_failure='nonexistent-handler',
+                            on_error='nonexistent-handler',
                         )
                     ],
                 ),
             )
         self.assertIn('non-existent error handler', str(cm.exception))
 
-    def test_on_failure_must_reference_error_stage_action(self) -> None:
-        """Test on_failure must reference action with stage=on_error."""
+    def test_on_error_must_reference_error_stage_action(self) -> None:
+        """Test on_error must reference action with stage=on_error."""
         with self.assertRaises(ValueError) as cm:
             models.Workflow(
                 path=pathlib.Path('/mock/workflow'),
@@ -207,7 +207,7 @@ class WorkflowErrorHandlerValidationTestCase(unittest.TestCase):
                             name='test-action',
                             type='shell',
                             command='echo "test"',
-                            on_failure='not-an-error-handler',
+                            on_error='not-an-error-handler',
                         ),
                         models.WorkflowShellAction(
                             name='not-an-error-handler',
@@ -251,7 +251,7 @@ class WorkflowErrorHandlerValidationTestCase(unittest.TestCase):
                         name='test-action',
                         type='shell',
                         command='echo "test"',
-                        on_failure='error-handler',
+                        on_error='error-handler',
                     ),
                     models.WorkflowShellAction(
                         name='error-handler',

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -233,6 +233,27 @@ class RenderTestCase(PromptsTestBase):
         result = prompts.render(self.context, template=template)
         self.assertEqual(result, 'custom-package')
 
+    def test_render_with_context_variables_flattened(self) -> None:
+        """Test context.variables items are accessible as top-level vars."""
+        # Add some variables to context.variables
+        self.context.variables['failed_action'] = {'name': 'test-action'}
+        self.context.variables['exception'] = 'Test error message'
+        self.context.variables['retry_attempt'] = 1
+
+        # Template should access variables directly, not via 'variables.'
+        result = prompts.render(
+            self.context,
+            template=(
+                'Action: {{ failed_action.name }}\n'
+                'Error: {{ exception }}\n'
+                'Attempt: {{ retry_attempt }}'
+            ),
+        )
+        self.assertEqual(
+            result,
+            'Action: test-action\nError: Test error message\nAttempt: 1',
+        )
+
 
 class RenderFileTestCase(PromptsTestBase):
     """Tests for render_file function."""


### PR DESCRIPTION
## Summary

Adds error recovery capabilities to the workflow engine, allowing workflows to automatically handle failures through configurable recovery actions.

## Problem

Previously, when workflow actions failed, the only options were:
- Fail immediately and require manual intervention
- Use `ignore_errors = true` to skip failures entirely
- Resume from the failed action after manual fixes

This meant workflows couldn't automatically diagnose issues, apply fixes, or retry failed operations.

## Solution

Implemented a new error recovery system with:

1. **Error Recovery Stage**: New `stage = "on_error"` for actions that only execute when other actions fail

2. **Two Attachment Mechanisms**:
   - **Action-specific handlers**: Via `on_error` field on any action
   - **Global handlers**: Via `error_filter` to match by action type, stage, exception type, etc.

3. **Configurable Recovery Behaviors**:
   - `retry`: Re-execute the failed action (with configurable max attempts)
   - `skip`: Continue to next action after recovery
   - `fail`: Fail workflow after cleanup

4. **Retry Management**: Configurable `max_retry_attempts` with retry counts that persist across resume operations

## What Was Done

### Core Implementation
- Added `WorkflowActionStage.on_error` enum value
- Added `ErrorRecoveryBehavior` enum (retry/skip/fail)
- Added `ErrorFilter` model for global handler matching
- Implemented error handler discovery and execution in `WorkflowEngine`
- Added retry count tracking that persists in resume state
- Refactored execution loops from `for` to `while` to support retries
- **Naming consistency**: Used `on_error` field to reference handlers (matches `stage = "on_error"` naming)

### Validation
- Action-level validation prevents invalid error handler configs
- Workflow-level validation ensures all handlers are properly attached
- Clear error messages for configuration issues

### Testing
- 21 new unit tests covering all error recovery scenarios
- All 765 existing tests still passing (no regressions)

### Documentation
- Updated `AGENTS.md` with error recovery architecture
- Created comprehensive `docs/error-handlers.md` with examples and patterns
- Updated `CLAUDE.md` with versioning requirements (PyPI format vs git tag format)
- Documented all new template variables available to error handlers

## Example Usage

### Action-specific handler with retry
```toml
[[actions]]
name = "run-tests"
type = "shell"
command = "pytest tests/"
on_error = "cleanup-and-retry"

[[actions]]
name = "cleanup-and-retry"
type = "shell"
stage = "on_error"
recovery_behavior = "retry"
max_retry_attempts = 2
command = "rm -rf .pytest_cache && pip install -e ."
```

### Global handler for Claude timeouts
```toml
[[actions]]
name = "handle-claude-timeouts"
type = "shell"
stage = "on_error"
recovery_behavior = "skip"
command = "echo 'Claude action timed out, continuing...'"

[actions.error_filter]
action_types = ["claude"]
exception_types = ["TimeoutError"]
```

## Additional Context

- Error handlers have access to special template variables: `failed_action`, `exception`, `exception_type`, `retry_attempt`, `max_retries`
- If an error handler itself fails, the workflow fails immediately (fail-fast)
- Retry counts persist across `--resume` operations
- Error actions cannot be committable, cannot have their own error handlers, and cannot use `ignore_errors`
- Consistent naming: `on_error` field references handlers with `stage = "on_error"` (eliminates confusion)

## Testing

Run the new test suite:
```bash
pytest tests/test_error_handlers.py -v
```

All 21 tests pass, covering model validation, workflow validation, and resume state tracking.