### PR TITLE
Serialize Claude plugin installation across concurrent projects

### DIFF
--- a/src/imbi_automations/claude.py
+++ b/src/imbi_automations/claude.py
@@ -12,6 +12,7 @@ import os
 import pathlib
 import re
 import typing
+import weakref
 
 import anthropic
 import claude_agent_sdk
@@ -28,8 +29,21 @@ COMMIT = 'commit'
 # Serializes marketplace/plugin installation across concurrently-running
 # Claude instances. They all write to the same shared cache directory, so
 # without this two projects can clone into the same path at once (or read a
-# marketplace mid-clone before its manifest exists).
-_PLUGIN_INSTALL_LOCK = asyncio.Lock()
+# marketplace mid-clone before its manifest exists). Keyed by event loop
+# because an asyncio.Lock binds to the loop it first contends on and raises
+# if a different loop later uses it.
+_PLUGIN_INSTALL_LOCKS: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, asyncio.Lock
+] = weakref.WeakKeyDictionary()
+
+
+def _plugin_install_lock() -> asyncio.Lock:
+    """Return the plugin install lock for the running event loop."""
+    loop = asyncio.get_running_loop()
+    lock = _PLUGIN_INSTALL_LOCKS.get(loop)
+    if lock is None:
+        lock = _PLUGIN_INSTALL_LOCKS[loop] = asyncio.Lock()
+    return lock
 
 
 def _expand_env_vars(value: str) -> str:
@@ -563,7 +577,7 @@ class Claude(mixins.WorkflowLoggerMixin):
 
         LOGGER.debug('Installing Claude marketplaces and plugins')
         plugins_dir = self.configuration.cache_dir / 'claude-plugins'
-        async with _PLUGIN_INSTALL_LOCK:
+        async with _plugin_install_lock():
             if self._plugins_installed:
                 return
             try:

--- a/src/imbi_automations/claude.py
+++ b/src/imbi_automations/claude.py
@@ -25,6 +25,12 @@ LOGGER = logging.getLogger(__name__)
 BASE_PATH = pathlib.Path(__file__).parent
 COMMIT = 'commit'
 
+# Serializes marketplace/plugin installation across concurrently-running
+# Claude instances. They all write to the same shared cache directory, so
+# without this two projects can clone into the same path at once (or read a
+# marketplace mid-clone before its manifest exists).
+_PLUGIN_INSTALL_LOCK = asyncio.Lock()
+
 
 def _expand_env_vars(value: str) -> str:
     """Expand $VAR and ${VAR} patterns in a string.
@@ -557,18 +563,21 @@ class Claude(mixins.WorkflowLoggerMixin):
 
         LOGGER.debug('Installing Claude marketplaces and plugins')
         plugins_dir = self.configuration.cache_dir / 'claude-plugins'
-        try:
-            self._installed_plugin_paths = (
-                await self._install_marketplaces_and_plugins(
-                    self._pending_plugin_config, plugins_dir
+        async with _PLUGIN_INSTALL_LOCK:
+            if self._plugins_installed:
+                return
+            try:
+                self._installed_plugin_paths = (
+                    await self._install_marketplaces_and_plugins(
+                        self._pending_plugin_config, plugins_dir
+                    )
                 )
-            )
-            self._plugins_installed = True
-        except RuntimeError as exc:
-            LOGGER.error(
-                'Failed to install Claude marketplaces/plugins: %s', exc
-            )
-            raise
+                self._plugins_installed = True
+            except RuntimeError as exc:
+                LOGGER.error(
+                    'Failed to install Claude marketplaces/plugins: %s', exc
+                )
+                raise
 
     async def _execute_sdk_query(self, prompt: str) -> AgentResult | None:
         """Execute SDK query and capture tool-based response.

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -578,6 +578,28 @@ class ClaudeTestCase(base.AsyncTestCase):
         for instance in instances:
             self.assertTrue(instance._plugins_installed)
 
+    def test_plugin_install_lock_is_per_event_loop(self) -> None:
+        """Each event loop gets its own lock.
+
+        An asyncio.Lock binds to the loop it first contends on, so a single
+        module-level lock would raise RuntimeError when a second loop (for
+        example another IsolatedAsyncioTestCase) contends on it.
+        """
+
+        async def contend() -> asyncio.Lock:
+            lock = claude._plugin_install_lock()
+
+            async def hold() -> None:
+                async with claude._plugin_install_lock():
+                    await asyncio.sleep(0)
+
+            await asyncio.gather(hold(), hold())
+            return lock
+
+        first = asyncio.run(contend())
+        second = asyncio.run(contend())
+        self.assertIsNot(first, second)
+
     # Note: Removed obsolete _parse_message tests that tested return values.
     # The _parse_message method was refactored to return None and work via
     # side effects.

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1,5 +1,6 @@
 """Comprehensive tests for the claude module."""
 
+import asyncio
 import json
 import pathlib
 import tempfile
@@ -496,6 +497,63 @@ class ClaudeTestCase(base.AsyncTestCase):
         # Client is created lazily on first query, not during init
         self.assertIsNone(claude_instance._client)
         mock_client_class.assert_not_called()
+
+    async def test_ensure_plugins_installed_serialized(self) -> None:
+        """Concurrent installs are serialized by the module-level lock.
+
+        Multiple Claude instances share one cache directory, so the install
+        must not overlap or two projects clone into the same path at once.
+        """
+        plugin_config = models.ClaudePluginConfig(
+            marketplaces={
+                'm': models.ClaudeMarketplace(
+                    source=models.ClaudeMarketplaceSource(
+                        source=models.ClaudeMarketplaceSourceType.directory,
+                        path='/marketplace/m',
+                    )
+                )
+            }
+        )
+
+        active = 0
+        max_active = 0
+
+        async def fake_install(*_args: object, **_kwargs: object) -> list[str]:
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0)
+            active -= 1
+            return []
+
+        instances = []
+        for _ in range(5):
+            with (
+                mock.patch('claude_agent_sdk.ClaudeSDKClient'),
+                mock.patch(
+                    'builtins.open',
+                    new_callable=mock.mock_open,
+                    read_data='Mock system prompt',
+                ),
+            ):
+                instance = claude.Claude(
+                    config=self.config, context=self.context
+                )
+            instance._pending_plugin_config = plugin_config
+            instances.append(instance)
+
+        with mock.patch.object(
+            claude.Claude,
+            '_install_marketplaces_and_plugins',
+            side_effect=fake_install,
+        ):
+            await asyncio.gather(
+                *(i._ensure_plugins_installed() for i in instances)
+            )
+
+        self.assertEqual(max_active, 1)
+        for instance in instances:
+            self.assertTrue(instance._plugins_installed)
 
     # Note: Removed obsolete _parse_message tests that tested return values.
     # The _parse_message method was refactored to return None and work via


### PR DESCRIPTION
## Summary

When running with `--max-concurrency`, multiple projects fail at the start of a run with errors like:

```
Marketplace manifest not found at .../marketplaces/daves-marketplace/.claude-plugin/marketplace.json
Git clone failed (exit code 128): fatal: destination path '.../installed/daves-marketplace/python-projects' already exists and is not an empty directory.
```

After the first project finishes installing the marketplace/plugin, everything works.

## Problem

Each project gets its own `Claude` instance, but they all run concurrently in a single event loop (semaphore-limited in `controller.py`) and install marketplaces/plugins into the **same shared cache directory** (`cache_dir/claude-plugins`). The install operations are idempotent (they skip if already present), but nothing serializes them, so concurrent tasks race:

- One task clones a marketplace while another reads it mid-clone, before `.claude-plugin/marketplace.json` exists → "Marketplace manifest not found".
- Two tasks `git clone` the same plugin into the same path at once → "destination path already exists and is not an empty directory".

## Solution

Guard `_ensure_plugins_installed` with a module-level `asyncio.Lock`. The first project installs while the rest wait; once it completes, the others acquire the lock, find everything already present via the existing filesystem idempotency checks, and skip. No duplicate downloads, no partial-clone races.

## Testing

Added `test_ensure_plugins_installed_serialized`, which runs five concurrent `_ensure_plugins_installed` calls and asserts the install never overlaps (`max_active == 1`). Verified it fails without the lock (`5 != 1`) and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)