### PR TITLE
Allow --project-id to be repeated for multiple projects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ uv sync --all-groups --all-extras --frozen && uv run pre-commit install
 # Run CLI
 # Note: Workflow directories must contain workflow.toml
 uv run imbi-automations config.toml workflows/workflow-name --all-projects
-uv run imbi-automations config.toml workflows/workflow-name --project-id proj_8FwQ1aN3
+uv run imbi-automations config.toml workflows/workflow-name --project-id proj_8FwQ1aN3  # repeatable for multiple projects
 uv run imbi-automations config.toml workflows/workflow-name --resume ./errors/workflow/project-timestamp
 
 # Testing & Quality

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,7 +30,7 @@ imbi-automations [-h] [-V] [--debug] [-v]
                  [--dry-run-dir DIR]
                  [--cache-dir DIR]
                  [--start-from-project ID_OR_SLUG]
-                 (--project-id ID |
+                 (--project-id ID [--project-id ID ...] |
                   --project-type SLUG |
                   --all-projects |
                   --github-repository URL |
@@ -88,14 +88,20 @@ workflows/my-workflow/
 
 ### --project-id ID
 
-Process a single Imbi project by ID.
+Process one or more Imbi projects by ID. Repeat the flag to target
+multiple projects in a single run; explicitly listed projects bypass
+the workflow's `[filter]` section (engine conditions still apply).
 
-**Type:** Integer
-**Use Case:** Testing workflows on specific project
+**Type:** Nano-ID string (repeatable)
+**Use Case:** Testing workflows on specific projects
 
 **Example:**
 ```bash
 imbi-automations config.toml workflows/fix-config --project-id 123
+
+# Multiple projects in one run
+imbi-automations config.toml workflows/fix-config \
+  --project-id 123 --project-id 456 --max-concurrency 2
 ```
 
 **Output:**

--- a/src/imbi_automations/cli.py
+++ b/src/imbi_automations/cli.py
@@ -149,9 +149,10 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
     target_group = parser.add_mutually_exclusive_group(required=True)
     target_group.add_argument(
         '--project-id',
+        action='append',
         type=str,
         metavar='ID',
-        help='Process a single project by Nano-ID',
+        help='Process a project by Nano-ID (repeatable for multiple projects)',
     )
     target_group.add_argument(
         '--project-type',

--- a/src/imbi_automations/controller.py
+++ b/src/imbi_automations/controller.py
@@ -444,8 +444,16 @@ class Automation(mixins.WorkflowLoggerMixin):
 
     async def _process_imbi_project(self) -> bool:
         client = clients.Imbi.get_instance(config=self.configuration.imbi)
-        project = await client.get_project(self.args.project_id)
-        return await self._process_workflow_from_imbi_project(project)
+        projects = []
+        for project_id in self.args.project_id:
+            project = await client.get_project(project_id)
+            if project is None:
+                self.logger.error('Project %s not found', project_id)
+                return False
+            projects.append(project)
+        return await self._process_imbi_projects_common(
+            projects, apply_filter=False
+        )
 
     async def _process_imbi_project_type(self) -> bool:
         self._validate_project_type_slug(self.args.project_type)
@@ -461,10 +469,12 @@ class Automation(mixins.WorkflowLoggerMixin):
         return await self._process_imbi_projects_common(projects)
 
     async def _process_imbi_projects_common(
-        self, projects: list[models.ImbiProject]
+        self, projects: list[models.ImbiProject], apply_filter: bool = True
     ) -> bool:
         self.logger.debug('Found %d total active projects', len(projects))
-        filtered = await self._filter_projects(projects)
+        filtered = (
+            await self._filter_projects(projects) if apply_filter else projects
+        )
 
         semaphore = asyncio.Semaphore(self.args.max_concurrency)
 

--- a/src/imbi_automations/controller.py
+++ b/src/imbi_automations/controller.py
@@ -445,7 +445,7 @@ class Automation(mixins.WorkflowLoggerMixin):
     async def _process_imbi_project(self) -> bool:
         client = clients.Imbi.get_instance(config=self.configuration.imbi)
         projects = []
-        for project_id in self.args.project_id:
+        for project_id in dict.fromkeys(self.args.project_id):
             project = await client.get_project(project_id)
             if project is None:
                 self.logger.error('Project %s not found', project_id)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -234,8 +234,23 @@ actions = []
             ]
         )
 
-        self.assertEqual(args.project_id, '123')
+        self.assertEqual(args.project_id, ['123'])
         self.assertIsInstance(args.workflow, models.Workflow)
+
+    def test_parse_args_multiple_project_ids(self) -> None:
+        """Test parsing with --project-id specified multiple times."""
+        args = cli.parse_args(
+            [
+                str(self.config_file),
+                str(self.workflow_dir),
+                '--project-id',
+                '123',
+                '--project-id',
+                '456',
+            ]
+        )
+
+        self.assertEqual(args.project_id, ['123', '456'])
 
     def test_parse_args_project_type(self) -> None:
         """Test parsing with --project-type."""

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -98,7 +98,7 @@ class ControllerInitializationTestCase(base.AsyncTestCase):
             verbose=False,
             resume=None,
             rerun_followup=None,
-            project_id='proj_123',
+            project_id=['proj_123'],
             project_type=None,
             all_projects=False,
             github_repository=None,
@@ -318,7 +318,7 @@ class ControllerSingleProjectTestCase(base.AsyncTestCase):
             verbose=False,
             max_concurrency=5,
             exit_on_error=False,
-            project_id='proj_123',
+            project_id=['proj_123'],
         )
 
         automation = controller.Automation(args, self.config, self.workflow)
@@ -345,7 +345,7 @@ class ControllerSingleProjectTestCase(base.AsyncTestCase):
             verbose=False,
             max_concurrency=5,
             exit_on_error=False,
-            project_id='proj_123',
+            project_id=['proj_123'],
         )
 
         automation = controller.Automation(args, self.config, self.workflow)
@@ -377,7 +377,7 @@ class ControllerSingleProjectTestCase(base.AsyncTestCase):
             verbose=False,
             max_concurrency=5,
             exit_on_error=False,
-            project_id='proj_123',
+            project_id=['proj_123'],
         )
 
         automation = controller.Automation(args, self.config, self.workflow)
@@ -396,6 +396,86 @@ class ControllerSingleProjectTestCase(base.AsyncTestCase):
             result = await automation._process_imbi_project()
 
             self.assertFalse(result)
+
+    async def test_process_imbi_project_multiple_ids(self) -> None:
+        """Test processing multiple projects via repeated --project-id."""
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            project_id=['proj_123', 'proj_456'],
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        project = create_test_project(id=123, slug='test-api', name='Test API')
+
+        self.http_client_side_effect = httpx.Response(
+            200, json=project.model_dump()
+        )
+
+        with mock.patch.object(
+            automation, '_process_workflow_from_imbi_project'
+        ) as mock_process:
+            mock_process.return_value = True
+
+            result = await automation._process_imbi_project()
+
+            self.assertTrue(result)
+            self.assertEqual(mock_process.call_count, 2)
+
+    async def test_process_imbi_project_multiple_ids_bypass_filter(
+        self,
+    ) -> None:
+        """Test explicit project IDs are not subject to workflow filters."""
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            project_id=['proj_123', 'proj_456'],
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        project = create_test_project(id=123, slug='test-api', name='Test API')
+
+        self.http_client_side_effect = httpx.Response(
+            200, json=project.model_dump()
+        )
+
+        with (
+            mock.patch.object(
+                automation, '_process_workflow_from_imbi_project'
+            ) as mock_process,
+            mock.patch.object(automation, '_filter_projects') as mock_filter,
+        ):
+            mock_process.return_value = True
+
+            result = await automation._process_imbi_project()
+
+            self.assertTrue(result)
+            mock_filter.assert_not_called()
+
+    async def test_process_imbi_project_not_found(self) -> None:
+        """Test failure when a specified project ID does not exist."""
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            project_id=['proj_missing'],
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        self.http_client_side_effect = httpx.Response(404)
+
+        with mock.patch.object(
+            automation, '_process_workflow_from_imbi_project'
+        ) as mock_process:
+            result = await automation._process_imbi_project()
+
+            self.assertFalse(result)
+            mock_process.assert_not_called()
 
 
 class ControllerProjectTypeTestCase(base.AsyncTestCase):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -424,6 +424,33 @@ class ControllerSingleProjectTestCase(base.AsyncTestCase):
             self.assertTrue(result)
             self.assertEqual(mock_process.call_count, 2)
 
+    async def test_process_imbi_project_duplicate_ids(self) -> None:
+        """Test duplicate --project-id values are processed once."""
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            project_id=['proj_123', 'proj_123'],
+        )
+
+        automation = controller.Automation(args, self.config, self.workflow)
+
+        project = create_test_project(id=123, slug='test-api', name='Test API')
+
+        self.http_client_side_effect = httpx.Response(
+            200, json=project.model_dump()
+        )
+
+        with mock.patch.object(
+            automation, '_process_workflow_from_imbi_project'
+        ) as mock_process:
+            mock_process.return_value = True
+
+            result = await automation._process_imbi_project()
+
+            self.assertTrue(result)
+            self.assertEqual(mock_process.call_count, 1)
+
     async def test_process_imbi_project_multiple_ids_bypass_filter(
         self,
     ) -> None:


### PR DESCRIPTION
- Change --project-id to an append action accepting multiple IDs
- Explicitly listed projects bypass workflow [filter] section
- Fail fast when a requested project ID is not found
- Update docs and tests for repeatable flag behavior