### PR TITLE
Fix error handler template variables not being available

### DIFF
--- a/src/imbi_automations/actions/claude.py
+++ b/src/imbi_automations/actions/claude.py
@@ -252,6 +252,9 @@ class ClaudeAction(mixins.WorkflowLoggerMixin):
             data: dict[str, typing.Any] = dict(self.prompt_kwargs)
             data.update(self.context.model_dump())
             data.update({'action': action.model_dump()})
+            # Explicitly add context.variables to ensure error handler
+            # context (failed_action, exception, etc.) is available
+            data.update(self.context.variables)
             for key in {'source', 'destination', 'template'}:
                 if key in data:
                     del data[key]


### PR DESCRIPTION
## Problem

Error handlers using Claude actions were failing with `'failed_action' is undefined` errors. This prevented error recovery workflows from functioning correctly.

**Error Example:**
```
Handler: 'failed_action' is undefined
```

**Context:**
- Error recovery mechanism adds context variables (failed_action, exception, retry_attempt, etc.) to `context.variables` before executing error handlers
- Error handler workflow prompts reference these variables (e.g., `{{ failed_action.name }}`, `{{ exception }}`)
- However, these variables were not being made available during template rendering

## Root Cause

In `actions/claude.py` the `_get_prompt()` method:

1. Built a `data` dict from `prompt_kwargs` and `context.model_dump()`
2. Passed `**data` to `prompts.render(self.context, prompt_file, **data)`
3. `prompts.render()` calls `kwargs.update(context.model_dump())` then `kwargs.update(context.variables)` to flatten variables
4. However, the `**data` passed in already included context fields, and the flattening wasn't working correctly due to the order of dict updates

The issue was that `context.variables` was not explicitly included in the `data` dict before being passed to `prompts.render()`, causing error handler context variables to be unavailable in templates.

## Solution

Explicitly update the `data` dict with `context.variables` before passing to `prompts.render()`. This ensures all error handler context variables are available at the top level in templates.

**Changes:**
- `actions/claude.py` line 255-257: Added `data.update(self.context.variables)` after building the data dict and before calling `prompts.render()`
- Added explanatory comment about why this is needed for error handlers

## Error Handler Context Variables

After this fix, error handler prompts can access:
- `failed_action`: The action that failed (includes `.name`, `.type`, `.stage`)
- `exception`: Exception message string
- `exception_type`: Exception class name
- `retry_attempt`: Current retry attempt (1-indexed)
- `max_retries`: Maximum retry attempts configured

## Example Usage

```jinja2
## Failed Action

**Action:** {{ failed_action.name }}
**Type:** {{ failed_action.type }}
**Retry Attempt:** {{ retry_attempt }}/{{ max_retries }}

## Error Details

```
{{ exception }}
```
```

## Testing

- All 771 tests pass
- The fix ensures `context.variables` is explicitly merged into the template data dict
- Error recovery workflows can now access all error context variables

## Verification

After deployment, verify that error recovery actions (like `fix-precommit-errors`) can successfully access template variables and execute recovery logic.

## Confidence: ~85%

This fix addresses the template variable availability issue by explicitly including `context.variables` in the data dict passed to template rendering. The approach is straightforward and aligns with how other parts of the codebase handle context variables.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed a bug where error handler context variables (`failed_action`, `exception`, `retry_attempt`, etc.) were not available in Claude action templates during error recovery workflows.

- Added explicit `data.update(self.context.variables)` in `_get_prompt()` to flatten error handler context variables into the template data dictionary before calling `prompts.render()`
- The fix ensures variables set by the workflow engine during error handling are accessible as top-level template variables (e.g., `{{ failed_action.name }}`)
- This is a minimal, low-risk change that aligns with how other actions handle context variables

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it's a minimal 3-line fix that makes error handler variables available in templates
- The change is small, well-documented with a clear comment, and follows existing patterns in the codebase (prompts.render already does similar flattening). All 771 tests pass per the PR description.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/actions/claude.py | 5/5 | Added explicit flattening of `context.variables` into template data dict to fix error handler variable availability. The 3-line change is minimal and correct. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->