### PR TITLE
Improve Jira issue-create logging

### DIFF
--- a/src/imbi_automations/clients/jira.py
+++ b/src/imbi_automations/clients/jira.py
@@ -81,13 +81,19 @@ class Jira(http.BaseURLHTTPClient):
         try:
             response.raise_for_status()
         except httpx.HTTPStatusError:
+            safe_fields = dict(fields)
+            if 'description' in safe_fields:
+                safe_fields['description'] = '<redacted>'
+            if 'summary' in safe_fields:
+                safe_fields['summary'] = '<redacted>'
             LOGGER.error(
                 'Failed to create Jira issue in %s: HTTP %d\n'
-                'Request body: %s\nResponse body: %s',
+                'Request body (redacted): %s\n'
+                'Response body (truncated): %s',
                 project_key,
                 response.status_code,
-                json.dumps(body, default=str),
-                response.text,
+                json.dumps({'fields': safe_fields}, default=str),
+                response.text[:2000],
             )
             raise
         return models.JiraIssueCreated.model_validate(response.json())

--- a/src/imbi_automations/clients/jira.py
+++ b/src/imbi_automations/clients/jira.py
@@ -1,6 +1,7 @@
 """Jira Cloud REST API client."""
 
 import base64
+import json
 import logging
 import typing
 
@@ -69,26 +70,24 @@ class Jira(http.BaseURLHTTPClient):
         if extra_fields:
             fields.update(extra_fields)
 
+        body = {'fields': fields}
         LOGGER.debug(
-            'Creating Jira issue in project %s (type=%s)',
+            'POST /rest/api/3/issue (project=%s, type=%s) body=%s',
             project_key,
             issue_type,
+            json.dumps(body, default=str),
         )
-        response = await self.post(
-            '/rest/api/3/issue', json={'fields': fields}
-        )
+        response = await self.post('/rest/api/3/issue', json=body)
         try:
             response.raise_for_status()
         except httpx.HTTPStatusError:
-            try:
-                error_body = response.text
-            except AttributeError, UnicodeDecodeError:
-                error_body = '<unable to read response body>'
             LOGGER.error(
-                'Failed to create Jira issue in %s: HTTP %d - %s',
+                'Failed to create Jira issue in %s: HTTP %d\n'
+                'Request body: %s\nResponse body: %s',
                 project_key,
                 response.status_code,
-                error_body,
+                json.dumps(body, default=str),
+                response.text,
             )
             raise
         return models.JiraIssueCreated.model_validate(response.json())


### PR DESCRIPTION
## Summary
- Logs the full POST body on both the request DEBUG line and the HTTP-error log so failed creates carry enough detail to diagnose without re-running.
- Drops a buggy `except AttributeError, UnicodeDecodeError:` form — in Py3 that binds the second name rather than catching both classes, and `response.text` always returns a string so the fallback was dead anyway.

## Test plan
- [ ] CI green