### PR TITLE
Have claude use bash to execute do-commit.sh

### DIFF
--- a/src/imbi_automations/prompts/commit.md.j2
+++ b/src/imbi_automations/prompts/commit.md.j2
@@ -66,11 +66,10 @@ git commit -F /tmp/commit_msg.txt {{ configuration.git.commit_args }} \
 rm {{ working_directory }}/commit_msg.txt
 ```
 
-Step 2: Make the script executable and run it:
+Step 2: Run the script:
 
 ```bash
-chmod +x {{ working_directory }}/do-commit.sh
-{{ working_directory }}/do-commit.sh
+bash {{ working_directory }}/do-commit.sh
 rm {{ working_directory }}/do-commit.sh
 ```
 


### PR DESCRIPTION
Claude does not have permissions to chmod +x the file. I see it consistently fail, and then it corrects itself with this pattern.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR removes the `chmod +x` requirement for executing the commit script by directly invoking it with `bash` instead. This prevents Claude from encountering permission errors when attempting to make the script executable.

- Changed from `chmod +x do-commit.sh && ./do-commit.sh` to `bash do-commit.sh`
- Simplified Step 2 description from "Make the script executable and run it" to just "Run the script"
- The script's shebang (`#!/bin/bash`) remains intact but is no longer strictly necessary

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risks
- This is a simple, well-motivated fix that removes a permission requirement that was causing failures. The change from chmod+execute to direct bash invocation is functionally equivalent and more reliable in environments where chmod may fail
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/imbi_automations/prompts/commit.md.j2 | Simplified script execution by removing chmod requirement - uses bash directly instead |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified script execution instructions by removing the need to make scripts executable separately; now using direct bash execution instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->