### PR TITLE
Bump version to 2.0.0b1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "imbi-automations"
-version = "2.0.0a1"
+version = "2.0.0b1"
 description = "CLI tool for executing automated workflows across Imbi projects with AI-powered transformations and GitHub PR integration."
 authors = [
   {name = "Gavin M. Roy", email = "gavinr@aweber.com"},
@@ -20,7 +20,7 @@ keywords = [
   "llm",
 ]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Environment :: Console",
   "Intended Audience :: System Administrators",
   "License :: OSI Approved :: BSD License",

--- a/uv.lock
+++ b/uv.lock
@@ -564,7 +564,7 @@ wheels = [
 
 [[package]]
 name = "imbi-automations"
-version = "2.0.0a1"
+version = "2.0.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic", extra = ["bedrock"] },


### PR DESCRIPTION
## Summary

Bumps the package version from `2.0.0a1` to `2.0.0b1` (PEP 440 beta 1) and advances the development-status trove classifier to match.

## Changes

- `pyproject.toml`: `version` `2.0.0a1` → `2.0.0b1`
- `pyproject.toml`: `Development Status :: 3 - Alpha` → `Development Status :: 4 - Beta`
- `uv.lock`: records the new self-version for the editable package

Verified the version resolves via package metadata as `2.0.0b1`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>