### PR TITLE
Fix jira action template rendering and Atlassian env auto-detection

### DIFF
--- a/src/imbi_automations/actions/jira.py
+++ b/src/imbi_automations/actions/jira.py
@@ -84,17 +84,31 @@ class JiraActions(mixins.WorkflowLoggerMixin):
     async def _run_create_ticket(
         self, action: models.WorkflowJiraAction, jira_client: clients.Jira
     ) -> None:
+        project_key = self._render(action.project_key)
+        issue_type = self._render(action.issue_type)
+        priority = self._render(action.priority)
+        labels = [self._render(label) for label in action.labels]
+        components = [self._render(c) for c in action.components]
+
         base_prompt = prompts.render(
             self.context,
             action.prompt,
-            project_key=action.project_key,
-            issue_type=action.issue_type,
-            labels=action.labels,
-            components=action.components,
-            priority=action.priority,
+            project_key=project_key,
+            issue_type=issue_type,
+            labels=labels,
+            components=components,
+            priority=priority,
         )
 
-        handler = self._build_create_handler(action, jira_client)
+        handler = self._build_create_handler(
+            action,
+            jira_client,
+            project_key=project_key,
+            issue_type=issue_type,
+            labels=labels,
+            components=components,
+            priority=priority,
+        )
         create_tool = claude_agent_sdk.tool(
             'create_jira_issue',
             (
@@ -189,8 +203,34 @@ class JiraActions(mixins.WorkflowLoggerMixin):
                 'browse_url': jira_client.browse_url(issue.key),
             }
 
+    def _render(self, value: str | None) -> str | None:
+        """Render a workflow-configured string as a Jinja2 template.
+
+        Returns the input unchanged when it is None or does not contain any
+        Jinja2 delimiters, so unused/empty fields are pass-through.
+        """
+        if value is None or ('{{' not in value and '{%' not in value):
+            return value
+        return prompts.render_template_string(
+            value,
+            workflow=self.context.workflow,
+            github_repository=self.context.github_repository,
+            imbi_project=self.context.imbi_project,
+            working_directory=self.context.working_directory,
+            starting_commit=self.context.starting_commit,
+            variables=self.context.variables,
+        )
+
     def _build_create_handler(
-        self, action: models.WorkflowJiraAction, jira_client: clients.Jira
+        self,
+        action: models.WorkflowJiraAction,
+        jira_client: clients.Jira,
+        *,
+        project_key: str,
+        issue_type: str,
+        labels: list[str],
+        components: list[str],
+        priority: str | None,
     ) -> typing.Callable[..., typing.Awaitable[dict[str, typing.Any]]]:
         """Return the raw tool-handler coroutine bound to the action config.
 
@@ -219,13 +259,13 @@ class JiraActions(mixins.WorkflowLoggerMixin):
 
             try:
                 issue = await jira_client.create_issue(
-                    project_key=action.project_key,
+                    project_key=project_key,
                     summary=summary,
-                    issue_type=action.issue_type,
+                    issue_type=issue_type,
                     description=description,
-                    labels=list(action.labels) or None,
-                    components=list(action.components) or None,
-                    priority=action.priority,
+                    labels=list(labels) or None,
+                    components=list(components) or None,
+                    priority=priority,
                 )
             except httpx.HTTPStatusError as err:
                 err_text = (

--- a/src/imbi_automations/models/configuration.py
+++ b/src/imbi_automations/models/configuration.py
@@ -6,6 +6,7 @@ for validation with SecretStr for sensitive data and environment variable
 defaults.
 """
 
+import contextlib
 import pathlib
 import typing
 
@@ -223,11 +224,9 @@ class Configuration(pydantic.BaseModel):
                     continue
                 data[field] = settings_cls(**data[field])
             elif field in optional_env_only_fields:
-                try:
+                # Required env vars not set — leave as None (opt-in).
+                with contextlib.suppress(pydantic.ValidationError):
                     data[field] = settings_cls()
-                except pydantic.ValidationError:
-                    # Required env vars not set — leave as None (opt-in).
-                    pass
         return data
 
     ai_commits: bool = False

--- a/src/imbi_automations/models/configuration.py
+++ b/src/imbi_automations/models/configuration.py
@@ -212,12 +212,22 @@ class Configuration(pydantic.BaseModel):
             'imbi': ImbiConfiguration,
             'jira': JiraConfiguration,
         }
+        # Optional sections that should auto-populate from env vars when the
+        # user did not provide a section in config.toml. This lets users
+        # configure Jira (and others) entirely via env vars.
+        optional_env_only_fields = {'jira'}
         for field, settings_cls in settings_fields.items():
             if field in data and data[field] is not None:
                 # Skip if already an instance (e.g., from direct construction)
                 if isinstance(data[field], settings_cls):
                     continue
                 data[field] = settings_cls(**data[field])
+            elif field in optional_env_only_fields:
+                try:
+                    data[field] = settings_cls()
+                except pydantic.ValidationError:
+                    # Required env vars not set — leave as None (opt-in).
+                    pass
         return data
 
     ai_commits: bool = False

--- a/tests/actions/test_jira.py
+++ b/tests/actions/test_jira.py
@@ -328,17 +328,24 @@ class JiraActionsTestCase(base.AsyncTestCase):
                 self.executor, action, self._issue('MAPPED-1')
             )
 
-        with mock.patch.object(
-            self.executor, '_build_create_handler', side_effect=capture_build
-        ):
-            with mock.patch(
+        with (
+            mock.patch.object(
+                self.executor,
+                '_build_create_handler',
+                side_effect=capture_build,
+            ),
+            mock.patch(
                 'imbi_automations.claude.Claude.custom_tool_session',
                 side_effect=fake_session,
-            ):
-                await self.executor.execute(action)
+            ),
+        ):
+            await self.executor.execute(action)
 
         self.assertEqual(captured.get('project_key'), 'MAPPED')
         self.assertEqual(captured.get('labels'), ['automated', 'test-project'])
+        self.assertEqual(captured.get('issue_type'), 'Task')
+        self.assertEqual(captured.get('components'), ['AppSec'])
+        self.assertIsNone(captured.get('priority'))
 
     async def test_unsupported_command_raises(self) -> None:
         action = self._make_action()

--- a/tests/actions/test_jira.py
+++ b/tests/actions/test_jira.py
@@ -230,7 +230,15 @@ class JiraActionsTestCase(base.AsyncTestCase):
         )
         mock_client = mock.AsyncMock()
         mock_client.create_issue.return_value = self._issue('SEC-7')
-        tool = self.executor._build_create_handler(action, mock_client)
+        tool = self.executor._build_create_handler(
+            action,
+            mock_client,
+            project_key='SEC',
+            issue_type='Task',
+            labels=['a', 'b'],
+            components=['c'],
+            priority='High',
+        )
 
         result = await tool({'summary': 'Hello', 'description': 'World'})
 
@@ -254,7 +262,15 @@ class JiraActionsTestCase(base.AsyncTestCase):
         mock_client.create_issue.side_effect = httpx.HTTPStatusError(
             'bad', request=request, response=response
         )
-        tool = self.executor._build_create_handler(action, mock_client)
+        tool = self.executor._build_create_handler(
+            action,
+            mock_client,
+            project_key='SEC',
+            issue_type='Task',
+            labels=['automated'],
+            components=['AppSec'],
+            priority=None,
+        )
 
         result = await tool({'summary': 's', 'description': 'd'})
 
@@ -266,7 +282,15 @@ class JiraActionsTestCase(base.AsyncTestCase):
     async def test_tool_closure_rejects_missing_fields(self) -> None:
         action = self._make_action()
         mock_client = mock.AsyncMock()
-        tool = self.executor._build_create_handler(action, mock_client)
+        tool = self.executor._build_create_handler(
+            action,
+            mock_client,
+            project_key='SEC',
+            issue_type='Task',
+            labels=['automated'],
+            components=['AppSec'],
+            priority=None,
+        )
 
         result = await tool({'summary': 'only summary'})
         self.assertTrue(result.get('is_error'))
@@ -280,6 +304,41 @@ class JiraActionsTestCase(base.AsyncTestCase):
                 command='create_ticket',
                 # Missing project_key and prompt
             )
+
+    async def test_create_ticket_renders_templated_project_key(self) -> None:
+        """project_key and labels support Jinja2 templates (e.g. for mapping
+        imbi_project.namespace_slug to a Jira project key)."""
+        action = self._make_action(
+            project_key=(
+                "{{ {'ns':'MAPPED','other':'OTHER'}"
+                '[imbi_project.namespace_slug] }}'
+            ),
+            labels=['automated', '{{ imbi_project.slug }}'],
+        )
+        captured: dict[str, object] = {}
+        real_build = self.executor._build_create_handler
+
+        def capture_build(*args: object, **kwargs: object) -> object:
+            captured.update(kwargs)
+            return real_build(*args, **kwargs)
+
+        async def fake_session(prompt: str, **_kwargs: object) -> None:
+            self.assertIn('MAPPED', prompt)
+            await self._simulate_tool_call(
+                self.executor, action, self._issue('MAPPED-1')
+            )
+
+        with mock.patch.object(
+            self.executor, '_build_create_handler', side_effect=capture_build
+        ):
+            with mock.patch(
+                'imbi_automations.claude.Claude.custom_tool_session',
+                side_effect=fake_session,
+            ):
+                await self.executor.execute(action)
+
+        self.assertEqual(captured.get('project_key'), 'MAPPED')
+        self.assertEqual(captured.get('labels'), ['automated', 'test-project'])
 
     async def test_unsupported_command_raises(self) -> None:
         action = self._make_action()

--- a/tests/test_model_validators.py
+++ b/tests/test_model_validators.py
@@ -11,6 +11,7 @@ from imbi_automations.models.workflow import (
     WorkflowFileAction,
     WorkflowFileActionCommand,
 )
+from tests import base
 
 
 class ModelValidatorsTestCase(unittest.TestCase):
@@ -103,7 +104,7 @@ class ModelValidatorsTestCase(unittest.TestCase):
             WorkflowCondition(file=pathlib.Path('f'))
 
 
-class ConfigurationJiraEnvTestCase(unittest.TestCase):
+class ConfigurationJiraEnvTestCase(base.AsyncTestCase):
     """Jira configuration should be auto-populated from ATLASSIAN_* env vars
     when the user omits a `[jira]` section in config.toml."""
 

--- a/tests/test_model_validators.py
+++ b/tests/test_model_validators.py
@@ -1,7 +1,9 @@
 import pathlib
 import re
 import unittest
+from unittest import mock
 
+from imbi_automations.models.configuration import Configuration
 from imbi_automations.models.workflow import (
     WorkflowCondition,
     WorkflowDockerAction,
@@ -99,6 +101,39 @@ class ModelValidatorsTestCase(unittest.TestCase):
             WorkflowCondition(file_contains='x')
         with self.assertRaises(ValueError):
             WorkflowCondition(file=pathlib.Path('f'))
+
+
+class ConfigurationJiraEnvTestCase(unittest.TestCase):
+    """Jira configuration should be auto-populated from ATLASSIAN_* env vars
+    when the user omits a `[jira]` section in config.toml."""
+
+    def test_jira_populated_from_env_vars_without_section(self) -> None:
+        env = {
+            'ATLASSIAN_DOMAIN': 'example.atlassian.net',
+            'ATLASSIAN_EMAIL': 'bot@example.com',
+            'ATLASSIAN_API_KEY': 'secret',
+            'GH_TOKEN': 'gh-token',
+            'IMBI_API_KEY': 'imbi-key',
+            'IMBI_HOSTNAME': 'imbi.example.com',
+        }
+        with mock.patch.dict('os.environ', env, clear=True):
+            cfg = Configuration()
+        self.assertIsNotNone(cfg.jira)
+        self.assertEqual(cfg.jira.domain, 'example.atlassian.net')
+        self.assertEqual(cfg.jira.email, 'bot@example.com')
+        self.assertEqual(
+            cfg.jira.api_key.get_secret_value(), 'secret'
+        )
+
+    def test_jira_left_none_when_env_vars_missing(self) -> None:
+        env = {
+            'GH_TOKEN': 'gh-token',
+            'IMBI_API_KEY': 'imbi-key',
+            'IMBI_HOSTNAME': 'imbi.example.com',
+        }
+        with mock.patch.dict('os.environ', env, clear=True):
+            cfg = Configuration()
+        self.assertIsNone(cfg.jira)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Render `project_key`, `issue_type`, `priority`, `labels`, and `components` through Jinja2 in the `jira` `create_ticket` action so workflows can derive values from `imbi_project` (e.g. map `namespace_slug` → Jira project key). Previously these fields were passed to the Jira client verbatim, causing HTTP 400 `valid project is required` when templated.
- Auto-populate `JiraConfiguration` from `ATLASSIAN_DOMAIN`, `ATLASSIAN_EMAIL`, and `ATLASSIAN_API_KEY` when `config.toml` omits a `[jira]` section. Falls back to `None` when the required env vars are absent, preserving opt-in behavior.

## Motivation

While running the `security-review` workflow against multiple Imbi namespaces, the jira action logged:

```
Failed to create Jira issue in {{ {'ASE':'ASE','CC':'CC', ...}[imbi_project.namespace_slug] }}: HTTP 400 - {"errors":{"project":"valid project is required"}}
```

The workflow.toml expression was being passed through untouched. Separately, setting the Atlassian env vars alone was insufficient — the user had to add a `[jira]` section to `config.toml` to get it recognized.

## Test plan

- [x] uv run python -m pytest tests/actions/test_jira.py tests/test_model_validators.py — 20 passed
- [x] uv run python -m pytest — 814 passed
- [x] New test `test_create_ticket_renders_templated_project_key` verifies `{{ ... }}` in `project_key`/`labels` is rendered before reaching the Jira client.
- [x] New tests cover `JiraConfiguration` populated from env vars (no `[jira]` section) and left `None` when env vars are missing.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>