### PR TITLE
Add documentation link to --help output

### DIFF
--- a/src/imbi_automations/cli.py
+++ b/src/imbi_automations/cli.py
@@ -125,6 +125,8 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
     """
     parser = argparse.ArgumentParser(
         description='Imbi Automations',
+        epilog='For full documentation visit '
+        'https://aweber-imbi.github.io/imbi-automations/',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.register('type', 'workflow', workflow)


### PR DESCRIPTION
Show the URL to the docs at the end of `--help`. This should help agents when configuring and creating workflows.