### PR TITLE
Cache Claude plugins across projects

### DIFF
--- a/src/imbi_automations/claude.py
+++ b/src/imbi_automations/claude.py
@@ -192,9 +192,11 @@ async def _install_plugins(
     """Install enabled Claude Code plugins from marketplaces.
 
     Reads the marketplace manifest at .claude-plugin/marketplace.json to find
-    plugin sources, then clones plugins to plugins_dir/installed/. Checks for
-    existing plugin.json (at root or .claude-plugin/) to skip already-installed
-    plugins.
+    plugin sources, then clones plugins to
+    plugins_dir/installed/<marketplace>/<plugin>. Namespacing by marketplace
+    prevents cache collisions when two marketplaces expose a plugin with the
+    same name. Checks for existing plugin.json (at root or .claude-plugin/)
+    to skip already-installed plugins.
 
     Args:
         enabled_plugins: Map of "plugin@marketplace" to enabled state
@@ -225,9 +227,14 @@ async def _install_plugins(
 
         plugin_name, marketplace_name = plugin_spec.rsplit('@', 1)
 
+        # Namespace plugin cache by marketplace to avoid collisions when
+        # two marketplaces expose plugins with the same name.
+        marketplace_install_dir = installed_dir / marketplace_name
+        marketplace_install_dir.mkdir(parents=True, exist_ok=True)
+
         # Check if plugin already cloned (manifest can be at root or
         # .claude-plugin/). Plugins installed to installed_dir, not marketplace
-        plugin_path = installed_dir / plugin_name
+        plugin_path = marketplace_install_dir / plugin_name
         plugin_manifest = plugin_path / 'plugin.json'
         alt_manifest = plugin_path / '.claude-plugin' / 'plugin.json'
         if plugin_path.exists() and (
@@ -311,7 +318,7 @@ async def _install_plugins(
             )
             try:
                 await git.clone_to_directory(
-                    working_directory=installed_dir,
+                    working_directory=marketplace_install_dir,
                     clone_url=clone_url,
                     destination=pathlib.Path(plugin_name),
                     depth=None,
@@ -338,7 +345,7 @@ async def _install_plugins(
             )
             try:
                 await git.clone_to_directory(
-                    working_directory=installed_dir,
+                    working_directory=marketplace_install_dir,
                     clone_url=clone_url,
                     destination=pathlib.Path(plugin_name),
                     depth=None,

--- a/src/imbi_automations/claude.py
+++ b/src/imbi_automations/claude.py
@@ -537,8 +537,9 @@ class Claude(mixins.WorkflowLoggerMixin):
     async def _ensure_plugins_installed(self) -> None:
         """Install Claude marketplaces and plugins if not already done.
 
-        Installs to the working directory (.claude/plugins/) to avoid
-        polluting the user's ~/.claude directory.
+        Installs to the shared cache directory so marketplaces and plugins
+        are reused across projects within a single CLI invocation (and
+        across invocations) instead of being re-cloned per project.
 
         This is called lazily before the first agent query to avoid
         running async code from __init__ which may be called from
@@ -548,7 +549,7 @@ class Claude(mixins.WorkflowLoggerMixin):
             return
 
         LOGGER.debug('Installing Claude marketplaces and plugins')
-        plugins_dir = self.context.working_directory / '.claude' / 'plugins'
+        plugins_dir = self.configuration.cache_dir / 'claude-plugins'
         try:
             self._installed_plugin_paths = (
                 await self._install_marketplaces_and_plugins(

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -882,8 +882,10 @@ class InstallPluginsTestCase(base.AsyncTestCase):
             {'local-plugin@test-marketplace': True}, self.plugins_dir
         )
 
-        # Verify symlink was created
-        expected_path = self.installed_dir / 'local-plugin'
+        # Verify symlink was created under the marketplace-namespaced path
+        expected_path = (
+            self.installed_dir / 'test-marketplace' / 'local-plugin'
+        )
         self.assertTrue(expected_path.is_symlink())
         self.assertEqual(expected_path.resolve(), plugin_source.resolve())
         self.assertEqual(result, [str(expected_path)])
@@ -923,14 +925,16 @@ class InstallPluginsTestCase(base.AsyncTestCase):
                 {'github-plugin@test-marketplace': True}, self.plugins_dir
             )
 
-        # Verify clone was called with GitHub URL
+        # Verify clone was called with GitHub URL into the
+        # marketplace-namespaced install directory.
+        marketplace_install_dir = self.installed_dir / 'test-marketplace'
         mock_clone.assert_called_once_with(
-            working_directory=self.installed_dir,
+            working_directory=marketplace_install_dir,
             clone_url='https://github.com/org/plugin.git',
             destination=pathlib.Path('github-plugin'),
             depth=None,
         )
-        expected_path = self.installed_dir / 'github-plugin'
+        expected_path = marketplace_install_dir / 'github-plugin'
         self.assertEqual(result, [str(expected_path)])
 
     async def test_install_plugins_github_source_missing_repo(self) -> None:
@@ -971,13 +975,14 @@ class InstallPluginsTestCase(base.AsyncTestCase):
                 {'url-plugin@test-marketplace': True}, self.plugins_dir
             )
 
+        marketplace_install_dir = self.installed_dir / 'test-marketplace'
         mock_clone.assert_called_once_with(
-            working_directory=self.installed_dir,
+            working_directory=marketplace_install_dir,
             clone_url='https://git.example.com/plugin.git',
             destination=pathlib.Path('url-plugin'),
             depth=None,
         )
-        expected_path = self.installed_dir / 'url-plugin'
+        expected_path = marketplace_install_dir / 'url-plugin'
         self.assertEqual(result, [str(expected_path)])
 
     async def test_install_plugins_unsupported_source_type(self) -> None:
@@ -993,6 +998,41 @@ class InstallPluginsTestCase(base.AsyncTestCase):
             )
 
         self.assertIn('Unsupported plugin source type', str(exc.exception))
+
+    async def test_install_plugins_same_name_different_marketplaces(
+        self,
+    ) -> None:
+        """Same-named plugins from different marketplaces do not collide."""
+        # Two marketplaces both expose a plugin named 'shared-plugin' but
+        # pointing at different local directories.
+        marketplace_a = self._create_marketplace_with_manifest(
+            'marketplace-a',
+            [{'name': 'shared-plugin', 'source': './plugins/shared-plugin'}],
+        )
+        marketplace_b = self._create_marketplace_with_manifest(
+            'marketplace-b',
+            [{'name': 'shared-plugin', 'source': './plugins/shared-plugin'}],
+        )
+        source_a = marketplace_a / 'plugins' / 'shared-plugin'
+        source_a.mkdir(parents=True)
+        (source_a / 'plugin.json').write_text('{"variant": "a"}')
+        source_b = marketplace_b / 'plugins' / 'shared-plugin'
+        source_b.mkdir(parents=True)
+        (source_b / 'plugin.json').write_text('{"variant": "b"}')
+
+        result = await claude._install_plugins(
+            {
+                'shared-plugin@marketplace-a': True,
+                'shared-plugin@marketplace-b': True,
+            },
+            self.plugins_dir,
+        )
+
+        path_a = self.installed_dir / 'marketplace-a' / 'shared-plugin'
+        path_b = self.installed_dir / 'marketplace-b' / 'shared-plugin'
+        self.assertEqual(result, [str(path_a), str(path_b)])
+        self.assertEqual(path_a.resolve(), source_a.resolve())
+        self.assertEqual(path_b.resolve(), source_b.resolve())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Fixes a bug where Claude marketplaces and plugins were re-cloned for every project processed in a workflow run.
- Moves the install target from the per-project temp working directory to `configuration.cache_dir/claude-plugins/` so the existing skip-if-present check can actually match on subsequent projects.

## Problem

`Claude` is instantiated per project, and `_ensure_plugins_installed` was writing into `context.working_directory/.claude/plugins`. Because `working_directory` is a fresh `tempfile.TemporaryDirectory` per project, `_install_marketplace` / `_install_plugins` never found an existing clone and re-ran every time. Symptom from the logs:

```
17:04:21 Installing Claude marketplace: aweber-marketplace
17:04:49 Installing Claude marketplace: aweber-marketplace
17:05:17 Installing Claude marketplace: aweber-marketplace
17:05:58 Installing Claude marketplace: aweber-marketplace
```

## Solution

Install into `configuration.cache_dir/claude-plugins/` (default `~/.cache/imbi-automations/claude-plugins`). The in-function filesystem checks (`marketplace_path/.git` exists, plugin manifest exists) now correctly short-circuit subsequent projects. Absolute plugin paths are passed to the SDK via `sdk_plugins`, so the location change is transparent to Claude Code.

## Test plan

- [x] `uv run pytest tests/test_claude.py` — 46 tests pass
- [ ] Run a multi-project workflow and confirm "Installing Claude marketplace" appears only once