### PR TITLE
Clarify working directory instruction in commit prompt

### DIFF
--- a/src/imbi_automations/prompts/commit.md.j2
+++ b/src/imbi_automations/prompts/commit.md.j2
@@ -1,6 +1,6 @@
 Your task is to analyze pending changes and create logical commits.
 
-You are working in the `repository` directory.
+Your current working directory is `repository`. Run git commands directly without changing directories.
 
 If there are no pending changes, exit immediately without performing any actions.
 

--- a/src/imbi_automations/prompts/commit.md.j2
+++ b/src/imbi_automations/prompts/commit.md.j2
@@ -44,7 +44,8 @@ set -e
 git add {file1} {file2} ...
 
 # Create commit message file
-cat > {{ working_directory }}/commit_msg.txt << 'EOF'
+COMMIT_MSG_FILE="{{ working_directory }}/commit_msg.txt"
+cat > "${COMMIT_MSG_FILE}" << 'EOF'
 imbi-automations: {{ workflow_name }} - {{ action_name }}
 
 {Detailed description of what changed}
@@ -58,12 +59,12 @@ GIT_AUTHOR_NAME="{{ commit_author_name }}" \
 GIT_AUTHOR_EMAIL="{{ commit_author_address }}" \
 GIT_COMMITTER_NAME="{{ commit_author_name }}" \
 GIT_COMMITTER_EMAIL="{{ commit_author_address }}" \
-git commit -F /tmp/commit_msg.txt {{ configuration.git.commit_args }} \
+git commit -F "${COMMIT_MSG_FILE}" {{ configuration.git.commit_args }} \
   --trailer "Authored-By: {{ commit_author }}" \
   --trailer "Co-Authored-By: Claude <noreply@anthropic.com>"
 
 # Cleanup
-rm {{ working_directory }}/commit_msg.txt
+rm "${COMMIT_MSG_FILE}"
 ```
 
 Step 2: Make the script executable and run it:

--- a/src/imbi_automations/prompts/commit.md.j2
+++ b/src/imbi_automations/prompts/commit.md.j2
@@ -1,6 +1,6 @@
 Your task is to analyze pending changes and create logical commits.
 
-Your current working directory is `repository`. Run git commands directly without changing directories.
+Your current working directory is already set to the repository directory. Run git commands directly without changing directories.
 
 If there are no pending changes, exit immediately without performing any actions.
 


### PR DESCRIPTION
The previous wording "You are working in the repository directory" was ambiguous and agents would unnecessarily run "cd repository" before git commands. Updated to explicitly state the cwd is already set and to run commands directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified git instructions: guidance now assumes the working directory is already set and directs users to run git commands directly without changing directories.

* **Chores**
  * Improved commit message handling to use a dynamic file path instead of a hard-coded temp location, improving robustness and cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR updates the working directory instruction in the commit prompt template to clarify that agents should run git commands directly without changing directories. The change addresses a real issue where the ambiguous previous wording ("You are working in the `repository` directory") was causing agents to unnecessarily run `cd repository` before git commands.

## Changes Made
- **Line 3**: Updated from "You are working in the `repository` directory." to "Your current working directory is `repository`. Run git commands directly without changing directories."

## Context
The commit prompt template is used by Claude AI agents when performing AI-powered commits. The Claude SDK sets `cwd` to `{working_directory}/repository` (see `claude.py:721`), so agents are already in the correct directory and don't need to change directories.

## Impact
The clarification should reduce unnecessary directory changes and make agent behavior more predictable. However, the wording could still be slightly improved for precision (see style comment).

## Critical Pre-existing Bug Found
During review, I discovered a **critical path mismatch bug** on line 61 (not introduced by this PR): the script creates a commit message file at `{{ working_directory }}/commit_msg.txt` but references `/tmp/commit_msg.txt` when committing. This will cause commits to fail and should be fixed immediately.

### Confidence Score: 3/5

- This PR is safe to merge as it improves the clarity of instructions, but contains a pre-existing critical bug that should be addressed separately
- Score of 3/5 reflects: (1) The change itself is beneficial and low-risk - it only clarifies wording without changing functionality, (2) The wording could be slightly more precise (see style comment), and (3) Most importantly, a critical pre-existing bug was discovered on line 61 where file paths are mismatched, which will cause commit failures. This bug exists in the current code and is not introduced by this PR, but significantly impacts the confidence score for the file overall.
- src/imbi_automations/prompts/commit.md.j2 - contains a critical path mismatch bug on line 61 that needs immediate attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/prompts/commit.md.j2 | 3/5 | Wording clarification improves agent behavior, but file contains a pre-existing critical path mismatch bug (line 61) and the new wording could be more precise about the actual cwd path |

</details>



<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/imbi_automations/prompts/commit.md.j2 | 3/5 | Wording clarification improves agent behavior, but file contains a pre-existing critical path mismatch bug (line 61) and the new wording could be more precise about the actual cwd path |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->