### PR TITLE
Fix zombie git processes by adding tini as PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update \
         openssh-client \
         ripgrep \
         sudo \
+        tini \
  && rm -rf /var/lib/apt/lists/* \
  && pip install --root-user-action ignore --break-system-packages --no-cache-dir --upgrade pip \
  && pip install --root-user-action ignore --break-system-packages --no-cache-dir /tmp/imbi_automations*.whl \
@@ -42,6 +43,6 @@ WORKDIR /opt
 
 VOLUME /opt/config /opt/dry-runs /opt/errors /opt/workflows /docker-entrypoint-init.d
 
-ENTRYPOINT ["docker-entrypoint.sh", "imbi-automations"]
+ENTRYPOINT ["/usr/bin/tini", "--", "docker-entrypoint.sh", "imbi-automations"]
 
 CMD ["--help"]

--- a/src/imbi_automations/cli.py
+++ b/src/imbi_automations/cli.py
@@ -8,7 +8,9 @@ orchestrating workflow execution through the controller.
 import argparse
 import asyncio
 import logging
+import os
 import pathlib
+import signal
 import sys
 import tomllib
 import typing
@@ -19,6 +21,34 @@ import pydantic
 from imbi_automations import controller, models, tracker, utils, version
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _reap_zombies(signum: int, frame: typing.Any) -> None:
+    """Signal handler to reap zombie child processes.
+
+    This handler is installed for SIGCHLD to ensure that any child processes
+    that exit are properly reaped, preventing zombie process accumulation.
+    This is especially important when running as PID 1 in containers.
+
+    Args:
+        signum: Signal number (SIGCHLD)
+        frame: Current stack frame (unused)
+
+    """
+    while True:
+        try:
+            # Non-blocking wait for any child process
+            # Returns (0, 0) when no more child processes to reap
+            pid, _ = os.waitpid(-1, os.WNOHANG)
+            if pid == 0:
+                break
+            LOGGER.debug('Reaped zombie process with PID %d', pid)
+        except ChildProcessError:
+            # No child processes left to reap
+            break
+        except OSError as exc:
+            LOGGER.debug('Error reaping zombie process: %s', exc)
+            break
 
 
 def configure_logging(debug: bool) -> None:
@@ -251,6 +281,10 @@ def main() -> None:
     """
     args = parse_args()
     configure_logging(args.debug)
+
+    # Install SIGCHLD handler to reap zombie processes
+    # This is defense-in-depth for containers running as PID 1
+    signal.signal(signal.SIGCHLD, _reap_zombies)
 
     config = load_configuration(args.config[0])
     args.config[0].close()


### PR DESCRIPTION
## Problem

Git subprocesses were becoming zombies (defunct processes) with 15+ accumulating under the main Python process running as PID 1 in the container.

**Process State:**
```
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
imbi-au+       1  0.4  0.4 836540 81792 pts/0   Ssl+ 22:51   0:01 /usr/local/bin/python3.12 /usr/local/bin/imbi-automations...
imbi-au+     554  0.0  0.0      0     0 ?        Zs   22:51   0:00 [git] <defunct>
imbi-au+     789  0.0  0.0      0     0 ?        Zs   22:52   0:00 [git] <defunct>
[... 13+ more zombie processes ...]
```

## Root Cause

**Python as PID 1 doesn't automatically reap orphaned child processes.** While the imbi-automations code properly waits for subprocesses using `asyncio.create_subprocess_exec` with `process.communicate()`, this isn't sufficient when running as PID 1 in containers because:

1. PID 1 has special responsibilities in Unix for reaping zombies
2. Standard Python subprocess handling doesn't fulfill these PID 1 duties
3. Even properly-waited subprocesses become zombies when parent is PID 1

## Solution

Implemented a **2-layer defense approach**:

### 1. Primary Fix: tini as PID 1 (Dockerfile)
- Installed `tini` package via apt-get
- Changed ENTRYPOINT to: `/usr/bin/tini -- docker-entrypoint.sh imbi-automations`
- tini acts as a proper init system and automatically reaps all zombie processes
- Industry-standard solution for this exact problem

### 2. Defense-in-depth: SIGCHLD Handler (cli.py)
- Created `_reap_zombies()` function using `os.waitpid(-1, os.WNOHANG)`
- Installed signal handler in `main()` before workflow execution
- Provides protection even if container runs without tini

## Changes

**Dockerfile:**
- Line 23: Added `tini` to apt-get install list
- Line 46: Changed ENTRYPOINT to use tini as PID 1

**cli.py:**
- Lines 26-51: Added `_reap_zombies()` SIGCHLD handler function
- Line 287: Install handler in `main()` at startup

## Verification

After deployment, verify:
```bash
# During workflow execution, check for zombie processes
docker exec <container> ps aux | grep defunct

# Expected: 0 zombies
# Before fix: 15+ zombies accumulating
```

Monitor over time to ensure no accumulation.

## Impact

**Current Impact:**
- 15+ zombie processes consuming process table entries
- Potential to exhaust PID namespace with long-running container
- Sign of underlying process management issues

**After Fix:**
- Zero zombie processes
- Clean process table
- Proper PID 1 behavior

## Confidence: ~95%

The imbi-automations subprocess handling is already correct - the problem is strictly that PID 1 has special responsibilities for zombie reaping that Python doesn't handle by default. tini is the industry-standard solution for this in containers.

## Testing

All 771 tests pass. The changes don't affect subprocess handling logic, only add zombie reaping at the OS level.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Implements a robust two-layer solution to eliminate zombie git processes when running as PID 1 in containers.

**Primary fix (Dockerfile):**
- Installs `tini` as a proper init system and configures it as PID 1
- Industry-standard solution that automatically reaps all zombie processes
- Changes ENTRYPOINT from direct Python execution to `/usr/bin/tini -- docker-entrypoint.sh imbi-automations`

**Defense-in-depth (cli.py):**
- Adds SIGCHLD signal handler with `_reap_zombies()` function
- Uses non-blocking `os.waitpid(-1, os.WNOHANG)` to reap zombies
- Provides fallback protection if container runs without tini
- Includes proper exception handling for `ChildProcessError` and `OSError`

The existing subprocess handling in `git.py` and `shell.py` already uses proper async patterns with `process.communicate()`, so the root cause was strictly the PID 1 special responsibility issue. This PR addresses that correctly.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation follows industry best practices for container PID 1 zombie reaping. tini is the standard solution for this exact problem. The defense-in-depth SIGCHLD handler is correctly implemented with non-blocking wait and proper error handling. Both changes are isolated and don't affect existing subprocess logic. All tests pass.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| Dockerfile | 5/5 | Added `tini` package and configured it as PID 1 in ENTRYPOINT to properly reap zombie processes |
| src/imbi_automations/cli.py | 5/5 | Added SIGCHLD signal handler for defense-in-depth zombie process reaping with proper error handling |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->