### PR TITLE
Add jira create_ticket action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ uv run pre-commit run --all-files      # All hooks
 | `git` | `git.py` | Extract files from history, branch ops |
 | `github` | `github.py` | Environment sync, repository updates |
 | `imbi` | `imbi.py` | Project facts, links, notes, type management |
+| `jira` | `jira.py` | Create Jira tickets via agentic Claude session |
 | `shell` | `shell.py` | Command execution with Jinja2 |
 | `template` | `template.py` | Jinja2 file generation |
 

--- a/docs/actions/jira.md
+++ b/docs/actions/jira.md
@@ -1,0 +1,197 @@
+# Jira Actions
+
+Jira actions create tickets in Jira Cloud via an agentic Claude session. The
+action invokes Claude Agent SDK with a configurable task prompt and an
+in-process MCP tool that posts to the Jira Cloud REST v3 API. Claude authors
+the ticket summary and description; the workflow config supplies the
+project, issue type, labels, and components — Claude cannot override those.
+
+Typical use case: a workflow runs an in-depth review (security, dependency,
+compliance) and needs to file a human-readable ticket summarising findings.
+
+## Configuration
+
+```toml
+[jira]
+# Reads ATLASSIAN_DOMAIN, ATLASSIAN_EMAIL, ATLASSIAN_API_KEY from env by
+# default. Any of these may also be set here explicitly.
+# domain = "example.atlassian.net"
+# email = "you@example.com"
+# api_key = "..."
+
+[[actions]]
+name = "action-name"
+type = "jira"
+command = "create_ticket"  # Required
+```
+
+The `[jira]` section is optional if the environment variables are set.
+
+### Authentication
+
+Uses Jira Cloud Basic auth (email + API token). Environment variable names
+are shared with other Atlassian tools to avoid duplication:
+
+- `ATLASSIAN_DOMAIN` — e.g. `example.atlassian.net` (no scheme)
+- `ATLASSIAN_EMAIL` — the account email
+- `ATLASSIAN_API_KEY` — API token from
+  <https://id.atlassian.com/manage-profile/security/api-tokens>
+
+## Available Commands
+
+### create_ticket
+
+Creates a Jira ticket driven by a Claude Agent SDK session.
+
+**Configuration:**
+```toml
+[[actions]]
+name = "file-security-findings"
+type = "jira"
+command = "create_ticket"
+project_key = "SEC"
+issue_type = "Task"
+labels = ["security-review", "automated", "{{ imbi_project.slug }}"]
+components = ["Application Security"]
+priority = "High"
+prompt = "workflow:///prompts/file-security-ticket.md.j2"
+max_cycles = 3
+timeout = "5m"
+variable_name = "ticket"
+```
+
+**Fields:**
+
+- `project_key` (string, required): Jira project key (e.g. `"SEC"`).
+- `prompt` (ResourceUrl, required): Path to a Jinja2 template with the task
+  prompt for Claude. Receives full workflow context (`workflow`,
+  `imbi_project`, `github_repository`, `variables`, `starting_commit`) plus
+  action-config passthroughs (`project_key`, `issue_type`, `labels`,
+  `components`, `priority`).
+- `issue_type` (string, optional, default `"Task"`): Jira issue type name.
+- `labels` (list of strings, optional): Labels to attach. List entries
+  support Jinja2 templates.
+- `components` (list of strings, optional): Component names to attach. Must
+  already exist in the Jira project; the action does not create them.
+- `priority` (string, optional): Priority name (e.g. `"High"`).
+- `variable_name` (string, optional): If set, stores a dict of the created
+  ticket under `context.variables[variable_name]` with keys `id`, `key`,
+  `url` (REST API URL), and `browse_url` (human-facing link). Downstream
+  actions can reference these via `{{ variables.<name>.browse_url }}`.
+- `max_cycles` (integer, optional, default `3`): Number of attempts. If the
+  Jira API rejects the first attempt (e.g., summary too long), the error is
+  surfaced to Claude in the retry prompt so it can revise and try again.
+- `timeout` (Go-duration string, optional, default `"5m"`): Per-cycle
+  timeout.
+
+**Features:**
+
+- **Agentic authoring**: Claude reads the prompt and any available skills
+  (including marketplace-packaged ones), then composes the ticket
+  summary/description itself.
+- **Markdown descriptions**: The client accepts a plain-text or markdown
+  description and wraps it into a minimal Atlassian Document Format (ADF)
+  envelope. Workflow authors never hand-author ADF.
+- **Fixed metadata**: `project_key`, `issue_type`, `labels`, `components`,
+  and `priority` come from the workflow config and are injected by the
+  tool closure. The agent cannot change them.
+- **Narrow tool surface**: The session allows only `Read`, `Skill`, and the
+  `create_jira_issue` MCP tool. The agent cannot touch the repository or
+  call other tools.
+- **Non-committable**: Does not create git commits.
+- **Retry on API errors**: Jira 4xx responses are surfaced to Claude in the
+  next cycle's prompt; content-shape errors (summary too long, invalid
+  markdown formatting) can often self-heal. Config errors (bad
+  `project_key`, missing component) will exhaust cycles and fail.
+
+**Use Cases:**
+
+- File a ticket summarising AI-generated security-review findings.
+- Open a tracking issue for a migration that requires human follow-up.
+- Escalate automation failures that need human triage.
+
+**Example — linking the created ticket back to the project:**
+
+```toml
+[[actions]]
+name = "file-ticket"
+type = "jira"
+command = "create_ticket"
+project_key = "SEC"
+issue_type = "Task"
+labels = ["security-review"]
+components = ["Application Security"]
+prompt = "workflow:///prompts/security-ticket.md.j2"
+variable_name = "ticket"
+
+[[actions]]
+name = "link-ticket-on-project"
+type = "imbi"
+command = "add_project_link"
+link_type = "Issue Tracker"
+url = "{{ variables.ticket.browse_url }}"
+```
+
+**Prompt template context (`prompts/security-ticket.md.j2`):**
+
+```markdown
+# File a security-review ticket
+
+You must call `create_jira_issue` exactly once. Use the skill available
+for guidance on how to write a good ticket.
+
+## Context
+
+- Project: {{ imbi_project.name }} ({{ imbi_project.slug }})
+- Repository: {{ github_repository.full_name if github_repository else 'n/a' }}
+- Labels to apply: {{ labels | join(', ') }}
+- Components to apply: {{ components | join(', ') }}
+
+## Findings to summarise
+
+{{ variables.security_findings }}
+
+## Required
+
+- `summary`: one line, plain text, < 120 chars.
+- `description`: markdown; use paragraphs separated by blank lines.
+```
+
+## Skill and plugin loading
+
+Claude-Code skills are loaded through the existing plugin mechanism. To make
+a Jira-writing skill available to the action:
+
+1. Package it as a plugin in a marketplace.
+2. Configure the marketplace in the main `config.toml` or the workflow
+   `workflow.toml` under `[claude_code.plugins]` / `[plugins]`.
+3. Enable the plugin.
+
+The Jira action shares the same plugin-install path as the `claude` action,
+so plugins installed by an earlier `claude` action in the same workflow are
+reused for free.
+
+## Error handling
+
+- **Missing Jira config**: `ValueError` at action start.
+- **Jira API 4xx**: surfaced to Claude in the next cycle's prompt. If
+  `max_cycles` exhausts without a successful `create_jira_issue` call, the
+  action raises `RuntimeError`.
+- **Timeout**: per-cycle timeout; raises `RuntimeError` wrapping a
+  `TimeoutError`.
+
+Standard workflow error handling applies: attach an `on_error` action or
+define an `error_filter` with `stage = "on_error"` to recover.
+
+## Out of scope (future commands)
+
+The following are intentionally not part of the first release. Expect
+dedicated commands in follow-up work:
+
+- `add_comment` — append a comment to an existing issue.
+- `transition_ticket` — change an issue's workflow state.
+- `link_issue` — create issue-to-issue links.
+- Assignee/reporter selection — current action cannot set either.
+- Attachments — not supported.
+- Custom-field writes beyond what's exposed via `labels`, `components`,
+  and `priority`.

--- a/src/imbi_automations/actions/__init__.py
+++ b/src/imbi_automations/actions/__init__.py
@@ -13,6 +13,7 @@ Supported action types:
 - git: Git operations (extract from history, clone repositories)
 - github: GitHub-specific operations and API integrations
 - imbi: Imbi API operations and integrations
+- jira: Jira ticket creation via agentic Claude session
 - shell: Shell command execution with templating support
 - template: Jinja2 template rendering with full workflow context
 """
@@ -29,6 +30,7 @@ from . import (
     git,
     github,
     imbi,
+    jira,
     shell,
     template,
 )
@@ -61,6 +63,7 @@ class Actions(mixins.WorkflowLoggerMixin):
             | models.WorkflowGitAction
             | models.WorkflowGitHubAction
             | models.WorkflowImbiAction
+            | models.WorkflowJiraAction
             | models.WorkflowShellAction
             | models.WorkflowTemplateAction
         ),
@@ -93,6 +96,10 @@ class Actions(mixins.WorkflowLoggerMixin):
                 )
             case models.WorkflowActionTypes.imbi:
                 obj = imbi.ImbiActions(
+                    self.configuration, context, self.verbose
+                )
+            case models.WorkflowActionTypes.jira:
+                obj = jira.JiraActions(
                     self.configuration, context, self.verbose
                 )
             case models.WorkflowActionTypes.shell:

--- a/src/imbi_automations/actions/jira.py
+++ b/src/imbi_automations/actions/jira.py
@@ -1,0 +1,252 @@
+"""Jira ticket creation action using an agentic Claude session.
+
+Invokes Claude Agent SDK with a configurable task prompt and an in-process
+MCP tool that posts to the Jira Cloud REST API. Claude authors the ticket
+summary and description; project_key, issue_type, labels, and components
+come from the action config and cannot be overridden by the agent.
+"""
+
+import logging
+import typing
+
+import claude_agent_sdk
+import httpx
+
+from imbi_automations import claude, clients, mixins, models, prompts
+
+LOGGER = logging.getLogger(__name__)
+
+_TOOL_SCHEMA: dict[str, typing.Any] = {
+    'type': 'object',
+    'properties': {
+        'summary': {
+            'type': 'string',
+            'description': 'Concise issue title (plain text, no markdown).',
+        },
+        'description': {
+            'type': 'string',
+            'description': (
+                'Issue body as plain text or markdown. Use blank lines to '
+                'separate paragraphs. The client wraps this into ADF.'
+            ),
+        },
+    },
+    'required': ['summary', 'description'],
+}
+
+
+class JiraActions(mixins.WorkflowLoggerMixin):
+    """Executes Jira actions (currently: create_ticket)."""
+
+    def __init__(
+        self,
+        configuration: models.Configuration,
+        context: models.WorkflowContext,
+        verbose: bool,
+    ) -> None:
+        super().__init__(verbose)
+        self._set_workflow_logger(context.workflow)
+        self.logger = LOGGER
+        self.configuration = configuration
+        self.context = context
+        self._created_issue: models.JiraIssueCreated | None = None
+        self._last_tool_error: str | None = None
+
+    async def execute(self, action: models.WorkflowJiraAction) -> None:
+        """Execute a Jira action.
+
+        Raises:
+            RuntimeError: If command is not supported or the agent fails to
+                create a ticket within max_cycles.
+            ValueError: If jira configuration is missing.
+
+        """
+        match action.command:
+            case models.WorkflowJiraActionCommand.create_ticket:
+                await self._create_ticket(action)
+            case _:
+                raise RuntimeError(f'Unsupported command: {action.command}')
+
+    async def _create_ticket(self, action: models.WorkflowJiraAction) -> None:
+        if self.configuration.jira is None:
+            raise ValueError(
+                'jira configuration is required for jira actions. Set '
+                'ATLASSIAN_DOMAIN, ATLASSIAN_EMAIL, ATLASSIAN_API_KEY or '
+                'provide a [jira] section in config.toml.'
+            )
+
+        jira_client = clients.Jira.get_instance(config=self.configuration.jira)
+        base_prompt = prompts.render(
+            self.context,
+            action.prompt,
+            project_key=action.project_key,
+            issue_type=action.issue_type,
+            labels=action.labels,
+            components=action.components,
+            priority=action.priority,
+        )
+
+        handler = self._build_create_handler(action, jira_client)
+        create_tool = claude_agent_sdk.tool(
+            'create_jira_issue',
+            (
+                'Create a Jira ticket. The project, issue type, labels, and '
+                'components are fixed by the workflow — only supply summary '
+                'and description.'
+            ),
+            _TOOL_SCHEMA,
+        )(handler)
+        jira_mcp = claude_agent_sdk.create_sdk_mcp_server(
+            'jira_tools', '1.0.0', [create_tool]
+        )
+
+        claude_client = claude.Claude(
+            self.configuration, self.context, self.verbose
+        )
+        allowed_tools = ['Read', 'Skill', 'mcp__jira_tools__create_jira_issue']
+        timeout = action.timeout or '5m'
+
+        for cycle in range(1, action.max_cycles + 1):
+            self.logger.debug(
+                '%s [%s/%s] %s jira create_ticket cycle %d/%d',
+                self.context.imbi_project.slug,
+                self.context.current_action_index,
+                self.context.total_actions,
+                action.name,
+                cycle,
+                action.max_cycles,
+            )
+            self._created_issue = None
+            prior_error = self._last_tool_error
+            self._last_tool_error = None
+
+            prompt = base_prompt
+            if cycle > 1 and prior_error:
+                prompt = (
+                    f'{base_prompt}\n\n---\n\n'
+                    'The previous attempt failed with this error from Jira:\n'
+                    f'```\n{prior_error}\n```\n\n'
+                    'Adjust the summary and/or description and call '
+                    '`create_jira_issue` again.'
+                )
+
+            try:
+                await claude_client.custom_tool_session(
+                    prompt,
+                    mcp_server_name='jira_tools',
+                    mcp_server=jira_mcp,
+                    allowed_tools=allowed_tools,
+                    timeout=timeout,
+                )
+            except TimeoutError as exc:
+                raise RuntimeError(
+                    f'Jira action {action.name} timed out after {timeout} '
+                    f'in cycle {cycle}/{action.max_cycles}'
+                ) from exc
+
+            if self._created_issue is not None:
+                break
+
+            self.logger.warning(
+                '%s [%s/%s] %s no ticket created in cycle %d/%d',
+                self.context.imbi_project.slug,
+                self.context.current_action_index,
+                self.context.total_actions,
+                action.name,
+                cycle,
+                action.max_cycles,
+            )
+
+        if self._created_issue is None:
+            raise RuntimeError(
+                f'Jira action {action.name} did not create a ticket after '
+                f'{action.max_cycles} cycles'
+            )
+
+        issue = self._created_issue
+        self.logger.info(
+            '%s [%s/%s] %s created Jira ticket %s',
+            self.context.imbi_project.slug,
+            self.context.current_action_index,
+            self.context.total_actions,
+            action.name,
+            issue.key,
+        )
+
+        if action.variable_name:
+            self.context.variables[action.variable_name] = {
+                'id': issue.id,
+                'key': issue.key,
+                'url': str(issue.self_url),
+                'browse_url': jira_client.browse_url(issue.key),
+            }
+
+    def _build_create_handler(
+        self, action: models.WorkflowJiraAction, jira_client: clients.Jira
+    ) -> typing.Callable[..., typing.Awaitable[dict[str, typing.Any]]]:
+        """Return the raw tool-handler coroutine bound to the action config.
+
+        Returned separately from the `@claude_agent_sdk.tool` decoration so
+        tests can invoke the handler directly without going through the SDK
+        tool wrapper.
+        """
+
+        async def create_jira_issue(
+            args: dict[str, typing.Any],
+        ) -> dict[str, typing.Any]:
+            summary = args.get('summary')
+            description = args.get('description')
+            if not summary or not description:
+                return {
+                    'content': [
+                        {
+                            'type': 'text',
+                            'text': (
+                                'Both summary and description are required.'
+                            ),
+                        }
+                    ],
+                    'is_error': True,
+                }
+
+            try:
+                issue = await jira_client.create_issue(
+                    project_key=action.project_key,
+                    summary=summary,
+                    issue_type=action.issue_type,
+                    description=description,
+                    labels=list(action.labels) or None,
+                    components=list(action.components) or None,
+                    priority=action.priority,
+                )
+            except httpx.HTTPStatusError as err:
+                err_text = (
+                    f'Jira returned HTTP {err.response.status_code}: '
+                    f'{err.response.text}'
+                )
+                self._last_tool_error = err_text
+                return {
+                    'content': [{'type': 'text', 'text': err_text}],
+                    'is_error': True,
+                }
+            except httpx.HTTPError as err:
+                err_text = f'Jira request failed: {err}'
+                self._last_tool_error = err_text
+                return {
+                    'content': [{'type': 'text', 'text': err_text}],
+                    'is_error': True,
+                }
+
+            self._created_issue = issue
+            return {
+                'content': [
+                    {
+                        'type': 'text',
+                        'text': (
+                            f'Created Jira issue {issue.key} (id={issue.id}).'
+                        ),
+                    }
+                ]
+            }
+
+        return create_jira_issue

--- a/src/imbi_automations/actions/jira.py
+++ b/src/imbi_automations/actions/jira.py
@@ -75,7 +75,15 @@ class JiraActions(mixins.WorkflowLoggerMixin):
                 'provide a [jira] section in config.toml.'
             )
 
-        jira_client = clients.Jira.get_instance(config=self.configuration.jira)
+        jira_client = clients.Jira(self.configuration.jira)
+        try:
+            await self._run_create_ticket(action, jira_client)
+        finally:
+            await jira_client.http_client.aclose()
+
+    async def _run_create_ticket(
+        self, action: models.WorkflowJiraAction, jira_client: clients.Jira
+    ) -> None:
         base_prompt = prompts.render(
             self.context,
             action.prompt,

--- a/src/imbi_automations/claude.py
+++ b/src/imbi_automations/claude.py
@@ -606,6 +606,72 @@ class Claude(mixins.WorkflowLoggerMixin):
 
         return self._submitted_response
 
+    async def custom_tool_session(
+        self,
+        prompt: str,
+        *,
+        mcp_server_name: str,
+        mcp_server: typing.Any,
+        allowed_tools: list[str],
+        cwd: pathlib.Path | None = None,
+        timeout: str = '5m',
+    ) -> None:
+        """Run a one-shot SDK session with a custom MCP tool.
+
+        Reuses the initialized working dir, settings, and installed plugin
+        paths from this Claude instance. Does not use the planning/task/
+        validation agent structure — the prompt is submitted directly.
+        """
+        import pytimeparse2
+
+        timeout_seconds = pytimeparse2.parse(timeout)
+        if timeout_seconds is None:
+            raise ValueError(f'Invalid timeout format: {timeout}')
+
+        await self._ensure_plugins_installed()
+
+        mcp_servers: dict[str, typing.Any] = {mcp_server_name: mcp_server}
+        for (
+            name,
+            config,
+        ) in self.context.workflow.configuration.mcp_servers.items():
+            mcp_servers[name] = _expand_mcp_config(config.model_dump())
+
+        sdk_plugins: list[types.SdkPluginConfig] = [
+            types.SdkPluginConfig(type='local', path=plugin.path)
+            for plugin in self._merged_local_plugins
+        ]
+        for plugin_path in self._installed_plugin_paths:
+            sdk_plugins.append(
+                types.SdkPluginConfig(type='local', path=plugin_path)
+            )
+
+        options = claude_agent_sdk.ClaudeAgentOptions(
+            allowed_tools=allowed_tools,
+            cwd=cwd or self.context.working_directory,
+            mcp_servers=mcp_servers,
+            model=self.configuration.claude.model,
+            plugins=sdk_plugins,
+            settings=str(self._settings_path),
+            setting_sources=['local'],
+            permission_mode='bypassPermissions',
+        )
+        client = claude_agent_sdk.ClaudeSDKClient(options)
+
+        async def run() -> None:
+            await client.connect()
+            try:
+                await client.query(prompt)
+                async for message in client.receive_response():
+                    self._parse_message(message)
+            finally:
+                try:
+                    await client.disconnect()
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.debug('SDK disconnect failed: %s', exc)
+
+        await asyncio.wait_for(run(), timeout=timeout_seconds)
+
     async def anthropic_query(
         self, prompt: str, model: str | None = None
     ) -> str:

--- a/src/imbi_automations/clients/__init__.py
+++ b/src/imbi_automations/clients/__init__.py
@@ -1,11 +1,19 @@
 """Client exports for HTTP and API clients.
 
-Provides access to GitHub and Imbi API clients along with base HTTP client
-classes and HTTP status codes.
+Provides access to GitHub, Imbi, and Jira API clients along with base HTTP
+client classes and HTTP status codes.
 """
 
 from .github import GitHub
 from .http import BaseURLHTTPClient, HTTPClient, HTTPStatus
 from .imbi import Imbi
+from .jira import Jira
 
-__all__ = ['GitHub', 'BaseURLHTTPClient', 'HTTPClient', 'HTTPStatus', 'Imbi']
+__all__ = [
+    'GitHub',
+    'BaseURLHTTPClient',
+    'HTTPClient',
+    'HTTPStatus',
+    'Imbi',
+    'Jira',
+]

--- a/src/imbi_automations/clients/jira.py
+++ b/src/imbi_automations/clients/jira.py
@@ -1,0 +1,117 @@
+"""Jira Cloud REST API client."""
+
+import base64
+import logging
+import typing
+
+import httpx
+
+from imbi_automations import models
+
+from . import http
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Jira(http.BaseURLHTTPClient):
+    """Jira Cloud REST v3 client (Basic auth)."""
+
+    def __init__(
+        self,
+        config: models.JiraConfiguration,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        super().__init__(transport=transport)
+        self._base_url = f'https://{config.domain}'
+        self._browse_base = f'https://{config.domain}/browse'
+        credential = (
+            f'{config.email}:{config.api_key.get_secret_value()}'
+        ).encode()
+        encoded = base64.b64encode(credential).decode()
+        self.add_header('Authorization', f'Basic {encoded}')
+        self.add_header('Accept', 'application/json')
+
+    def browse_url(self, key: str) -> str:
+        """Return the Jira browse URL for an issue key."""
+        return f'{self._browse_base}/{key}'
+
+    async def create_issue(
+        self,
+        *,
+        project_key: str,
+        summary: str,
+        issue_type: str = 'Task',
+        description: str | None = None,
+        labels: list[str] | None = None,
+        components: list[str] | None = None,
+        priority: str | None = None,
+        extra_fields: dict[str, typing.Any] | None = None,
+    ) -> models.JiraIssueCreated:
+        """Create a Jira issue.
+
+        `description` is accepted as a plain-text / markdown string and
+        wrapped into a minimal Atlassian Document Format (ADF) envelope —
+        callers should not hand-author ADF.
+        """
+        fields: dict[str, typing.Any] = {
+            'project': {'key': project_key},
+            'summary': summary,
+            'issuetype': {'name': issue_type},
+        }
+        if description is not None:
+            fields['description'] = _markdown_to_adf(description)
+        if labels:
+            fields['labels'] = labels
+        if components:
+            fields['components'] = [{'name': c} for c in components]
+        if priority:
+            fields['priority'] = {'name': priority}
+        if extra_fields:
+            fields.update(extra_fields)
+
+        LOGGER.debug(
+            'Creating Jira issue in project %s (type=%s)',
+            project_key,
+            issue_type,
+        )
+        response = await self.post(
+            '/rest/api/3/issue', json={'fields': fields}
+        )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError:
+            try:
+                error_body = response.text
+            except (AttributeError, UnicodeDecodeError):
+                error_body = '<unable to read response body>'
+            LOGGER.error(
+                'Failed to create Jira issue in %s: HTTP %d - %s',
+                project_key,
+                response.status_code,
+                error_body,
+            )
+            raise
+        return models.JiraIssueCreated.model_validate(response.json())
+
+
+def _markdown_to_adf(text: str) -> dict[str, typing.Any]:
+    """Wrap a plain-text/markdown string into a minimal ADF document.
+
+    Each blank-line-separated block becomes a paragraph; newlines inside a
+    block become hard breaks. This is intentionally minimal — rich ADF
+    authoring is out of scope for the `jira` action's v1.
+    """
+    blocks = [block for block in text.split('\n\n') if block.strip()]
+    if not blocks:
+        blocks = ['']
+    paragraphs: list[dict[str, typing.Any]] = []
+    for block in blocks:
+        lines = block.split('\n')
+        content: list[dict[str, typing.Any]] = []
+        for idx, line in enumerate(lines):
+            if idx > 0:
+                content.append({'type': 'hardBreak'})
+            if line:
+                content.append({'type': 'text', 'text': line})
+        paragraphs.append({'type': 'paragraph', 'content': content})
+    return {'type': 'doc', 'version': 1, 'content': paragraphs}

--- a/src/imbi_automations/models/__init__.py
+++ b/src/imbi_automations/models/__init__.py
@@ -4,7 +4,7 @@ Centralizes imports for configuration, API responses (GitHub, Imbi),
 workflow definitions, git operations, and Claude Code integration models.
 """
 
-from . import configuration, imbi, mcp
+from . import configuration, imbi, jira, mcp
 from .claude import (
     ClaudeAgentPlanningResult,
     ClaudeAgentResponse,
@@ -24,6 +24,7 @@ from .configuration import (
     GitConfiguration,
     GitHubConfiguration,
     ImbiConfiguration,
+    JiraConfiguration,
 )
 from .git import GitCommit, GitCommitSummary, GitFileChange
 from .github import (
@@ -49,6 +50,7 @@ from .imbi import (
     ImbiProjectLink,
     ImbiProjectType,
 )
+from .jira import JiraIssueCreated
 from .mcp import McpHttpServer, McpServerConfig, McpSSEServer, McpStdioServer
 from .resume_state import ResumeState
 from .workflow import (
@@ -82,6 +84,8 @@ from .workflow import (
     WorkflowGitHubCommand,
     WorkflowImbiAction,
     WorkflowImbiActionCommand,
+    WorkflowJiraAction,
+    WorkflowJiraActionCommand,
     WorkflowShellAction,
     WorkflowTemplateAction,
 )
@@ -89,6 +93,7 @@ from .workflow import (
 __all__ = [
     'configuration',
     'imbi',
+    'jira',
     'mcp',
     'AnthropicConfiguration',
     'ClaudeAgentConfiguration',
@@ -130,6 +135,8 @@ __all__ = [
     'ImbiProjectFactTypeRange',
     'ImbiProjectLink',
     'ImbiProjectType',
+    'JiraConfiguration',
+    'JiraIssueCreated',
     'McpHttpServer',
     'McpServerConfig',
     'McpSSEServer',
@@ -163,6 +170,8 @@ __all__ = [
     'WorkflowGitHubCommand',
     'WorkflowImbiAction',
     'WorkflowImbiActionCommand',
+    'WorkflowJiraAction',
+    'WorkflowJiraActionCommand',
     'WorkflowShellAction',
     'WorkflowTemplateAction',
 ]

--- a/src/imbi_automations/models/configuration.py
+++ b/src/imbi_automations/models/configuration.py
@@ -157,6 +157,23 @@ class ImbiConfiguration(pydantic_settings.BaseSettings):
     sonarqube_link: str = 'SonarQube'
 
 
+class JiraConfiguration(pydantic_settings.BaseSettings):
+    """Atlassian / Jira Cloud configuration for the `jira` action type.
+
+    Uses Basic auth (email + API key) against the Jira Cloud REST v3 API.
+    Reads from shared Atlassian env vars: ATLASSIAN_DOMAIN, ATLASSIAN_EMAIL,
+    ATLASSIAN_API_KEY.
+    """
+
+    model_config = pydantic_settings.SettingsConfigDict(
+        env_prefix='ATLASSIAN_', **BASE_SETTINGS
+    )
+
+    domain: str
+    email: str
+    api_key: pydantic.SecretStr
+
+
 class Configuration(pydantic.BaseModel):
     """Main application configuration.
 
@@ -193,6 +210,7 @@ class Configuration(pydantic.BaseModel):
             'git': GitConfiguration,
             'github': GitHubConfiguration,
             'imbi': ImbiConfiguration,
+            'jira': JiraConfiguration,
         }
         for field, settings_cls in settings_fields.items():
             if field in data and data[field] is not None:
@@ -218,4 +236,5 @@ class Configuration(pydantic.BaseModel):
     git: GitConfiguration = pydantic.Field(default_factory=GitConfiguration)
     github: GitHubConfiguration | None = None
     imbi: ImbiConfiguration | None = None
+    jira: JiraConfiguration | None = None
     preserve_on_error: bool = False

--- a/src/imbi_automations/models/jira.py
+++ b/src/imbi_automations/models/jira.py
@@ -1,0 +1,13 @@
+"""Jira API response models."""
+
+import pydantic
+
+
+class JiraIssueCreated(pydantic.BaseModel):
+    """Response body from `POST /rest/api/3/issue`."""
+
+    model_config = pydantic.ConfigDict(populate_by_name=True)
+
+    id: str
+    key: str
+    self_url: pydantic.HttpUrl = pydantic.Field(alias='self')

--- a/src/imbi_automations/models/workflow.py
+++ b/src/imbi_automations/models/workflow.py
@@ -1,9 +1,9 @@
 """Workflow definition models with comprehensive action and condition support.
 
 Defines the complete workflow structure including actions (callable, claude,
-docker, file, git, github, imbi, shell, template), conditions (local and
-remote file checks), filters (project targeting), and workflow context for
-execution state management.
+docker, file, git, github, imbi, jira, shell, template), conditions (local
+and remote file checks), filters (project targeting), and workflow context
+for execution state management.
 """
 
 import enum
@@ -121,6 +121,7 @@ class WorkflowActionTypes(enum.StrEnum):
     git = 'git'
     github = 'github'
     imbi = 'imbi'
+    jira = 'jira'
     shell = 'shell'
     template = 'template'
 
@@ -606,6 +607,60 @@ class WorkflowImbiAction(validators.CommandRulesMixin, WorkflowAction):
     }
 
 
+class WorkflowJiraActionCommand(enum.StrEnum):
+    """Jira action commands.
+
+    Currently only supports creating a ticket. Future commands (add_comment,
+    transition_ticket, link_issue) are out of scope for the initial release.
+    """
+
+    create_ticket = 'create_ticket'
+
+
+class WorkflowJiraAction(validators.CommandRulesMixin, WorkflowAction):
+    """Action for creating Jira tickets via an agentic Claude session.
+
+    The action invokes Claude Agent SDK with a configurable task prompt and
+    an in-process MCP tool that posts to the Jira Cloud REST API. The agent
+    authors the ticket summary and description; the action config provides
+    the project_key, issue_type, labels, and components.
+    """
+
+    type: typing.Literal['jira'] = 'jira'
+    command: WorkflowJiraActionCommand
+    committable: bool = False
+
+    # Fields for create_ticket command
+    project_key: str | None = None
+    issue_type: str = 'Task'
+    labels: list[str] = []
+    components: list[str] = []
+    priority: str | None = None
+    prompt: ResourceUrl | None = None
+    variable_name: str | None = None
+    max_cycles: int = 3
+    timeout: str | None = None
+
+    # CommandRulesMixin configuration
+    command_field: typing.ClassVar[str] = 'command'
+    required_fields: typing.ClassVar[dict[object, set[str]]] = {
+        WorkflowJiraActionCommand.create_ticket: {'project_key', 'prompt'}
+    }
+    allowed_fields: typing.ClassVar[dict[object, set[str]]] = {
+        WorkflowJiraActionCommand.create_ticket: {
+            'project_key',
+            'issue_type',
+            'labels',
+            'components',
+            'priority',
+            'prompt',
+            'variable_name',
+            'max_cycles',
+            'timeout',
+        }
+    }
+
+
 class WorkflowShellAction(WorkflowAction):
     """Action for shell command execution with templating support.
 
@@ -640,6 +695,7 @@ WorkflowActions = typing.Annotated[
         | WorkflowGitAction
         | WorkflowGitHubAction
         | WorkflowImbiAction
+        | WorkflowJiraAction
         | WorkflowShellAction
         | WorkflowTemplateAction
     ),

--- a/tests/actions/test_jira.py
+++ b/tests/actions/test_jira.py
@@ -1,0 +1,288 @@
+"""Tests for the Jira action module."""
+
+import pathlib
+import tempfile
+from unittest import mock
+
+import httpx
+import pydantic
+
+from imbi_automations import models
+from imbi_automations.actions import jira as jira_actions
+from tests import base
+
+
+class JiraActionsTestCase(base.AsyncTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.working_directory = pathlib.Path(self.temp_dir.name)
+        (self.working_directory / 'workflow').mkdir()
+        (self.working_directory / 'workflow' / 'prompts').mkdir()
+        self.prompt_path = (
+            self.working_directory / 'workflow' / 'prompts' / 'file.md.j2'
+        )
+        self.prompt_path.write_text(
+            'Create a ticket for {{ imbi_project.name }} in {{ project_key }}.'
+        )
+
+        self.workflow = models.Workflow(
+            path=pathlib.Path('/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow', actions=[]
+            ),
+        )
+
+        self.context = models.WorkflowContext(
+            workflow=self.workflow,
+            imbi_project=models.ImbiProject(
+                id=123,
+                dependencies=None,
+                description='Test project',
+                environments=None,
+                facts={},
+                identifiers={},
+                links=None,
+                name='Test Project',
+                namespace='ns',
+                namespace_slug='ns',
+                project_score=None,
+                project_type='API',
+                project_type_slug='api',
+                slug='test-project',
+                urls=None,
+                imbi_url='https://imbi.example.com/projects/123',
+            ),
+            working_directory=self.working_directory,
+        )
+
+        self.configuration = models.Configuration(
+            github=models.GitHubConfiguration(
+                token='test-key'  # noqa: S106
+            ),
+            jira=models.JiraConfiguration(
+                domain='example.atlassian.net',
+                email='tester@example.com',
+                api_key='abc',  # noqa: S106
+            ),
+        )
+
+        self.executor = jira_actions.JiraActions(
+            self.configuration, self.context, verbose=True
+        )
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self.temp_dir.cleanup()
+
+    def _make_action(self, **overrides: object) -> models.WorkflowJiraAction:
+        kwargs = {
+            'name': 'file-ticket',
+            'type': 'jira',
+            'command': 'create_ticket',
+            'project_key': 'SEC',
+            'issue_type': 'Task',
+            'labels': ['automated'],
+            'components': ['AppSec'],
+            'prompt': 'workflow:///prompts/file.md.j2',
+            'max_cycles': 3,
+            'timeout': '5m',
+        }
+        kwargs.update(overrides)
+        return models.WorkflowJiraAction(**kwargs)
+
+    def _issue(self, key: str = 'SEC-1') -> models.JiraIssueCreated:
+        return models.JiraIssueCreated.model_validate(
+            {
+                'id': '10001',
+                'key': key,
+                'self': (
+                    'https://example.atlassian.net/rest/api/3/issue/10001'
+                ),
+            }
+        )
+
+    async def _simulate_tool_call(
+        self,
+        executor: jira_actions.JiraActions,
+        action: models.WorkflowJiraAction,
+        issue: models.JiraIssueCreated | None,
+        error_text: str | None = None,
+    ) -> None:
+        """Simulate what the Claude session would do: set closure state."""
+        executor._created_issue = issue
+        executor._last_tool_error = error_text
+
+    async def test_create_ticket_success_stores_variable(self) -> None:
+        action = self._make_action(variable_name='ticket')
+        issue = self._issue('SEC-42')
+
+        async def fake_session(prompt: str, **kwargs: object) -> None:
+            self.assertIn('Create a ticket for Test Project in SEC.', prompt)
+            self.assertIn('Skill', kwargs['allowed_tools'])
+            self.assertIn(
+                'mcp__jira_tools__create_jira_issue', kwargs['allowed_tools']
+            )
+            await self._simulate_tool_call(self.executor, action, issue)
+
+        with mock.patch(
+            'imbi_automations.claude.Claude.custom_tool_session',
+            side_effect=fake_session,
+        ):
+            await self.executor.execute(action)
+
+        stored = self.context.variables['ticket']
+        self.assertEqual(stored['key'], 'SEC-42')
+        self.assertEqual(stored['id'], '10001')
+        self.assertEqual(
+            stored['browse_url'], 'https://example.atlassian.net/browse/SEC-42'
+        )
+
+    async def test_create_ticket_no_variable_still_succeeds(self) -> None:
+        action = self._make_action()
+        issue = self._issue()
+
+        async def fake_session(prompt: str, **kwargs: object) -> None:
+            await self._simulate_tool_call(self.executor, action, issue)
+
+        with mock.patch(
+            'imbi_automations.claude.Claude.custom_tool_session',
+            side_effect=fake_session,
+        ):
+            await self.executor.execute(action)
+
+        self.assertEqual(self.context.variables, {})
+
+    async def test_create_ticket_retries_on_tool_error(self) -> None:
+        action = self._make_action(max_cycles=3)
+        call_count = {'n': 0}
+        issue = self._issue('SEC-9')
+
+        async def fake_session(prompt: str, **kwargs: object) -> None:
+            call_count['n'] += 1
+            if call_count['n'] == 1:
+                await self._simulate_tool_call(
+                    self.executor,
+                    action,
+                    issue=None,
+                    error_text='HTTP 400: summary too long',
+                )
+            elif call_count['n'] == 2:
+                # Second cycle should receive the retry prompt with the error.
+                self.assertIn('summary too long', prompt)
+                await self._simulate_tool_call(self.executor, action, issue)
+            else:
+                self.fail('Should not need a third cycle')
+
+        with mock.patch(
+            'imbi_automations.claude.Claude.custom_tool_session',
+            side_effect=fake_session,
+        ):
+            await self.executor.execute(action)
+
+        self.assertEqual(call_count['n'], 2)
+
+    async def test_create_ticket_fails_when_no_issue_after_max_cycles(
+        self,
+    ) -> None:
+        action = self._make_action(max_cycles=2)
+
+        async def fake_session(prompt: str, **kwargs: object) -> None:
+            await self._simulate_tool_call(
+                self.executor, action, issue=None, error_text='failed'
+            )
+
+        with mock.patch(
+            'imbi_automations.claude.Claude.custom_tool_session',
+            side_effect=fake_session,
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                await self.executor.execute(action)
+            self.assertIn('after 2 cycles', str(ctx.exception))
+
+    async def test_create_ticket_timeout_raises_runtime_error(self) -> None:
+        action = self._make_action()
+
+        async def fake_session(prompt: str, **kwargs: object) -> None:
+            raise TimeoutError('timed out')
+
+        with mock.patch(
+            'imbi_automations.claude.Claude.custom_tool_session',
+            side_effect=fake_session,
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                await self.executor.execute(action)
+            self.assertIn('timed out', str(ctx.exception))
+
+    async def test_missing_jira_config_raises(self) -> None:
+        self.configuration.jira = None
+        action = self._make_action()
+        with self.assertRaises(ValueError) as ctx:
+            await self.executor.execute(action)
+        self.assertIn('jira configuration is required', str(ctx.exception))
+
+    async def test_tool_closure_builds_and_calls_client(self) -> None:
+        """Exercise the MCP tool closure directly to verify it wires to the
+        Jira client with action config (project_key/issue_type/labels/
+        components/priority)."""
+        action = self._make_action(
+            labels=['a', 'b'], components=['c'], priority='High'
+        )
+        mock_client = mock.AsyncMock()
+        mock_client.create_issue.return_value = self._issue('SEC-7')
+        tool = self.executor._build_create_handler(action, mock_client)
+
+        result = await tool({'summary': 'Hello', 'description': 'World'})
+
+        self.assertNotIn('is_error', result)
+        mock_client.create_issue.assert_awaited_once_with(
+            project_key='SEC',
+            summary='Hello',
+            issue_type='Task',
+            description='World',
+            labels=['a', 'b'],
+            components=['c'],
+            priority='High',
+        )
+        self.assertEqual(self.executor._created_issue.key, 'SEC-7')
+
+    async def test_tool_closure_captures_http_error(self) -> None:
+        action = self._make_action()
+        mock_client = mock.AsyncMock()
+        request = httpx.Request('POST', 'https://x/rest/api/3/issue')
+        response = httpx.Response(400, request=request, text='bad')
+        mock_client.create_issue.side_effect = httpx.HTTPStatusError(
+            'bad', request=request, response=response
+        )
+        tool = self.executor._build_create_handler(action, mock_client)
+
+        result = await tool({'summary': 's', 'description': 'd'})
+
+        self.assertTrue(result.get('is_error'))
+        self.assertIn('HTTP 400', result['content'][0]['text'])
+        self.assertIn('HTTP 400', self.executor._last_tool_error)
+        self.assertIsNone(self.executor._created_issue)
+
+    async def test_tool_closure_rejects_missing_fields(self) -> None:
+        action = self._make_action()
+        mock_client = mock.AsyncMock()
+        tool = self.executor._build_create_handler(action, mock_client)
+
+        result = await tool({'summary': 'only summary'})
+        self.assertTrue(result.get('is_error'))
+        mock_client.create_issue.assert_not_called()
+
+    async def test_missing_required_fields_fails_validation(self) -> None:
+        with self.assertRaises(pydantic.ValidationError):
+            models.WorkflowJiraAction(
+                name='missing',
+                type='jira',
+                command='create_ticket',
+                # Missing project_key and prompt
+            )
+
+    async def test_unsupported_command_raises(self) -> None:
+        action = self._make_action()
+        action.command = 'not_real'  # type: ignore[assignment]
+        with self.assertRaises(RuntimeError):
+            await self.executor.execute(action)

--- a/tests/clients/test_jira.py
+++ b/tests/clients/test_jira.py
@@ -1,0 +1,181 @@
+"""Tests for the Jira Cloud client."""
+
+import base64
+import http
+import json
+
+import httpx
+
+from imbi_automations import models
+from imbi_automations.clients import jira
+from tests import base
+
+
+class TestJiraClient(base.AsyncTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.JiraConfiguration(
+            domain='example.atlassian.net',
+            email='tester@example.com',
+            api_key='abc123',  # noqa: S106
+        )
+        self.instance = jira.Jira(self.config, self.http_client_transport)
+
+    async def test_auth_header_is_basic_email_and_token(self) -> None:
+        expected = base64.b64encode(b'tester@example.com:abc123').decode()
+        self.assertEqual(
+            self.instance.http_client.headers['Authorization'],
+            f'Basic {expected}',
+        )
+
+    async def test_base_url_derived_from_domain(self) -> None:
+        self.assertEqual(
+            self.instance.base_url, 'https://example.atlassian.net'
+        )
+
+    async def test_browse_url_format(self) -> None:
+        self.assertEqual(
+            self.instance.browse_url('SEC-42'),
+            'https://example.atlassian.net/browse/SEC-42',
+        )
+
+    async def test_create_issue_minimal_payload(self) -> None:
+        captured: dict[str, httpx.Request] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured['request'] = request
+            return httpx.Response(
+                http.HTTPStatus.CREATED,
+                request=request,
+                json={
+                    'id': '10001',
+                    'key': 'SEC-1',
+                    'self': (
+                        'https://example.atlassian.net/rest/api/3/issue/10001'
+                    ),
+                },
+            )
+
+        transport = httpx.MockTransport(handler)
+        client = jira.Jira(self.config, transport)
+
+        issue = await client.create_issue(
+            project_key='SEC', summary='Summary here', issue_type='Task'
+        )
+
+        self.assertEqual(issue.key, 'SEC-1')
+        self.assertEqual(issue.id, '10001')
+
+        request = captured['request']
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.url.path, '/rest/api/3/issue')
+        body = json.loads(request.content)
+        self.assertEqual(body['fields']['project']['key'], 'SEC')
+        self.assertEqual(body['fields']['summary'], 'Summary here')
+        self.assertEqual(body['fields']['issuetype']['name'], 'Task')
+        self.assertNotIn('description', body['fields'])
+        self.assertNotIn('labels', body['fields'])
+        self.assertNotIn('components', body['fields'])
+
+    async def test_create_issue_wraps_description_as_adf(self) -> None:
+        captured: dict[str, httpx.Request] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured['request'] = request
+            return httpx.Response(
+                http.HTTPStatus.CREATED,
+                request=request,
+                json={
+                    'id': '2',
+                    'key': 'SEC-2',
+                    'self': (
+                        'https://example.atlassian.net/rest/api/3/issue/2'
+                    ),
+                },
+            )
+
+        client = jira.Jira(self.config, httpx.MockTransport(handler))
+        await client.create_issue(
+            project_key='SEC',
+            summary='S',
+            description='Para one.\n\nPara two line1\nPara two line2',
+        )
+
+        body = json.loads(captured['request'].content)
+        adf = body['fields']['description']
+        self.assertEqual(adf['type'], 'doc')
+        self.assertEqual(adf['version'], 1)
+        self.assertEqual(len(adf['content']), 2)
+        para1, para2 = adf['content']
+        self.assertEqual(
+            para1['content'], [{'type': 'text', 'text': 'Para one.'}]
+        )
+        # Second paragraph contains a hardBreak between the two lines.
+        self.assertEqual(
+            para2['content'],
+            [
+                {'type': 'text', 'text': 'Para two line1'},
+                {'type': 'hardBreak'},
+                {'type': 'text', 'text': 'Para two line2'},
+            ],
+        )
+
+    async def test_create_issue_labels_components_priority(self) -> None:
+        captured: dict[str, httpx.Request] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured['request'] = request
+            return httpx.Response(
+                http.HTTPStatus.CREATED,
+                request=request,
+                json={
+                    'id': '3',
+                    'key': 'SEC-3',
+                    'self': (
+                        'https://example.atlassian.net/rest/api/3/issue/3'
+                    ),
+                },
+            )
+
+        client = jira.Jira(self.config, httpx.MockTransport(handler))
+        await client.create_issue(
+            project_key='SEC',
+            summary='S',
+            labels=['security-review', 'automated'],
+            components=['AppSec', 'Platform'],
+            priority='High',
+        )
+
+        fields = json.loads(captured['request'].content)['fields']
+        self.assertEqual(fields['labels'], ['security-review', 'automated'])
+        self.assertEqual(
+            fields['components'], [{'name': 'AppSec'}, {'name': 'Platform'}]
+        )
+        self.assertEqual(fields['priority'], {'name': 'High'})
+
+    async def test_create_issue_raises_on_4xx(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                http.HTTPStatus.BAD_REQUEST,
+                request=request,
+                json={'errorMessages': ['project key invalid']},
+            )
+
+        client = jira.Jira(self.config, httpx.MockTransport(handler))
+        with self.assertRaises(httpx.HTTPStatusError):
+            await client.create_issue(
+                project_key='NOPE', summary='x', issue_type='Task'
+            )
+
+
+class TestMarkdownToADF(base.AsyncTestCase):
+    async def test_blank_input_produces_single_empty_paragraph(self) -> None:
+        adf = jira._markdown_to_adf('')
+        self.assertEqual(
+            adf,
+            {
+                'type': 'doc',
+                'version': 1,
+                'content': [{'type': 'paragraph', 'content': []}],
+            },
+        )


### PR DESCRIPTION
## Summary

- New `jira` action type that files Jira Cloud tickets via an agentic Claude Agent SDK session.
- `project_key`, `issue_type`, `labels`, `components`, and `priority` are bound from the action config and injected by the in-process MCP tool — Claude cannot override them. The agent only supplies `summary` and `description`.
- Jira API errors are surfaced back into the retry prompt so content-shape rejections (e.g. summary too long) can self-heal across `max_cycles`.

## Problem

Workflows that run in-depth reviews (security, dependency audits) needed a way to file Jira tickets summarising findings. The `imbi` action's `add_project_note` (#103) covers persistence on the project, but Jira is where human follow-up happens.

## Solution

**Configuration**: reads `ATLASSIAN_DOMAIN` / `ATLASSIAN_EMAIL` / `ATLASSIAN_API_KEY` env vars (shared with other Atlassian tools). Can also be set under `[jira]` in `config.toml`.

**Client** (`clients/jira.py`): `Jira(BaseURLHTTPClient)` using Basic auth against the Cloud REST v3 API. Wraps plain-text/markdown `description` into minimal Atlassian Document Format (ADF) — callers never hand-author ADF.

**Action** (`actions/jira.py`): orchestrates a Claude Agent SDK session with a narrow tool surface (`Read`, `Skill`, `mcp__jira_tools__create_jira_issue`) — the agent cannot touch the repo. Reuses plugin install / settings plumbing via a new `Claude.custom_tool_session(...)` helper so marketplace-packaged skills (e.g. a Jira-writing skill) are auto-loaded.

**Result capture**: successful creation stashes `{id, key, url, browse_url}` in `context.variables[variable_name]` so downstream actions can reference the ticket:

```toml
[[actions]]
name = "file-ticket"
type = "jira"
command = "create_ticket"
project_key = "SEC"
issue_type = "Task"
labels = ["security-review", "{{ imbi_project.slug }}"]
components = ["Application Security"]
prompt = "workflow:///prompts/security-ticket.md.j2"
max_cycles = 3
variable_name = "ticket"

[[actions]]
name = "link-ticket-on-project"
type = "imbi"
command = "add_project_link"
link_type = "Issue Tracker"
url = "{{ variables.ticket.browse_url }}"
```

**Out of scope** (future PRs): `add_comment`, `transition_ticket`, `link_issue`, assignee/reporter, attachments, custom-field writes beyond labels/components/priority.

## Test plan

- [x] `uv run ruff format` / `uv run ruff check` — clean
- [x] `uv run pytest` — 811 passed (19 new Jira tests)
- [x] Client tests cover auth header, base URL, browse URL, payload construction (minimal / labels / components / priority), ADF wrapping for multi-paragraph markdown, 4xx error propagation, and blank-description ADF
- [x] Action tests cover success with/without `variable_name`, retry-with-error-context across cycles, `max_cycles` exhaustion, timeout, missing config, tool closure success / HTTP error / missing fields, required-field pydantic validation, unsupported command
- [ ] End-to-end run against a real Atlassian Cloud instance filing a ticket into a sandbox project, verifying skill loads and the ticket renders correctly