### PR TITLE
Add uv 7-day holdback for third-party packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,3 +148,7 @@ docs = [
   "mkdocstrings-python-xref>=1.6,<3",
   "mkdocstrings[python]>=0.26,<1.1",
 ]
+
+[tool.uv]
+exclude-newer = "7 days"
+exclude-newer-package = { "imbi-common" = false, "imbi-plugin-aws" = false, "imbi-plugin-github" = false, "imbi-plugin-logzio" = false, "imbi-plugin-oidc" = false, "imbi-plugin-pagerduty" = false, "imbi-plugin-sentry" = false, "imbi-plugin-sonarqube" = false }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,4 +151,4 @@ docs = [
 
 [tool.uv]
 exclude-newer = "7 days"
-exclude-newer-package = { "imbi-common" = false, "imbi-plugin-aws" = false, "imbi-plugin-github" = false, "imbi-plugin-logzio" = false, "imbi-plugin-oidc" = false, "imbi-plugin-pagerduty" = false, "imbi-plugin-sentry" = false, "imbi-plugin-sonarqube" = false }
+exclude-newer-package = { "clickhouse-connect" = false, "imbi-common" = false, "imbi-plugin-aws" = false, "imbi-plugin-github" = false, "imbi-plugin-logzio" = false, "imbi-plugin-oidc" = false, "imbi-plugin-pagerduty" = false, "imbi-plugin-sentry" = false, "imbi-plugin-sonarqube" = false }


### PR DESCRIPTION
## Summary
- Sets `tool.uv.exclude-newer = "7 days"` to defer installing recently-published versions, as supply-chain hardening
- Exempts internal imbi packages (imbi-common, imbi-plugin-*) including forthcoming sentry/pagerduty/sonarqube plugins so cross-repo work isn't blocked

## Test plan
- [ ] `uv sync` succeeds against the lockfile
- [ ] No unintended dependency downgrades