### PR TITLE
Fix resume handling for workflow symlinks

### DIFF
--- a/src/imbi_automations/controller.py
+++ b/src/imbi_automations/controller.py
@@ -166,6 +166,10 @@ class Automation(mixins.WorkflowLoggerMixin):
                 f'Failed to load resume state from {state_file}: {exc}'
             ) from exc
 
+        # Update preserved_directory_path to use the actual path provided
+        # by user (state file may contain relative or outdated path)
+        state.preserved_directory_path = self.args.resume.resolve()
+
         self.logger.info(
             'Resuming workflow "%s" for project %s from action "%s" '
             '(index %d)',

--- a/src/imbi_automations/workflow_engine.py
+++ b/src/imbi_automations/workflow_engine.py
@@ -88,13 +88,18 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
 
             # Copy preserved state to new temp location, ignoring workflow
             # symlink (may be broken if path differs between environments)
+            source_root = self.resume_state.preserved_directory_path.resolve()
+
             def ignore_workflow_symlink(
                 directory: str, contents: list[str]
             ) -> list[str]:
-                return ['workflow'] if 'workflow' in contents else []
+                # Only ignore workflow symlink at root level, not nested dirs
+                if pathlib.Path(directory) == source_root:
+                    return ['workflow'] if 'workflow' in contents else []
+                return []
 
             shutil.copytree(
-                self.resume_state.preserved_directory_path.resolve(),
+                source_root,
                 working_directory.name,
                 dirs_exist_ok=True,
                 symlinks=True,

--- a/src/imbi_automations/workflow_engine.py
+++ b/src/imbi_automations/workflow_engine.py
@@ -86,13 +86,26 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
             # Resume mode: reuse preserved directory (don't auto-cleanup)
             working_directory = tempfile.TemporaryDirectory(delete=False)
 
-            # Copy preserved state to new temp location
+            # Copy preserved state to new temp location, ignoring workflow
+            # symlink (may be broken if path differs between environments)
+            def ignore_workflow_symlink(
+                directory: str, contents: list[str]
+            ) -> list[str]:
+                return ['workflow'] if 'workflow' in contents else []
+
             shutil.copytree(
-                self.resume_state.preserved_directory_path,
+                self.resume_state.preserved_directory_path.resolve(),
                 working_directory.name,
                 dirs_exist_ok=True,
                 symlinks=True,
+                ignore=ignore_workflow_symlink,
             )
+
+            # Recreate workflow symlink using current workflow path
+            workflow_symlink = (
+                pathlib.Path(working_directory.name) / 'workflow'
+            )
+            workflow_symlink.symlink_to(self.workflow.path.resolve())
 
             # Restore context from saved state
             context = self._restore_workflow_context(
@@ -964,8 +977,11 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
         project_slug = context.imbi_project.slug
 
         # Create target directory: <base>/<workflow>/<project>-<timestamp>
+        # Resolve to absolute path to ensure resume works across environments
         target_path = (
-            target_base_dir / workflow_slug / f'{project_slug}-{timestamp}'
+            target_base_dir.resolve()
+            / workflow_slug
+            / f'{project_slug}-{timestamp}'
         )
 
         try:

--- a/tests/test_workflow_engine_execution.py
+++ b/tests/test_workflow_engine_execution.py
@@ -1421,6 +1421,7 @@ class WorkflowEngineResumabilityTestCase(base.AsyncTestCase):
         super().setUp()
         self.temp_dir = tempfile.TemporaryDirectory()
         self.preserved_dir = tempfile.TemporaryDirectory()
+        self.workflow_dir = tempfile.TemporaryDirectory()
         self.working_directory = pathlib.Path(self.temp_dir.name)
         self.preserved_path = pathlib.Path(self.preserved_dir.name)
 
@@ -1434,7 +1435,8 @@ class WorkflowEngineResumabilityTestCase(base.AsyncTestCase):
             ),
         )
 
-        self.workflow_path = pathlib.Path('/mock/workflow')
+        # Use a real directory for workflow path (needed for symlink creation)
+        self.workflow_path = pathlib.Path(self.workflow_dir.name)
         self.workflow = models.Workflow(
             path=self.workflow_path,
             configuration=models.WorkflowConfiguration(
@@ -1485,6 +1487,7 @@ class WorkflowEngineResumabilityTestCase(base.AsyncTestCase):
         super().tearDown()
         self.temp_dir.cleanup()
         self.preserved_dir.cleanup()
+        self.workflow_dir.cleanup()
 
     async def test_execute_resumes_from_failed_action(self) -> None:
         """Test that execute resumes from the correct action index."""


### PR DESCRIPTION
## Summary

- Skip copying workflow symlink during resume (may be broken if path differs between environments like Docker vs host)
- Recreate workflow symlink using current workflow path after copy
- Use actual `--resume` path provided by user instead of stored path in state file (state may contain relative or outdated path)
- Resolve paths to absolute when saving state for portability

## Problem

When resuming a workflow from an error state, the preserved directory contains a `workflow` symlink that points to the original workflow path (e.g., `/opt/workflows/python3.12-upgrade` inside Docker). When resuming from a different environment or after the workflow has moved, this symlink is broken and `shutil.copytree` fails.

Additionally, the state file stored relative paths like `errors/python3.12-upgrade/...` which don't resolve correctly when the working directory differs.

## Solution

1. Ignore the workflow symlink during `copytree` and recreate it fresh using `self.workflow.path`
2. Use the actual path provided via `--resume` instead of the stored `preserved_directory_path`
3. Resolve paths to absolute when saving state to improve portability

## Test plan

- [x] All 777 existing tests pass
- [x] Pre-commit hooks pass
- [x] Manually tested resume functionality in Docker environment

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable workflow resume and preservation by consistently using absolute, resolved paths—fixes failures when resuming across environments and improves handling of preserved workflow state.

* **Tests**
  * Enhanced test setup and cleanup to better validate resume and preservation behavior involving real workflow directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->