### PR TITLE
Add jira action to docs index and nav

### DIFF
--- a/docs/actions/index.md
+++ b/docs/actions/index.md
@@ -39,6 +39,7 @@ See [Action Stages](stages.md) for complete stage documentation.
 | [Git](git.md) | Version control operations | Extract commits, branch management |
 | [GitHub](github.md) | GitHub-specific operations | Environment sync, workflow management |
 | [Imbi](imbi.md) | Imbi project management | Update project facts and metadata |
+| [Jira](jira.md) | Jira ticket creation | Create tickets via agentic Claude session |
 | [Shell](shell.md) | Command execution | Run tests, build processes, scripts |
 | [Template](template.md) | Jinja2 file generation | Generate configs, documentation |
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -107,6 +107,7 @@ Workflows support multiple action types for different operations:
 - **Git Actions**: Extract files from commit history, clone repositories
 - **Docker Actions**: Extract files from containers, build images
 - **GitHub/Imbi Actions**: API operations on project management platforms
+- **Jira Actions**: Create Jira tickets via agentic Claude session
 
 See the [Actions Reference](actions/index.md) for complete documentation.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - Git: actions/git.md
       - GitHub: actions/github.md
       - Imbi: actions/imbi.md
+      - Jira: actions/jira.md
       - Shell: actions/shell.md
       - Template: actions/template.md
     - Templating: templating.md


### PR DESCRIPTION
## Summary
- Add **Jira Actions** bullet to the Action Types list on the Workflows overview page
- Add Jira row to the Action Types Overview table in `docs/actions/index.md`
- Add Jira entry to the mkdocs nav under Workflows → Actions

The jira action type was added in #104 with a standalone reference page (`docs/actions/jira.md`), but it wasn't linked from the index of available action types or included in the site navigation.

## Test plan
- [ ] `mkdocs serve` renders the Jira entry in the nav and on the Actions index page
- [ ] Link from the Action Types Overview table resolves to `docs/actions/jira.md`