### PR TITLE
Pass implementer context to Claude commit agent

### DIFF
--- a/src/imbi_automations/actions/__init__.py
+++ b/src/imbi_automations/actions/__init__.py
@@ -66,6 +66,8 @@ class Actions(mixins.WorkflowLoggerMixin):
         ),
     ) -> None:
         self._set_workflow_logger(context.workflow)
+        # Drop stale implementer context from prior actions
+        context.variables.pop('_commit_context', None)
         match action.type:
             case models.WorkflowActionTypes.callable:
                 obj = callablea.CallableAction(

--- a/src/imbi_automations/actions/claude.py
+++ b/src/imbi_automations/actions/claude.py
@@ -32,6 +32,7 @@ class ClaudeAction(mixins.WorkflowLoggerMixin):
         self.has_planning_prompt: bool = False
         self.last_error: models.ClaudeAgentResponse | None = None
         self.task_plan: models.ClaudeAgentResponse | None = None
+        self.task_message: str | None = None
         git = configuration.git
         self.prompt_kwargs = {
             'commit_author': f'{git.user_name} <{git.user_email}>',
@@ -82,6 +83,9 @@ class ClaudeAction(mixins.WorkflowLoggerMixin):
                         action.name,
                         cycle,
                     )
+                    self._record_commit_context(
+                        action, skipped=self.task_message is None
+                    )
                     success = True
                     break
             except TimeoutError as exc:
@@ -117,12 +121,34 @@ class ClaudeAction(mixins.WorkflowLoggerMixin):
                 )
             raise RuntimeError(error_msg)
 
+    def _record_commit_context(
+        self, action: models.WorkflowClaudeAction, *, skipped: bool
+    ) -> None:
+        """Persist implementer reasoning for the committer to consume.
+
+        Writes to ``context.variables['_commit_context']``, which
+        ``commit.md.j2`` renders conditionally. Planning fields are None
+        when the action had no planning_prompt; message is None when
+        planning skipped the task.
+        """
+        plan = self.task_plan.plan if self.task_plan else None
+        analysis = self.task_plan.analysis if self.task_plan else None
+        self.context.variables['_commit_context'] = {
+            'action_name': action.name,
+            'action_type': 'claude',
+            'plan': plan,
+            'analysis': analysis,
+            'message': self.task_message,
+            'skipped': skipped,
+        }
+
     async def _execute_cycle(
         self, action: models.WorkflowClaudeAction, cycle: int
     ) -> bool:
-        # Reset task_plan at the start of each cycle
+        # Reset per-cycle state
         self.has_planning_prompt = False
         self.task_plan = None
+        self.task_message = None
 
         # Build agent execution sequence
         agents = []
@@ -193,6 +219,7 @@ class ClaudeAction(mixins.WorkflowLoggerMixin):
                 )
                 # Continue to task agent - don't return yet
             elif run.message is not None:  # Task agent response
+                self.task_message = run.message
                 self.logger.debug(
                     '%s %s task result: %s',
                     self.context.imbi_project.slug,

--- a/src/imbi_automations/committer.py
+++ b/src/imbi_automations/committer.py
@@ -67,6 +67,7 @@ class Committer(mixins.WorkflowLoggerMixin):
         # Build the commit prompt from the command template
         commit_template = BASE_PATH / 'prompts' / 'commit.md.j2'
         prompt = prompts.render(
+            context=context,
             source=commit_template,
             action_name=action.name,
             **client.prompt_kwargs,

--- a/src/imbi_automations/prompts/commit.md.j2
+++ b/src/imbi_automations/prompts/commit.md.j2
@@ -1,3 +1,36 @@
+{% if _commit_context is defined and _commit_context %}
+# Context from the preceding action
+
+The `{{ _commit_context.action_name }}` action ({{ _commit_context.action_type }})
+produced the pending changes. Use the following reasoning to craft the
+commit message body — especially the *why* behind the change. Do NOT
+alter the subject line format.
+
+{% if _commit_context.plan %}
+## Plan the implementer followed
+
+{% for step in _commit_context.plan %}
+{{ loop.index }}. {{ step }}
+{% endfor %}
+{% endif %}
+{% if _commit_context.analysis %}
+## Analysis
+
+{{ _commit_context.analysis }}
+{% endif %}
+{% if _commit_context.message %}
+## Implementer's summary of what was done
+
+{{ _commit_context.message }}
+{% endif %}
+{% if _commit_context.skipped %}
+Note: the implementer determined no work was needed and skipped execution.
+If there are no pending changes, exit without committing.
+{% endif %}
+
+---
+
+{% endif %}
 Your task is to analyze pending changes and create logical commits.
 
 Your current working directory is already set to the repository directory. Run git commands directly without changing directories.

--- a/tests/actions/test_claude.py
+++ b/tests/actions/test_claude.py
@@ -400,5 +400,131 @@ class ClaudeActionTestCase(base.AsyncTestCase):
 # exists with unified ClaudeAgentResponse model
 
 
+class RecordCommitContextTestCase(base.AsyncTestCase):
+    """ClaudeAction._record_commit_context populates context.variables."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.working_directory = pathlib.Path(self.temp_dir.name)
+        (self.working_directory / 'workflow').mkdir()
+        (self.working_directory / 'extracted').mkdir()
+        (self.working_directory / 'repository').mkdir()
+
+        self.config = models.Configuration(
+            claude=models.ClaudeAgentConfiguration(executable='claude'),
+            anthropic=models.AnthropicConfiguration(),
+            git=models.GitConfiguration(
+                user_name='Test Author', user_email='test@example.com'
+            ),
+            imbi=models.ImbiConfiguration(api_key='test', hostname='test.com'),
+            github=models.GitHubConfiguration(
+                token='test'  # noqa: S106
+            ),
+        )
+
+        self.workflow = models.Workflow(
+            path=pathlib.Path('/mock/workflow'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow', actions=[]
+            ),
+        )
+
+        self.context = models.WorkflowContext(
+            workflow=self.workflow,
+            imbi_project=models.ImbiProject(
+                id=123,
+                dependencies=None,
+                description='Test project',
+                environments=None,
+                facts=None,
+                identifiers=None,
+                links=None,
+                name='test-project',
+                namespace='test-namespace',
+                namespace_slug='test-namespace',
+                project_score=None,
+                project_type='API',
+                project_type_slug='api',
+                slug='test-project',
+                urls=None,
+                imbi_url='https://imbi.example.com/projects/123',
+            ),
+            working_directory=self.working_directory,
+        )
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self.temp_dir.cleanup()
+
+    def _build_action(self) -> claude.ClaudeAction:
+        with (
+            mock.patch('claude_agent_sdk.ClaudeSDKClient'),
+            mock.patch(
+                'builtins.open',
+                new_callable=mock.mock_open,
+                read_data='Mock system prompt',
+            ),
+        ):
+            return claude.ClaudeAction(
+                self.config, self.context, verbose=False
+            )
+
+    def test_records_plan_analysis_and_message_on_success(self) -> None:
+        """_commit_context includes plan, analysis, and message on success."""
+        claude_action = self._build_action()
+        claude_action.task_plan = models.ClaudeAgentResponse(
+            plan=['step one', 'step two'], analysis='analysis text'
+        )
+        claude_action.task_message = 'Updated three files'
+
+        action = models.WorkflowClaudeAction(
+            name='migrate-code', type='claude', task_prompt='t.md'
+        )
+        claude_action._record_commit_context(action, skipped=False)
+
+        recorded = self.context.variables['_commit_context']
+        self.assertEqual(recorded['action_name'], 'migrate-code')
+        self.assertEqual(recorded['action_type'], 'claude')
+        self.assertEqual(recorded['plan'], ['step one', 'step two'])
+        self.assertEqual(recorded['analysis'], 'analysis text')
+        self.assertEqual(recorded['message'], 'Updated three files')
+        self.assertFalse(recorded['skipped'])
+
+    def test_records_skipped_true_when_no_task_message(self) -> None:
+        """skipped=True with message=None when planning skipped the task."""
+        claude_action = self._build_action()
+        claude_action.task_plan = models.ClaudeAgentResponse(
+            plan=['no-op'], analysis='nothing to do', skip_task=True
+        )
+        claude_action.task_message = None
+
+        action = models.WorkflowClaudeAction(
+            name='migrate-code', type='claude', task_prompt='t.md'
+        )
+        claude_action._record_commit_context(action, skipped=True)
+
+        recorded = self.context.variables['_commit_context']
+        self.assertTrue(recorded['skipped'])
+        self.assertIsNone(recorded['message'])
+        self.assertEqual(recorded['plan'], ['no-op'])
+
+    def test_records_none_plan_when_no_planning_prompt(self) -> None:
+        """plan and analysis are None when action had no planning_prompt."""
+        claude_action = self._build_action()
+        claude_action.task_plan = None
+        claude_action.task_message = 'done'
+
+        action = models.WorkflowClaudeAction(
+            name='migrate-code', type='claude', task_prompt='t.md'
+        )
+        claude_action._record_commit_context(action, skipped=False)
+
+        recorded = self.context.variables['_commit_context']
+        self.assertIsNone(recorded['plan'])
+        self.assertIsNone(recorded['analysis'])
+        self.assertEqual(recorded['message'], 'done')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_committer.py
+++ b/tests/test_committer.py
@@ -342,6 +342,38 @@ class ClaudeCommitTestCase(base.AsyncTestCase):
     # test_passes_correct_response_model removed - agent_query no longer
     # takes response_model parameter with unified ClaudeAgentResponse
 
+    @mock.patch('imbi_automations.committer.prompts.render')
+    @mock.patch('imbi_automations.committer.claude.Claude')
+    async def test_passes_context_to_prompts_render(
+        self, mock_claude_class: mock.MagicMock, mock_render: mock.MagicMock
+    ) -> None:
+        """_claude_commit passes context so _commit_context is templated."""
+        mock_client = mock.MagicMock()
+        mock_claude_class.return_value = mock_client
+        mock_client.prompt_kwargs = {'workflow_name': 'test-workflow'}
+        mock_render.return_value = 'Commit the changes'
+
+        async def mock_agent_query(prompt: str) -> models.ClaudeAgentResponse:
+            return models.ClaudeAgentResponse(message='Done')
+
+        mock_client.agent_query = mock_agent_query
+
+        self.context.variables['_commit_context'] = {
+            'action_name': 'migrate-code',
+            'action_type': 'claude',
+            'plan': ['step one', 'step two'],
+            'analysis': 'migration needed for new API',
+            'message': 'Updated three files to use new endpoint',
+            'skipped': False,
+        }
+
+        c = committer.Committer(self.config, verbose=False)
+        await c._claude_commit(self.context, self.action)
+
+        _, kwargs = mock_render.call_args
+        self.assertIs(kwargs['context'], self.context)
+        self.assertEqual(kwargs['action_name'], self.action.name)
+
 
 class ManualCommitTestCase(base.AsyncTestCase):
     """Test cases for Committer._manual_commit()."""


### PR DESCRIPTION
## Summary
Thread the implementer's plan, analysis, and task summary through to the Claude commit-message agent so generated commits describe *why* a change was made rather than reconstructing intent from `git diff` alone.

## Problem
Claude-powered `ai_commit` runs rebuilt commit messages from pending diffs with no knowledge of what the preceding `ClaudeAction` intended or how it reasoned about the work. Commit bodies were generic diff summaries instead of reflecting the implementer's plan, trade-offs, or analysis.

## Solution
- `ClaudeAction` now captures the final successful cycle's task message and exposes a `_record_commit_context` helper that writes `{action_name, action_type, plan, analysis, message, skipped}` to `context.variables['_commit_context']`.
- `Actions.execute` clears `_commit_context` at the top of every dispatch so data cannot leak from one action's commit into another's.
- `Committer._claude_commit` now passes `context=context` into `prompts.render`, which already flattens `context.variables` into template kwargs.
- `prompts/commit.md.j2` gains a conditional block (`{% if _commit_context is defined and _commit_context %}`) that renders plan/analysis/implementer-summary above the existing commit instructions. Non-Claude actions — which do not populate the key — continue to render the template unchanged.

## Impact
- Claude-action commits on this workflow will include implementer reasoning in the body; subject-line format is untouched.
- Non-Claude actions and manual commits behave identically to today.
- Storage reuses the existing `context.variables` bus already serialized by resume-state, so no model or resume-state surgery.

## Testing
- `uv run pytest` — 783 passed.
- Added `RecordCommitContextTestCase` with three cases (success with plan, skipped task, no planning) and `test_passes_context_to_prompts_render` on the committer.
- `uv run ruff format && uv run ruff check --fix` — clean.