### PR TITLE
Add support for ThinkingBlock in _log_message

### DIFF
--- a/src/imbi_automations/claude.py
+++ b/src/imbi_automations/claude.py
@@ -883,6 +883,7 @@ class Claude(mixins.WorkflowLoggerMixin):
         content: str
         | list[
             claude_agent_sdk.TextBlock
+            | claude_agent_sdk.ThinkingBlock
             | claude_agent_sdk.ContentBlock
             | claude_agent_sdk.ToolUseBlock
             | claude_agent_sdk.ToolResultBlock
@@ -903,6 +904,15 @@ class Claude(mixins.WorkflowLoggerMixin):
                         self.context.imbi_project.slug,
                         message_type,
                         entry.text.rstrip(':'),
+                    )
+                elif isinstance(entry, claude_agent_sdk.ThinkingBlock):
+                    self.logger.debug(
+                        '[%s] %s: [thinking] %s',
+                        self.context.imbi_project.slug,
+                        message_type,
+                        entry.thinking[:100] + '...'
+                        if len(entry.thinking) > 100
+                        else entry.thinking,
                     )
                 elif isinstance(
                     entry,


### PR DESCRIPTION
The claude-agent-sdk library now includes a ThinkingBlock type for extended thinking/reasoning content. This commit adds handling for ThinkingBlock in the _log_message method to prevent "Unknown message type" errors.

Changes:
- Add ThinkingBlock to type hints in _log_message method
- Add isinstance check and logging for ThinkingBlock entries
- Truncate thinking content to 100 chars in logs to keep output manageable
- Add test coverage for both short and long ThinkingBlock content

Fixes the error: "Unknown message type: <class 'claude_agent_sdk.types.ThinkingBlock'>"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for capturing and logging Claude's thinking blocks with automatic truncation for improved log readability.

* **Tests**
  * Added comprehensive tests for thinking block logging to verify correct behavior with standard and extended thinking content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->