### PR TITLE
Fix fenced code blocks not rendering in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,7 +67,6 @@ extra_css:
 
 markdown_extensions:
   - admonition
-  - codehilite
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.inlinehilite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,10 @@ docs = [
   "mkdocs-material>9.5,<10",
   "mkdocstrings-python-xref>=1.6,<3",
   "mkdocstrings[python]>=0.26,<1.1",
+  # 10.21.3 stops passing filename=None to Pygments' HtmlFormatter, which
+  # crashes on Pygments >=2.19 (html.escape(None)) and breaks fenced code
+  # rendering. Keep this floor until the transitive pin is >= this.
+  "pymdown-extensions>=10.21.3",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,21 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+imbi-common = false
+imbi-plugin-pagerduty = false
+imbi-plugin-github = false
+imbi-plugin-logzio = false
+imbi-plugin-aws = false
+imbi-plugin-sonarqube = false
+clickhouse-connect = false
+imbi-plugin-sentry = false
+imbi-plugin-oidc = false
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -586,6 +601,7 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mkdocstrings-python-xref" },
+    { name = "pymdown-extensions" },
 ]
 
 [package.metadata]
@@ -624,6 +640,7 @@ docs = [
     { name = "mkdocs-material", specifier = ">9.5,<10" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26,<1.1" },
     { name = "mkdocstrings-python-xref", specifier = ">=1.6,<3" },
+    { name = "pymdown-extensions", specifier = ">=10.21.3" },
 ]
 
 [[package]]
@@ -1236,15 +1253,15 @@ crypto = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fenced code blocks were rendering as literal ```` ``` ```` text across the
published docs site — `#` comments inside blocks became headings and TOML
reflowed into paragraphs (see the Workflow Configuration page).

## Problem

Two compounding causes, both reproduced locally with `mkdocs build`:

1. **`codehilite` + `pymdownx.highlight` both enabled.** Material's docs say
   these must not be combined; together they break `superfences`, so fences are
   never converted to code blocks (build "succeeds" but emits literal `` ``` ``).
2. With `codehilite` removed, `pymdownx.highlight` **10.21** then crashes
   Pygments **2.20**: it passes `filename=title` (which is `None` for an
   untitled block), and Pygments ≥2.19 calls `html.escape(None)` →
   `AttributeError: 'NoneType' object has no attribute 'replace'`.

## Solution

- Remove `codehilite` from `mkdocs.yml` (keep `pymdownx.highlight` +
  `pymdownx.superfences`, the supported combination).
- Floor `pymdown-extensions>=10.21.3` (the patch that stops passing
  `filename=None`) and relock. The lock now resolves `10.21 → 10.21.3`.

## Verification

`uv run --group docs mkdocs build`:

| Page | Before | After |
|---|---|---|
| `workflow-configuration` | 0 code blocks, 38 leaked `` ``` `` | **41 code blocks, 0 leaked** |
| `actions/imbi` | leaked | 0 leaked |

Docs-only change; no application code touched.