### PR TITLE
Abort entrypoint when an init shell script fails

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -74,10 +74,13 @@ if [ -d "$INIT_DIR" ] && [ "$(ls -A $INIT_DIR 2>/dev/null)" ]; then
         pip install --user --no-cache-dir -r "$f" >> /opt/logs/entrypoint.log 2>&1
     done
 
-    # Run shell scripts
+    # Run shell scripts (abort the entrypoint if any script fails)
     for f in $SH_FILES; do
         echo "Running script: $f"
-        bash "$f"
+        if ! bash "$f"; then
+            echo "Error: initialization script failed: $f" >&2
+            exit 1
+        fi
     done
 
     echo "Initialization complete."


### PR DESCRIPTION
## Summary

`/docker-entrypoint-init.d/*.sh` scripts were run with a bare `bash "$f"`. With `set -e` a failure would abort, but **silently** — no indication of which script failed. This makes the failure explicit.

## Change

```bash
# Run shell scripts (abort the entrypoint if any script fails)
for f in $SH_FILES; do
    echo "Running script: $f"
    if ! bash "$f"; then
        echo "Error: initialization script failed: $f" >&2
        exit 1
    fi
done
```

On a non-zero exit the entrypoint logs the offending script to stderr and exits `1`, so the container fails fast with an actionable message.

## Verification

- `bash -n docker-entrypoint.sh` passes.
- `shellcheck` reports no new findings on the changed lines (pre-existing warnings elsewhere left untouched).