### PR TITLE
Fix ImbiProject.relationships model to match API response shape

### DIFF
--- a/src/imbi_automations/models/__init__.py
+++ b/src/imbi_automations/models/__init__.py
@@ -54,6 +54,7 @@ from .imbi import (
     ImbiProjectSchema,
     ImbiProjectType,
     ImbiRelationshipLink,
+    ImbiRelationships,
     ImbiTeam,
 )
 from .jira import JiraIssueCreated
@@ -146,6 +147,7 @@ __all__ = [
     'ImbiProjectSchema',
     'ImbiProjectType',
     'ImbiRelationshipLink',
+    'ImbiRelationships',
     'ImbiTeam',
     'JiraConfiguration',
     'JiraIssueCreated',

--- a/src/imbi_automations/models/imbi.py
+++ b/src/imbi_automations/models/imbi.py
@@ -88,6 +88,14 @@ class ImbiRelationshipLink(base.BaseModel):
     count: int = 0
 
 
+class ImbiRelationships(base.BaseModel):
+    """Project relationship summary returned by the Imbi API."""
+
+    href: str
+    outbound_count: int = 0
+    inbound_count: int = 0
+
+
 class ImbiProject(base.BaseModel):
     """Imbi project.
 
@@ -113,7 +121,7 @@ class ImbiProject(base.BaseModel):
     links: dict[str, pydantic.AnyUrl] = {}
     identifiers: dict[str, int | str] = {}
     score: float | None = None
-    relationships: dict[str, ImbiRelationshipLink] | None = None
+    relationships: ImbiRelationships | None = None
 
 
 class ImbiDocument(base.BaseModel):


### PR DESCRIPTION
The API returns relationships as a flat object with href, outbound_count, and inbound_count fields. The model had it typed as dict[str, ImbiRelationshipLink] which caused a ValidationError on every project fetch.

Adds ImbiRelationships to hold the actual shape and updates ImbiProject.relationships accordingly.