### PR TITLE
Add configurable Claude reasoning effort

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,6 +270,28 @@ Available models include:
 - `claude-sonnet-4-5` - Balanced performance
 - `claude-opus-4-5` - Most capable
 
+### [claude].effort
+
+Reasoning effort for Claude Code SDK operations. Higher effort spends more of
+the model's reasoning budget for deeper analysis at the cost of speed.
+
+**Type:** `string`
+**Default:** `high`
+**Environment Variable:** `CLAUDE_EFFORT`
+
+```toml
+[claude]
+effort = "high"
+```
+
+Available levels:
+
+- `low` - Minimal thinking, fastest responses
+- `medium` - Moderate thinking
+- `high` - Deep reasoning (default)
+- `xhigh` - Extended reasoning (Opus 4.7 only; falls back to `high` on other models)
+- `max` - Maximum effort
+
 ### [claude].base_prompt
 
 Custom base prompt file for Claude Code sessions.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -51,11 +51,13 @@ Environment variables for Claude Agent SDK integration.
 | `CLAUDE_BASE_PROMPT` | path | (built-in) | Custom base prompt file path |
 | `CLAUDE_ENABLED` | boolean | `true` | Enable Claude Code actions |
 | `CLAUDE_MODEL` | string | `claude-haiku-4-5` | Model for Claude Agent SDK |
+| `CLAUDE_EFFORT` | string | `high` | Reasoning effort (`low`, `medium`, `high`, `xhigh`, `max`) |
 
 **Example:**
 ```bash
 export CLAUDE_EXECUTABLE="/usr/local/bin/claude"
 export CLAUDE_MODEL="claude-sonnet-4-5"
+export CLAUDE_EFFORT="high"
 export CLAUDE_ENABLED="true"
 ```
 

--- a/src/imbi_automations/claude.py
+++ b/src/imbi_automations/claude.py
@@ -649,6 +649,7 @@ class Claude(mixins.WorkflowLoggerMixin):
         options = claude_agent_sdk.ClaudeAgentOptions(
             allowed_tools=allowed_tools,
             cwd=cwd or self.context.working_directory,
+            effort=self.configuration.claude.effort,
             mcp_servers=mcp_servers,
             model=self.configuration.claude.model,
             plugins=sdk_plugins,
@@ -793,6 +794,7 @@ class Claude(mixins.WorkflowLoggerMixin):
                 'mcp__agent_tools__submit_agent_response',
             ],
             cwd=self.context.working_directory / 'repository',
+            effort=self.configuration.claude.effort,
             mcp_servers=mcp_servers,
             model=self.configuration.claude.model,
             plugins=sdk_plugins,

--- a/src/imbi_automations/models/configuration.py
+++ b/src/imbi_automations/models/configuration.py
@@ -43,8 +43,12 @@ class ClaudeAgentConfiguration(pydantic_settings.BaseSettings):
     """Claude Agent SDK configuration.
 
     Configures the Claude Agent SDK executable path, base prompt file, model
-    selection, whether AI-powered transformations are enabled, and
-    marketplace/plugin settings.
+    selection, reasoning effort, whether AI-powered transformations are
+    enabled, and marketplace/plugin settings.
+
+    ``effort`` controls the reasoning budget: ``low`` (fastest), ``medium``,
+    ``high`` (default, deep reasoning), ``xhigh`` (Opus 4.7 only; falls back
+    to ``high`` on other models), or ``max``.
 
     Plugin configuration supports:
     - enabled_plugins: Map of "plugin@marketplace" to enabled state
@@ -74,6 +78,7 @@ class ClaudeAgentConfiguration(pydantic_settings.BaseSettings):
     base_prompt: pathlib.Path | None = None
     enabled: bool = True
     model: str = pydantic.Field(default='claude-haiku-4-5')
+    effort: typing.Literal['low', 'medium', 'high', 'xhigh', 'max'] = 'high'
     plugins: claude_models.ClaudePluginConfig = pydantic.Field(
         default_factory=claude_models.ClaudePluginConfig
     )

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -497,6 +497,29 @@ class ClaudeTestCase(base.AsyncTestCase):
         self.assertIsNone(claude_instance._client)
         mock_client_class.assert_not_called()
 
+    @mock.patch('claude_agent_sdk.ClaudeAgentOptions')
+    @mock.patch('claude_agent_sdk.ClaudeSDKClient')
+    @mock.patch(
+        'builtins.open',
+        new_callable=mock.mock_open,
+        read_data='Mock system prompt',
+    )
+    def test_create_client_passes_effort(
+        self,
+        mock_file: mock.MagicMock,
+        mock_client_class: mock.MagicMock,
+        mock_options: mock.MagicMock,
+    ) -> None:
+        """_create_client forwards configured effort to the SDK options."""
+        self.config.claude.effort = 'xhigh'
+        claude_instance = claude.Claude(
+            config=self.config, context=self.context
+        )
+
+        claude_instance._create_client()
+
+        self.assertEqual(mock_options.call_args.kwargs['effort'], 'xhigh')
+
     # Note: Removed obsolete _parse_message tests that tested return values.
     # The _parse_message method was refactored to return None and work via
     # side effects.


### PR DESCRIPTION
## Summary

Adds a configurable reasoning effort level for Claude Code SDK operations.

## Problem

The only Claude model knob exposed was `model`. The Claude Agent SDK supports an `effort` option to control the reasoning budget, but there was no way to set it through imbi-automations configuration.

## Solution

- New `[claude] effort` setting (env var `CLAUDE_EFFORT`) accepting `low`, `medium`, `high`, `xhigh`, `max`, defaulting to `high`.
- Forwarded to `ClaudeAgentOptions` for both the custom-tool session and the main agentic client.
- Pydantic `Literal` rejects invalid values.
- Documented in `docs/configuration.md` and `docs/environment-variables.md`.
- Added `test_create_client_passes_effort` verifying the value reaches the SDK options.

### Note on `xhigh`

`xhigh` is forwarded as-is to the `claude` CLI binary (the SDK dataclass does not validate it), so it takes effect only when the installed `claude` executable supports it (Opus 4.7); older CLIs will reject or ignore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)