### PR TITLE
Move test_imbi inline payloads to JSON fixtures

### DIFF
--- a/tests/clients/test_imbi.py
+++ b/tests/clients/test_imbi.py
@@ -12,7 +12,7 @@ import httpx
 from imbi_automations import models
 from imbi_automations.clients import http as ia_http
 from imbi_automations.clients import imbi
-from tests import base
+from tests import base, factories
 
 BASE = 'https://imbi.test.com'
 ORG = 'test-org'
@@ -137,11 +137,7 @@ class ImbiClientAuthTestCase(base.AsyncTestCase):
             [
                 _resp(
                     http.HTTPStatus.OK,
-                    json_body={
-                        'access_token': access_token,
-                        'refresh_token': 'refresh-1',
-                        'token_type': 'bearer',
-                    },
+                    json_body=factories.auth_response(access_token),
                 ),
                 _resp(http.HTTPStatus.OK, json_body=[]),
             ]
@@ -168,20 +164,18 @@ class ImbiClientAuthTestCase(base.AsyncTestCase):
             [
                 _resp(  # login
                     http.HTTPStatus.OK,
-                    json_body={
-                        'access_token': first_access,
-                        'refresh_token': 'refresh-1',
-                        'token_type': 'bearer',
-                    },
+                    json_body=factories.auth_response(
+                        first_access,
+                        refresh_token='refresh-1',  # noqa: S106
+                    ),
                 ),
                 _resp(http.HTTPStatus.UNAUTHORIZED),  # request 1
                 _resp(  # refresh
                     http.HTTPStatus.OK,
-                    json_body={
-                        'access_token': second_access,
-                        'refresh_token': 'refresh-2',
-                        'token_type': 'bearer',
-                    },
+                    json_body=factories.auth_response(
+                        second_access,
+                        refresh_token='refresh-2',  # noqa: S106
+                    ),
                 ),
                 _resp(http.HTTPStatus.OK, json_body=[]),  # request retry
             ]
@@ -208,11 +202,7 @@ class ImbiClientAuthTestCase(base.AsyncTestCase):
             [
                 _resp(
                     http.HTTPStatus.OK,
-                    json_body={
-                        'access_token': access_token,
-                        'refresh_token': 'refresh-1',
-                        'token_type': 'bearer',
-                    },
+                    json_body=factories.auth_response(access_token),
                 ),
                 _resp(http.HTTPStatus.OK, json_body=[]),
             ]
@@ -277,10 +267,7 @@ class ImbiClientReadsTestCase(base.AsyncTestCase):
             [
                 _resp(
                     http.HTTPStatus.OK,
-                    json_body=[
-                        {'name': 'Prod', 'slug': 'production'},
-                        {'name': 'Stage', 'slug': 'staging'},
-                    ],
+                    json_body=factories.load_imbi_fixture('environments.json'),
                 )
             ]
         )
@@ -295,10 +282,9 @@ class ImbiClientReadsTestCase(base.AsyncTestCase):
             [
                 _resp(
                     http.HTTPStatus.OK,
-                    json_body=[
-                        {'name': 'API', 'slug': 'api'},
-                        {'name': 'Consumer', 'slug': 'consumer'},
-                    ],
+                    json_body=factories.load_imbi_fixture(
+                        'project_types.json'
+                    ),
                 )
             ]
         )
@@ -310,13 +296,9 @@ class ImbiClientReadsTestCase(base.AsyncTestCase):
             [
                 _resp(
                     http.HTTPStatus.OK,
-                    json_body=[
-                        {
-                            'name': 'GitHub Repository',
-                            'slug': 'github-repository',
-                            'url_template': None,
-                        }
-                    ],
+                    json_body=factories.load_imbi_fixture(
+                        'link_definitions.json'
+                    ),
                 )
             ]
         )
@@ -412,20 +394,9 @@ class ImbiClientReadsTestCase(base.AsyncTestCase):
             [
                 _resp(
                     http.HTTPStatus.OK,
-                    json_body={
-                        'sections': [
-                            {
-                                'name': 'Tech',
-                                'slug': 'tech',
-                                'properties': {
-                                    'programming_language': {
-                                        'type': 'string',
-                                        'enum': ['Python 3.12', 'Go 1.22'],
-                                    }
-                                },
-                            }
-                        ]
-                    },
+                    json_body=factories.load_imbi_fixture(
+                        'project_schema.json'
+                    ),
                 )
             ]
         )
@@ -535,13 +506,7 @@ class ImbiClientPatchesTestCase(base.AsyncTestCase):
 
     async def test_add_project_link_uses_link_definition_slug(self) -> None:
         project = project_payload(project_id='proj_x')
-        defs = [
-            {
-                'name': 'GitHub Repository',
-                'slug': 'github-repository',
-                'url_template': None,
-            }
-        ]
+        defs = factories.load_imbi_fixture('link_definitions.json')
         client, recorder = self._client(
             [
                 _resp(http.HTTPStatus.OK, json_body=defs),  # link definitions
@@ -679,16 +644,9 @@ class ImbiClientPatchesTestCase(base.AsyncTestCase):
             [
                 _resp(
                     http.HTTPStatus.CREATED,
-                    json_body={
-                        'id': 'doc_x',
-                        'title': 'Release Notes',
-                        'content': 'body',
-                        'created_by': 'gavinr',
-                        'created_at': '2026-05-11T00:00:00+00:00',
-                        'project_id': 'proj_x',
-                        'is_pinned': False,
-                        'tags': [],
-                    },
+                    json_body=factories.load_imbi_fixture(
+                        'document_created.json'
+                    ),
                 )
             ]
         )

--- a/tests/data/imbi/auth_token_response.json
+++ b/tests/data/imbi/auth_token_response.json
@@ -1,0 +1,5 @@
+{
+  "access_token": "",
+  "refresh_token": "",
+  "token_type": "bearer"
+}

--- a/tests/data/imbi/document_created.json
+++ b/tests/data/imbi/document_created.json
@@ -1,0 +1,10 @@
+{
+  "id": "doc_x",
+  "title": "Release Notes",
+  "content": "body",
+  "created_by": "gavinr",
+  "created_at": "2026-05-11T00:00:00+00:00",
+  "project_id": "proj_x",
+  "is_pinned": false,
+  "tags": []
+}

--- a/tests/data/imbi/environments.json
+++ b/tests/data/imbi/environments.json
@@ -1,0 +1,4 @@
+[
+  {"name": "Prod", "slug": "production"},
+  {"name": "Stage", "slug": "staging"}
+]

--- a/tests/data/imbi/link_definitions.json
+++ b/tests/data/imbi/link_definitions.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "GitHub Repository",
+    "slug": "github-repository",
+    "url_template": null
+  }
+]

--- a/tests/data/imbi/project_schema.json
+++ b/tests/data/imbi/project_schema.json
@@ -1,0 +1,14 @@
+{
+  "sections": [
+    {
+      "name": "Tech",
+      "slug": "tech",
+      "properties": {
+        "programming_language": {
+          "type": "string",
+          "enum": ["Python 3.12", "Go 1.22"]
+        }
+      }
+    }
+  ]
+}

--- a/tests/data/imbi/project_types.json
+++ b/tests/data/imbi/project_types.json
@@ -1,0 +1,4 @@
+[
+  {"name": "API", "slug": "api"},
+  {"name": "Consumer", "slug": "consumer"}
+]

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,9 +2,29 @@
 
 from __future__ import annotations
 
+import json
+import pathlib
 import typing
 
 from imbi_automations import models
+
+_FIXTURES = pathlib.Path(__file__).parent / 'data' / 'imbi'
+
+
+def load_imbi_fixture(name: str) -> typing.Any:
+    """Return the parsed JSON fixture at ``tests/data/imbi/<name>``."""
+    return json.loads((_FIXTURES / name).read_text())
+
+
+def auth_response(
+    access_token: str,
+    refresh_token: str = 'refresh-1',  # noqa: S107
+) -> dict[str, typing.Any]:
+    """Return an ``auth_token_response.json`` fixture with tokens filled in."""
+    payload = load_imbi_fixture('auth_token_response.json')
+    payload['access_token'] = access_token
+    payload['refresh_token'] = refresh_token
+    return payload
 
 
 def make_project(

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -13,7 +13,7 @@ _FIXTURES = pathlib.Path(__file__).parent / 'data' / 'imbi'
 
 def load_imbi_fixture(name: str) -> typing.Any:
     """Return the parsed JSON fixture at ``tests/data/imbi/<name>``."""
-    return json.loads((_FIXTURES / name).read_text())
+    return json.loads((_FIXTURES / name).read_text(encoding='utf-8'))
 
 
 def auth_response(


### PR DESCRIPTION
## Summary

Follow-up to #118 (CodeRabbit thread `r3227359989`, deferred at `r3227410656` to keep the API-migration diff focused).

Extracts fixed-shape inline HTTP response payloads in `tests/clients/test_imbi.py` to `tests/data/imbi/*.json`, loaded through a new `load_imbi_fixture` helper in `tests/factories.py`. The existing `project_payload()` factory is unchanged — it stays the canonical in-memory builder for `ProjectResponse` permutations (`identifiers=`, `links=`, `project_type_slugs=`, `extras=`), as suggested by the followup design note.

Auth payloads use a small `auth_response(access_token, refresh_token=...)` helper that loads `auth_token_response.json` and substitutes the tokens, so the JWT generation in `_make_jwt()` stays put.

## What changed

- New fixtures under `tests/data/imbi/`:
  - `environments.json`, `project_types.json`, `link_definitions.json`
  - `project_schema.json`, `document_created.json`
  - `auth_token_response.json` (token-slot template)
- New helpers in `tests/factories.py`:
  - `load_imbi_fixture(name)` — reads a fixture file
  - `auth_response(access_token, refresh_token='refresh-1')` — substitutes tokens into the auth fixture
- `tests/clients/test_imbi.py` reads from the fixtures; the `_Recorder` / `_resp` test scaffolding is unchanged
- `link_definitions.json` is reused by `test_get_link_definitions` and `test_add_project_link_uses_link_definition_slug`

## What did NOT change

- `project_payload()` remains the source of truth for project-shaped payloads (per the followup spec — too many call sites with overrides to be worth materializing)
- `tests/base.py`'s path-based fixture autoloader is untouched (Imbi tests need an ordered queue of responses, not URL-keyed lookup)
- `tests/factories.py:make_project` is untouched

## Test plan

- [x] `uv run --frozen --no-sync pytest --no-cov tests/clients/test_imbi.py` — 28 passed
- [x] `uv run --frozen --no-sync pytest --no-cov` — 779 passed (full suite)
- [x] `uv run --frozen --no-sync ruff check src tests` — clean

Closes the followup tracked at `docs/followup-test-imbi-fixtures.md`.