### PR TITLE
Add generic imbi `request` action for full-API reach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,10 +62,29 @@ uv run pre-commit run --all-files      # All hooks
 | `file` | `filea.py` | Copy/move/delete with glob support |
 | `git` | `git.py` | Extract files from history, branch ops |
 | `github` | `github.py` | Environment sync, repository updates |
-| `imbi` | `imbi.py` | Project facts, links, notes, type management |
+| `imbi` | `imbi.py` | Project facts, links, notes, type management, generic `request` escape hatch |
 | `jira` | `jira.py` | Create Jira tickets via agentic Claude session |
 | `shell` | `shell.py` | Command execution with Jinja2 |
 | `template` | `template.py` | Jinja2 file generation |
+
+### Imbi `request` escape hatch
+
+`command = "request"` reaches any Imbi API endpoint without a dedicated
+command. `method` + `path` are required; `path` is org-scoped (a bare path
+resolves under `/api/organizations/{org}/`, an `/api/...` path hits the host
+root). `path`/`query`/`body` are Jinja2-rendered; the JSON response is captured
+into `variable_name`. Mutating methods require `allow_writes = true`.
+
+```toml
+[[actions]]
+name = "load-doc-templates"
+type = "imbi"
+command = "request"
+method = "GET"
+path = "document-templates/"
+query = { project_type = "{{ imbi_project.project_types[0].slug }}" }
+variable_name = "doc_templates"
+```
 
 ## Workflow Configuration
 

--- a/docs/actions/imbi.md
+++ b/docs/actions/imbi.md
@@ -339,9 +339,9 @@ variable_name = "doc_templates"
 **Fields:**
 
 - `method` (string, required): HTTP method (`GET`, `POST`, `PATCH`, `DELETE`, etc.).
-- `path` (string, required): Request path, Jinja2-templated. A bare path is **org-scoped** (resolved under `/api/organizations/{org}/`); a path beginning with `/api/` hits the host root; an absolute URL is used verbatim.
+- `path` (string, required): Request path, Jinja2-templated. A bare path is **org-scoped** (resolved under `/api/organizations/{org}/`); a path beginning with `/api/` hits the host root. Absolute URLs are rejected so the bearer token is never sent to an arbitrary host.
 - `query` (table, optional): Query-string parameters; values are Jinja2-templated.
-- `body` (table or array, optional): JSON request body; string leaves are Jinja2-templated.
+- `body` (any JSON value, optional): JSON request body — a table, array, or scalar (string/number/boolean/null); string leaves are Jinja2-templated.
 - `allow_writes` (boolean, optional, default `false`): Required to be `true` for any method other than `GET`/`HEAD`. Guards against unintended mutations.
 - `variable_name` (string, optional): Captures the parsed JSON response into `variables.<name>` for later actions (`{{ variables.doc_templates }}`). A `204`/empty response captures `None`.
 

--- a/docs/actions/imbi.md
+++ b/docs/actions/imbi.md
@@ -320,6 +320,41 @@ Performed against commit `{{ starting_commit }}`.
 
 **Note:** Each invocation creates a new note. If you want a single evolving note, read + update via the API directly rather than appending with this action.
 
+### request
+
+Generic escape hatch that reaches any Imbi API endpoint without a dedicated command. Use it for endpoints that don't have a purpose-built command yet (for example, retrieving document/note templates).
+
+**Configuration:**
+```toml
+[[actions]]
+name = "load-doc-templates"
+type = "imbi"
+command = "request"
+method = "GET"
+path = "document-templates/"
+query = { project_type = "{{ imbi_project.project_types[0].slug }}" }
+variable_name = "doc_templates"
+```
+
+**Fields:**
+
+- `method` (string, required): HTTP method (`GET`, `POST`, `PATCH`, `DELETE`, etc.).
+- `path` (string, required): Request path, Jinja2-templated. A bare path is **org-scoped** (resolved under `/api/organizations/{org}/`); a path beginning with `/api/` hits the host root; an absolute URL is used verbatim.
+- `query` (table, optional): Query-string parameters; values are Jinja2-templated.
+- `body` (table or array, optional): JSON request body; string leaves are Jinja2-templated.
+- `allow_writes` (boolean, optional, default `false`): Required to be `true` for any method other than `GET`/`HEAD`. Guards against unintended mutations.
+- `variable_name` (string, optional): Captures the parsed JSON response into `variables.<name>` for later actions (`{{ variables.doc_templates }}`). A `204`/empty response captures `None`.
+
+**Authentication, refresh, and org scoping are identical to every other Imbi action** — the request rides the same authenticated client.
+
+**Use Cases:**
+
+- Read endpoints that have no dedicated command (e.g. `document-templates/`)
+- One-off writes during a workflow (with `allow_writes = true`)
+- Capturing API data into a variable to drive later actions or conditions
+
+**Note:** Prefer a dedicated command when one exists — they validate inputs more strictly. Reach for `request` for the long tail.
+
 ### update_project_type
 
 Changes the project type classification.
@@ -523,6 +558,7 @@ fact_value = "FastAPI"
 | `batch_update_facts` | Update multiple facts in a single operation |
 | `delete_project_fact` | Remove obsolete project facts |
 | `get_project_fact` | Retrieve fact values for conditional logic |
+| `request` | Generic escape hatch to any Imbi API endpoint (read by default; writes need `allow_writes`) |
 | `set_environments` | Update project environments with smart validation |
 | `set_project_fact` | Update or create project facts with validation |
 | `update_project` | Update any project attributes with template support |

--- a/src/imbi_automations/actions/imbi.py
+++ b/src/imbi_automations/actions/imbi.py
@@ -46,6 +46,8 @@ class ImbiActions(mixins.WorkflowLoggerMixin):
                 await self._delete_project_fact(action)
             case models.WorkflowImbiActionCommand.get_project_fact:
                 await self._get_project_fact(action)
+            case models.WorkflowImbiActionCommand.request:
+                await self._request_passthrough(action)
             case models.WorkflowImbiActionCommand.set_project_fact:
                 await self._set_project_fact(action)
             case models.WorkflowImbiActionCommand.set_environments:
@@ -82,6 +84,16 @@ class ImbiActions(mixins.WorkflowLoggerMixin):
             starting_commit=self.context.starting_commit,
             variables=self.context.variables,
         )
+
+    def _render_body(self, value: typing.Any) -> typing.Any:
+        """Recursively render Jinja2 in string leaves of a request body."""
+        if isinstance(value, str):
+            return self._render(value)
+        if isinstance(value, dict):
+            return {key: self._render_body(val) for key, val in value.items()}
+        if isinstance(value, list):
+            return [self._render_body(item) for item in value]
+        return value
 
     # -- Commands -------------------------------------------------------
 
@@ -399,6 +411,36 @@ class ImbiActions(mixins.WorkflowLoggerMixin):
             document.id,
             self._project_id(),
         )
+
+    async def _request_passthrough(
+        self, action: models.WorkflowImbiAction
+    ) -> None:
+        if not action.method or not action.path:
+            raise ValueError("'method' and 'path' are required for request")
+        method = action.method.upper()
+        if method not in {'GET', 'HEAD'} and not action.allow_writes:
+            raise ValueError(
+                f'{action.name}: {method} requires allow_writes = true'
+            )
+        path = self._render(action.path)
+        params = {
+            key: self._render(val) for key, val in action.query.items()
+        } or None
+        body = self._render_body(action.body)
+        self.logger.debug(
+            '%s [%s/%s] %s request %s %s',
+            self.context.imbi_project.slug,
+            self.context.current_action_index,
+            self.context.total_actions,
+            action.name,
+            method,
+            path,
+        )
+        result = await self._client().request_json(
+            method, path, params=params, json=body
+        )
+        if action.variable_name:
+            self.context.variables[action.variable_name] = result
 
     async def _update_project_type(
         self, action: models.WorkflowImbiAction

--- a/src/imbi_automations/clients/imbi.py
+++ b/src/imbi_automations/clients/imbi.py
@@ -261,9 +261,15 @@ class Imbi(http.BaseURLHTTPClient):
         Powers the workflow ``request`` escape-hatch action. Path
         resolution and auth follow the same rules as every other client
         call (see :meth:`_url_for` and :meth:`_request`): a bare path is
-        org-scoped, an ``/api/`` path hits the host root, and an absolute
-        URL is used verbatim.
+        org-scoped and an ``/api/`` path hits the host root. Absolute
+        URLs are rejected so the bearer token is never sent to an
+        arbitrary host.
         """
+        if path.startswith(('http://', 'https://')):
+            raise ValueError(
+                'request_json only supports Imbi-relative paths, not '
+                f'absolute URLs: {path}'
+            )
         response = await self._request(method, path, params=params, json=json)
         response.raise_for_status()
         if response.status_code == 204 or not response.content:

--- a/src/imbi_automations/clients/imbi.py
+++ b/src/imbi_automations/clients/imbi.py
@@ -76,7 +76,7 @@ def _decode_jwt_exp(token: str) -> datetime.datetime | None:
         payload = json.loads(
             base64.urlsafe_b64decode(payload_b64 + padding).decode('utf-8')
         )
-    except (ValueError, UnicodeDecodeError):
+    except ValueError, UnicodeDecodeError:
         return None
     exp = payload.get('exp')
     if not isinstance(exp, (int, float)):
@@ -247,6 +247,28 @@ class Imbi(http.BaseURLHTTPClient):
         if path.startswith('/api/'):
             return f'{self._base_url}{path}'
         return f'{self.org_base}/{path.lstrip("/")}'
+
+    async def request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, typing.Any] | None = None,
+        json: typing.Any = None,
+    ) -> typing.Any:
+        """Issue a generic request and return parsed JSON (or ``None``).
+
+        Powers the workflow ``request`` escape-hatch action. Path
+        resolution and auth follow the same rules as every other client
+        call (see :meth:`_url_for` and :meth:`_request`): a bare path is
+        org-scoped, an ``/api/`` path hits the host root, and an absolute
+        URL is used verbatim.
+        """
+        response = await self._request(method, path, params=params, json=json)
+        response.raise_for_status()
+        if response.status_code == 204 or not response.content:
+            return None
+        return response.json()
 
     # -- Reads ----------------------------------------------------------
 

--- a/src/imbi_automations/models/workflow.py
+++ b/src/imbi_automations/models/workflow.py
@@ -525,6 +525,7 @@ class WorkflowImbiActionCommand(enum.StrEnum):
     batch_update_facts = 'batch_update_facts'
     delete_project_fact = 'delete_project_fact'
     get_project_fact = 'get_project_fact'
+    request = 'request'
     set_environments = 'set_environments'
     set_project_fact = 'set_project_fact'
     update_project = 'update_project'
@@ -556,6 +557,11 @@ class WorkflowImbiAction(validators.CommandRulesMixin, WorkflowAction):
     content: str | None = None
     tags: list[str] = []
     project_types: list[str] = []
+    method: str | None = None
+    path: str | None = None
+    body: dict[str, typing.Any] | list[typing.Any] | None = None
+    query: dict[str, str] = {}
+    allow_writes: bool = False
 
     # CommandRulesMixin configuration
     command_field: typing.ClassVar[str] = 'command'
@@ -568,6 +574,7 @@ class WorkflowImbiAction(validators.CommandRulesMixin, WorkflowAction):
         WorkflowImbiActionCommand.batch_update_facts: {'facts'},
         WorkflowImbiActionCommand.delete_project_fact: {'attribute_name'},
         WorkflowImbiActionCommand.get_project_fact: {'attribute_name'},
+        WorkflowImbiActionCommand.request: {'method', 'path'},
         WorkflowImbiActionCommand.set_environments: {'values'},
         WorkflowImbiActionCommand.set_project_fact: {
             'attribute_name',
@@ -596,6 +603,14 @@ class WorkflowImbiAction(validators.CommandRulesMixin, WorkflowAction):
         },
         WorkflowImbiActionCommand.get_project_fact: {
             'attribute_name',
+            'variable_name',
+        },
+        WorkflowImbiActionCommand.request: {
+            'method',
+            'path',
+            'body',
+            'query',
+            'allow_writes',
             'variable_name',
         },
         WorkflowImbiActionCommand.set_environments: {'values'},

--- a/src/imbi_automations/models/workflow.py
+++ b/src/imbi_automations/models/workflow.py
@@ -559,7 +559,7 @@ class WorkflowImbiAction(validators.CommandRulesMixin, WorkflowAction):
     project_types: list[str] = []
     method: str | None = None
     path: str | None = None
-    body: dict[str, typing.Any] | list[typing.Any] | None = None
+    body: typing.Any = None
     query: dict[str, str] = {}
     allow_writes: bool = False
 

--- a/tests/actions/test_imbi.py
+++ b/tests/actions/test_imbi.py
@@ -6,6 +6,7 @@ import unittest
 from unittest import mock
 
 import httpx
+import pydantic
 
 from imbi_automations import models
 from imbi_automations.actions import imbi as imbi_actions
@@ -408,6 +409,93 @@ class ImbiActionsTestCase(base.AsyncTestCase):
         )
         with self.assertRaises(ValueError):
             await self.imbi_executor.execute(action)
+
+    # -- request -------------------------------------------------------
+
+    @mock.patch('imbi_automations.clients.Imbi.get_instance')
+    async def test_request_get_captures_response(
+        self, mock_get_instance: mock.MagicMock
+    ) -> None:
+        client = mock.AsyncMock()
+        client.request_json.return_value = [{'slug': 'runbook'}]
+        mock_get_instance.return_value = client
+        action = models.WorkflowImbiAction(
+            name='load-templates',
+            type='imbi',
+            command='request',
+            method='GET',
+            path='document-templates/',
+            query={'project_type': '{{ imbi_project.project_types[0].slug }}'},
+            variable_name='templates',
+        )
+        await self.imbi_executor.execute(action)
+        client.request_json.assert_awaited_once_with(
+            'GET',
+            'document-templates/',
+            params={'project_type': 'api'},
+            json=None,
+        )
+        self.assertEqual(
+            self.context.variables.get('templates'), [{'slug': 'runbook'}]
+        )
+
+    @mock.patch('imbi_automations.clients.Imbi.get_instance')
+    async def test_request_post_renders_body_with_allow_writes(
+        self, mock_get_instance: mock.MagicMock
+    ) -> None:
+        client = mock.AsyncMock()
+        client.request_json.return_value = {'id': 'doc_1'}
+        mock_get_instance.return_value = client
+        action = models.WorkflowImbiAction(
+            name='create-doc',
+            type='imbi',
+            command='request',
+            method='post',
+            path='projects/{{ imbi_project.id }}/documents/',
+            body={
+                'title': '{{ imbi_project.name }}',
+                'content': 'body',
+                'tags': ['auto'],
+            },
+            allow_writes=True,
+        )
+        await self.imbi_executor.execute(action)
+        client.request_json.assert_awaited_once_with(
+            'POST',
+            'projects/proj_123/documents/',
+            params=None,
+            json={
+                'title': 'Test Project',
+                'content': 'body',
+                'tags': ['auto'],
+            },
+        )
+
+    @mock.patch('imbi_automations.clients.Imbi.get_instance')
+    async def test_request_write_without_allow_writes_raises(
+        self, mock_get_instance: mock.MagicMock
+    ) -> None:
+        client = mock.AsyncMock()
+        mock_get_instance.return_value = client
+        action = models.WorkflowImbiAction(
+            name='danger',
+            type='imbi',
+            command='request',
+            method='DELETE',
+            path='document-templates/runbook',
+        )
+        with self.assertRaises(ValueError):
+            await self.imbi_executor.execute(action)
+        client.request_json.assert_not_awaited()
+
+    def test_request_requires_method_and_path(self) -> None:
+        with self.assertRaises(pydantic.ValidationError):
+            models.WorkflowImbiAction(
+                name='bad',
+                type='imbi',
+                command='request',
+                path='document-templates/',
+            )
 
 
 if __name__ == '__main__':

--- a/tests/clients/test_imbi.py
+++ b/tests/clients/test_imbi.py
@@ -277,6 +277,26 @@ class ImbiClientReadsTestCase(base.AsyncTestCase):
             str(recorder.requests[0].url), f'{ORG_BASE}/environments/'
         )
 
+    async def test_request_json_org_scoped_with_params(self) -> None:
+        client, recorder = self._client(
+            [_resp(http.HTTPStatus.OK, json_body=[{'slug': 'runbook'}])]
+        )
+        result = await client.request_json(
+            'GET', 'document-templates/', params={'project_type': 'api'}
+        )
+        self.assertEqual(result, [{'slug': 'runbook'}])
+        self.assertEqual(
+            str(recorder.requests[0].url),
+            f'{ORG_BASE}/document-templates/?project_type=api',
+        )
+
+    async def test_request_json_204_returns_none(self) -> None:
+        client, _ = self._client([_resp(http.HTTPStatus.NO_CONTENT)])
+        result = await client.request_json(
+            'DELETE', 'document-templates/runbook'
+        )
+        self.assertIsNone(result)
+
     async def test_get_project_types(self) -> None:
         client, _ = self._client(
             [

--- a/tests/clients/test_imbi.py
+++ b/tests/clients/test_imbi.py
@@ -297,6 +297,13 @@ class ImbiClientReadsTestCase(base.AsyncTestCase):
         )
         self.assertIsNone(result)
 
+    async def test_request_json_rejects_absolute_url(self) -> None:
+        client, recorder = self._client([])
+        for url in ('http://evil.example.com/steal', 'https://evil/steal'):
+            with self.assertRaisesRegex(ValueError, 'Imbi-relative paths'):
+                await client.request_json('GET', url)
+        self.assertEqual(len(recorder.requests), 0)
+
     async def test_get_project_types(self) -> None:
         client, _ = self._client(
             [


### PR DESCRIPTION
## Summary

Adds a generic `request` command to the `imbi` action type — a Jinja2-templated
HTTP escape hatch over the existing org-scoped Imbi client. Workflows can now
reach **any** Imbi API endpoint (e.g. retrieving document/note templates)
without a hand-written client method and a dedicated `WorkflowImbiActionCommand`
per route.

This is **Phase 1** of the runtime OpenAPI-client exploration. The full design —
including the Phase 2 runtime `OperationRegistry` (built from the live
`/openapi.json` via `fastmcp.utilities.openapi`, blueprint-aware, validated with
`jsonschema`) and the agentic `imbi-mcp`-reuse path — is written up in the
orchestrator repo at `docs/imbi-automations-openapi-runtime-client-functional-spec.md`.

## Problem

The `imbi` action exposes a curated set of commands, each backed by a bespoke
client method. The Imbi API surface (and its per-org, blueprint-extended schema)
is far larger; anything without a dedicated command — e.g. `GET
/document-templates/` — is simply unreachable from a workflow.

## Solution

- **`clients.Imbi.request_json`** — thin public wrapper over the existing
  `_request` primitive, so it inherits bearer auth, 401-refresh, and `_url_for`
  org scoping. Returns parsed JSON, or `None` for `204`/empty bodies.
- **`WorkflowImbiAction`** — new `request` command with
  `method`/`path`/`body`/`query`/`allow_writes` fields and `CommandRulesMixin`
  rules (`method`+`path` required, enforced at workflow **load time**).
- **`_request_passthrough`** — renders `path`/`query`/`body` through Jinja2,
  gates mutating methods behind `allow_writes`, and captures the JSON response
  into `variable_name`.

The write-gate defaults to a `GET`/`HEAD` allowlist so an authored (or
LLM-authored) workflow cannot `DELETE` through the escape hatch unintentionally.

```toml
[[actions]]
name = "load-doc-templates"
type = "imbi"
command = "request"
method = "GET"
path = "document-templates/"
query = { project_type = "{{ imbi_project.project_types[0].slug }}" }
variable_name = "doc_templates"
```

## Tests

- Action-level: GET capture into a variable, POST body Jinja rendering with
  `allow_writes`, write-gate rejection, and `method`/`path` model validation.
- Client-level: org-scoped path + params, and `204` → `None`.

Full suite: `785 passed`; `ruff check .` clean.