### PR TITLE
Auto-prepend api. to GitHub host for API requests

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -140,13 +140,8 @@ Host *
 EOF
 
     # Add GitHub hosts to known_hosts
-	ssh-keyscan -t ed25519,rsa "github.com" >> "$SSH_DIR/known_hosts" 2>/dev/null || true
-
-    # Scan GHE host if GITHUB_HOSTNAME is set (strip api. prefix if present)
-    if [ -n "$GITHUB_HOSTNAME" ]; then
-        GHE_HOST=$(echo "$GITHUB_HOSTNAME" | sed 's/^api\.//')
-        ssh-keyscan -t ed25519,rsa "$GHE_HOST" >> "$SSH_DIR/known_hosts" 2>/dev/null || true
-    fi
+    # GH_HOST contains the base domain (e.g., github.com or github.enterprise.com)
+    ssh-keyscan -t ed25519,rsa "${GH_HOST:-github.com}" >> "$SSH_DIR/known_hosts" 2>/dev/null || true
 
     # Point SSH to our runtime config
     export GIT_SSH_COMMAND="ssh -F $SSH_DIR/config"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -140,8 +140,13 @@ Host *
 EOF
 
     # Add GitHub hosts to known_hosts
-    # GH_HOST contains the base domain (e.g., github.com or github.enterprise.com)
-    ssh-keyscan -t ed25519,rsa "${GH_HOST:-github.com}" >> "$SSH_DIR/known_hosts" 2>/dev/null || true
+	ssh-keyscan -t ed25519,rsa "github.com" >> "$SSH_DIR/known_hosts" 2>/dev/null || true
+
+    # Scan GHE host if GITHUB_HOSTNAME is set (strip api. prefix if present)
+    if [ -n "$GH_HOST" ]; then
+        GHE_HOST=$(echo "$GH_HOST" | sed 's/^api\.//')
+        ssh-keyscan -t ed25519,rsa "$GHE_HOST" >> "$SSH_DIR/known_hosts" 2>/dev/null || true
+    fi
 
     # Point SSH to our runtime config
     export GIT_SSH_COMMAND="ssh -F $SSH_DIR/config"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -482,7 +482,8 @@ token = "ghp_your_github_personal_access_token"
 
 ### [github].host
 
-GitHub hostname for Enterprise installations.
+GitHub hostname (base domain). The `api.` prefix is automatically prepended
+for API requests.
 
 **Type:** `string`
 **Default:** `github.com`
@@ -492,6 +493,8 @@ For GitHub Enterprise:
 [github]
 host = "github.enterprise.com"
 ```
+
+This will automatically use `api.github.enterprise.com` for API requests.
 
 ## Imbi Configuration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,8 +76,8 @@ Create a `config.toml` file with your API credentials:
 
 ```toml
 [github]
-api_key = "ghp_your_github_token"
-hostname = "github.com"  # Optional, defaults to github.com
+token = "ghp_your_github_token"
+host = "github.com"  # Optional, defaults to github.com
 
 [imbi]
 api_key = "your-imbi-api-key"

--- a/src/imbi_automations/clients/github.py
+++ b/src/imbi_automations/clients/github.py
@@ -35,7 +35,7 @@ class GitHub(http.BaseURLHTTPClient):
             raise errors.ConfigurationError('GitHub configuration missing')
 
         super().__init__(transport)
-        self._base_url = f'https://{config.github.host}'
+        self._base_url = config.github.api_base_url
         self.add_header(
             'Authorization', f'Bearer {config.github.token.get_secret_value()}'
         )

--- a/src/imbi_automations/models/configuration.py
+++ b/src/imbi_automations/models/configuration.py
@@ -111,6 +111,10 @@ class GitHubConfiguration(pydantic_settings.BaseSettings):
 
     Supports both GitHub.com and GitHub Enterprise with API token
     authentication.
+
+    The host field should be set to the base domain (e.g., 'github.com' or
+    'github.enterprise.com'). The api_base_url property automatically
+    prepends 'api.' to form the API endpoint.
     """
 
     model_config = pydantic_settings.SettingsConfigDict(
@@ -119,6 +123,14 @@ class GitHubConfiguration(pydantic_settings.BaseSettings):
 
     host: str = pydantic.Field(default='github.com')
     token: pydantic.SecretStr
+
+    @property
+    def api_base_url(self) -> str:
+        """Compute the GitHub API base URL from the host.
+
+        Prepends 'api.' to the host to form the API endpoint.
+        """
+        return f'https://api.{self.host}'
 
 
 class ImbiConfiguration(pydantic_settings.BaseSettings):

--- a/tests/clients/test_github.py
+++ b/tests/clients/test_github.py
@@ -179,7 +179,7 @@ class GitHubRepositoryTestCase(base.AsyncTestCase):
         super().setUp()
         self.config = models.Configuration(
             github=models.GitHubConfiguration(
-                token='test-token', host='api.github.com'
+                token='test-token', host='github.com'
             ),
             imbi=models.ImbiConfiguration(
                 api_key='test-key',
@@ -255,7 +255,7 @@ class GitHubEnvironmentsTestCase(base.AsyncTestCase):
         super().setUp()
         self.config = models.Configuration(
             github=models.GitHubConfiguration(
-                token='test-token', host='api.github.com'
+                token='test-token', host='github.com'
             ),
             imbi=models.ImbiConfiguration(
                 api_key='test-key', hostname='imbi.example.com'
@@ -320,7 +320,7 @@ class GitHubPullRequestTestCase(base.AsyncTestCase):
         super().setUp()
         self.config = models.Configuration(
             github=models.GitHubConfiguration(
-                token='test-token', host='api.github.com'
+                token='test-token', host='github.com'
             ),
             imbi=models.ImbiConfiguration(
                 api_key='test-key', hostname='imbi.example.com'
@@ -476,7 +476,7 @@ class GitHubFileOperationsTestCase(base.AsyncTestCase):
         super().setUp()
         self.config = models.Configuration(
             github=models.GitHubConfiguration(
-                token='test-token', host='api.github.com'
+                token='test-token', host='github.com'
             ),
             imbi=models.ImbiConfiguration(
                 api_key='test-key', hostname='imbi.example.com'
@@ -587,7 +587,7 @@ class GitHubWorkflowTestCase(base.AsyncTestCase):
         super().setUp()
         self.config = models.Configuration(
             github=models.GitHubConfiguration(
-                token='test-token', host='api.github.com'
+                token='test-token', host='github.com'
             ),
             imbi=models.ImbiConfiguration(
                 api_key='test-key', hostname='imbi.example.com'
@@ -630,7 +630,7 @@ class GitHubRepositoryUpdateTestCase(base.AsyncTestCase):
         super().setUp()
         self.config = models.Configuration(
             github=models.GitHubConfiguration(
-                token='test-token', host='api.github.com'
+                token='test-token', host='github.com'
             ),
             imbi=models.ImbiConfiguration(
                 api_key='test-key', hostname='imbi.example.com'
@@ -665,7 +665,7 @@ class GitHubJobLogsTestCase(base.AsyncTestCase):
         super().setUp()
         self.config = models.Configuration(
             github=models.GitHubConfiguration(
-                token='test-token', host='api.github.com'
+                token='test-token', host='github.com'
             ),
             imbi=models.ImbiConfiguration(
                 api_key='test-key', hostname='imbi.example.com'


### PR DESCRIPTION
Users now set the base domain (e.g., github.com) in config, and the api. prefix is automatically added when making API requests. This simplifies configuration since users don't need to know about the API subdomain.

- Add api_base_url property to GitHubConfiguration
- Update GitHub client to use new property
- Simplify docker-entrypoint.sh SSH keyscan to use GH_HOST directly
- Fix incorrect field names in docs/index.md (was showing hostname instead of host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Configuration keys renamed: `api_key` → `token`, `hostname` → `host`. Update existing configs.
  * Clarified GitHub Enterprise docs: the configured host is the base domain and an `api.` prefix is used for API requests.

* **Behavior**
  * Startup SSH host handling now prefers a configured GH host while still ensuring github.com keys are collected.

* **Tests**
  * Test configurations updated to use the new field names and host format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Simplified GitHub configuration by auto-prepending `api.` subdomain for API requests. Users now configure the base domain (e.g., `github.com`), and the `api_base_url` property automatically constructs the API endpoint.

**Key changes:**
- Added `api_base_url` property to `GitHubConfiguration` that prepends `api.` to the host
- Updated GitHub client to use the new property instead of manual URL construction
- Simplified docker-entrypoint.sh SSH keyscan logic to use `GH_HOST` directly
- Fixed documentation errors (`api_key`/`hostname` → `token`/`host`)
- Updated all test fixtures to use base domain format

**Notes:**
- Implementation assumes all GitHub Enterprise instances use `api.` subdomain pattern (GHES 3.0+)
- The new `api_base_url` property lacks direct test coverage

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor considerations
- The implementation is clean and well-documented, with all test fixtures updated correctly. The change simplifies user configuration meaningfully. Score reduced by one point due to: (1) lack of test coverage for the new `api_base_url` property, and (2) assumption that all GitHub Enterprise instances use the `api.` subdomain pattern, which may not be true for older GHES versions (pre-3.0) that use `/api/v3` path-based endpoints instead
- Pay attention to `src/imbi_automations/models/configuration.py` - the new `api_base_url` property should have test coverage to ensure correct URL construction for both github.com and GitHub Enterprise hosts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/imbi_automations/models/configuration.py | Added `api_base_url` property to prepend `api.` to host for GitHub API requests |
| src/imbi_automations/clients/github.py | Updated to use `config.github.api_base_url` property instead of constructing URL directly |
| tests/clients/test_github.py | Updated test fixtures to use base domain `github.com` instead of `api.github.com` |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->