### PR TITLE
Require Python 3.14+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12', '3.13', '3.14']
+        python-version: ['3.14']
 
     steps:
     - uses: actions/checkout@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,7 +327,7 @@ State saved in `.state` file (MessagePack format) with:
 ## Code Style
 
 - **Line length**: 79 chars (ruff enforced)
-- **Python**: 3.12+ with type hints
+- **Python**: 3.14+ with type hints
 - **Quotes**: Single preferred, double for docstrings
 - **Imports**: Module imports over direct class imports
 - **Pydantic**: Use `field: list[int] = []` not `Field(default_factory=list)`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-trixie AS builder
+FROM python:3.14-trixie AS builder
 
 COPY pyproject.toml uv.lock dist/imbi_automations*.whl /tmp/
 
@@ -11,7 +11,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
  && uv sync --active --no-install-project --frozen --no-dev \
  && uv pip install imbi_automations*.whl
 
-FROM python:3.12-trixie AS runtime
+FROM python:3.14-trixie AS runtime
 
 ENV CLAUDE_CODE_USE_ANTHROPIC_API=1 \
     GH_HOST=github.com \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 license = {text = "BSD-3-Clause"}
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.14"
 keywords = [
   "imbi",
   "github",
@@ -27,8 +27,6 @@ classifiers = [
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Topic :: Database",
   "Topic :: System :: Systems Administration",
@@ -72,7 +70,7 @@ serve-docs = ["mkdocs serve -a localhost:8080"]
 
 [tool.ruff]
 line-length = 79
-target-version = "py312"
+target-version = "py314"
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/src/imbi_automations/clients/github.py
+++ b/src/imbi_automations/clients/github.py
@@ -324,7 +324,7 @@ class GitHub(http.BaseURLHTTPClient):
 
     async def create_pull_request(
         self,
-        context: 'models.WorkflowContext',
+        context: models.WorkflowContext,
         title: str,
         body: str,
         head_branch: str,
@@ -418,7 +418,7 @@ class GitHub(http.BaseURLHTTPClient):
 
     def _repository_base_path(
         self,
-        context: 'models.WorkflowContext | None' = None,
+        context: models.WorkflowContext | None = None,
         org: str | None = None,
         repo_name: str | None = None,
         repository: models.GitHubRepository | None = None,
@@ -552,7 +552,7 @@ class GitHub(http.BaseURLHTTPClient):
         return job_logs
 
     async def get_file_contents(
-        self, context: 'models.WorkflowContext', file_path: str
+        self, context: models.WorkflowContext, file_path: str
     ) -> str | None:
         """Get file contents from GitHub repository.
 
@@ -689,7 +689,7 @@ class GitHub(http.BaseURLHTTPClient):
                 raise
 
     async def get_repository_tree(
-        self, context: 'models.WorkflowContext', ref: str | None = None
+        self, context: models.WorkflowContext, ref: str | None = None
     ) -> list[str]:
         """Get repository file tree recursively from GitHub.
 

--- a/src/imbi_automations/models/claude.py
+++ b/src/imbi_automations/models/claude.py
@@ -38,7 +38,7 @@ class ClaudeMarketplaceSource(pydantic.BaseModel):
     path: str | None = None  # For 'directory' source type
 
     @pydantic.model_validator(mode='after')
-    def validate_source_fields(self) -> 'ClaudeMarketplaceSource':
+    def validate_source_fields(self) -> ClaudeMarketplaceSource:
         """Validate that the correct field is set for the source type."""
         if self.source == ClaudeMarketplaceSourceType.github and not self.repo:
             raise ValueError("'repo' is required for 'github' source type")

--- a/src/imbi_automations/models/resume_state.py
+++ b/src/imbi_automations/models/resume_state.py
@@ -74,7 +74,7 @@ class ResumeState(pydantic.BaseModel):
         return msgpack.packb(self.model_dump(mode='json'), use_bin_type=True)
 
     @classmethod
-    def from_msgpack(cls, data: bytes) -> 'ResumeState':
+    def from_msgpack(cls, data: bytes) -> ResumeState:
         """Deserialize from MessagePack binary format.
 
         Args:

--- a/src/imbi_automations/models/workflow.py
+++ b/src/imbi_automations/models/workflow.py
@@ -57,7 +57,7 @@ class ProjectFieldFilter(pydantic.BaseModel):
     is_empty: bool | None = None
 
     @pydantic.model_validator(mode='after')
-    def validate_single_operator(self) -> 'ProjectFieldFilter':
+    def validate_single_operator(self) -> ProjectFieldFilter:
         """Ensure only one operator is specified."""
         operators = [
             self.is_null,
@@ -195,7 +195,7 @@ class WorkflowAction(pydantic.BaseModel):
     stage: WorkflowActionStage = WorkflowActionStage.primary
     ai_commit: bool = False
     commit_message: str | None = None
-    conditions: list['WorkflowCondition'] = []
+    conditions: list[WorkflowCondition] = []
     condition_type: WorkflowConditionType = WorkflowConditionType.all
     committable: bool = True
     filter: WorkflowFilter | None = None
@@ -234,7 +234,7 @@ class WorkflowAction(pydantic.BaseModel):
         return v
 
     @pydantic.model_validator(mode='after')
-    def validate_commit_message(self) -> 'WorkflowAction':
+    def validate_commit_message(self) -> WorkflowAction:
         """Validate that commit_message is only set when ai_commit=False
         and committable=True.
 
@@ -251,7 +251,7 @@ class WorkflowAction(pydantic.BaseModel):
         return self
 
     @pydantic.model_validator(mode='after')
-    def validate_error_config(self) -> 'WorkflowAction':
+    def validate_error_config(self) -> WorkflowAction:
         """Validate error handling configuration."""
         if self.stage == WorkflowActionStage.on_error:
             # Error actions cannot have error handlers themselves
@@ -379,7 +379,7 @@ class WorkflowFileActionCommand(enum.StrEnum):
     write = 'write'
 
 
-def _file_delete_requires_path_or_pattern(model: 'WorkflowFileAction') -> None:
+def _file_delete_requires_path_or_pattern(model: WorkflowFileAction) -> None:
     if (
         model.command == WorkflowFileActionCommand.delete
         and model.path is None
@@ -469,7 +469,7 @@ class WorkflowGitAction(WorkflowAction):
     committable: bool = False
 
     @pydantic.model_validator(mode='after')
-    def validate_git_action_fields(self) -> 'WorkflowGitAction':
+    def validate_git_action_fields(self) -> WorkflowGitAction:
         """Validate required fields based on command type."""
         if self.command == WorkflowGitActionCommand.extract:
             self.committable = False
@@ -754,7 +754,7 @@ class WorkflowGitHub(pydantic.BaseModel):
     replace_branch: bool = False
 
     @pydantic.model_validator(mode='after')
-    def validate_replace_branch(self) -> 'WorkflowGitHub':
+    def validate_replace_branch(self) -> WorkflowGitHub:
         if self.replace_branch and not self.create_pull_request:
             raise ValueError(
                 'replace_branch requires create_pull_request to be True'
@@ -822,13 +822,13 @@ class Workflow(pydantic.BaseModel):
     slug: str | None = None
 
     @pydantic.model_validator(mode='after')
-    def _set_slug(self) -> 'Workflow':
+    def _set_slug(self) -> Workflow:
         if not self.slug:
             self.slug = self.path.name.lower().replace('_', '-')
         return self
 
     @pydantic.model_validator(mode='after')
-    def _validate_error_handlers(self) -> 'Workflow':
+    def _validate_error_handlers(self) -> Workflow:
         """Validate error handler references and attachments."""
         # Build map of action names
         action_names = {a.name for a in self.configuration.actions}

--- a/src/imbi_automations/workflow_engine.py
+++ b/src/imbi_automations/workflow_engine.py
@@ -471,7 +471,7 @@ class WorkflowEngine(mixins.WorkflowLoggerMixin):
         self,
         context: models.WorkflowContext,
         followup_actions: list[tuple[int, models.WorkflowActions]],
-        working_directory: 'tempfile.TemporaryDirectory',
+        working_directory: tempfile.TemporaryDirectory,
     ) -> None:
         """Execute followup stage actions with commit cycling.
 


### PR DESCRIPTION
## Summary

- Bump `requires-python` to `>=3.14` and drop Python 3.12/3.13 classifiers.
- Set Ruff `target-version = "py314"`.
- Narrow the CI test matrix to 3.14 only.
- Rebase the Dockerfile onto `python:3.14-trixie` (was 3.12).
- Update AGENTS.md to reference Python 3.14+.

## Test plan

- [ ] `uv sync --all-groups --all-extras --frozen` succeeds on Python 3.14.
- [ ] `uv run ruff check .` passes.
- [ ] `uv run pytest --cov=imbi_automations tests/` passes.
- [ ] Docker build succeeds on `python:3.14-trixie`.