### PR TITLE
Implement missing GitHub get_repository_by_url method

### DIFF
--- a/src/imbi_automations/clients/github.py
+++ b/src/imbi_automations/clients/github.py
@@ -96,16 +96,20 @@ class GitHub(http.BaseURLHTTPClient):
             url: GitHub repository URL from an Imbi project link
 
         Returns:
-            GitHubRepository object or None if the URL cannot be parsed
-            or the repository is not found
+            GitHubRepository object or None if the URL cannot be parsed,
+            is not on the configured GitHub host, or the repository is
+            not found
 
         Raises:
             httpx.HTTPError: If API request fails (except 404)
 
         """
-        path = urllib.parse.urlparse(str(url)).path
-        segments = [segment for segment in path.split('/') if segment]
-        if len(segments) < 2:
+        parsed = urllib.parse.urlparse(str(url))
+        segments = [segment for segment in parsed.path.split('/') if segment]
+        if (
+            parsed.hostname != self.configuration.github.host.lower()
+            or len(segments) < 2
+        ):
             LOGGER.warning('Could not parse owner/repo from URL: %s', url)
             return None
         owner, repo = segments[0], segments[1].removesuffix('.git')

--- a/src/imbi_automations/clients/github.py
+++ b/src/imbi_automations/clients/github.py
@@ -104,7 +104,11 @@ class GitHub(http.BaseURLHTTPClient):
             httpx.HTTPError: If API request fails (except 404)
 
         """
-        parsed = urllib.parse.urlparse(str(url))
+        try:
+            parsed = urllib.parse.urlparse(str(url))
+        except ValueError:
+            LOGGER.warning('Could not parse owner/repo from URL: %s', url)
+            return None
         segments = [segment for segment in parsed.path.split('/') if segment]
         if (
             parsed.hostname != self.configuration.github.host.lower()

--- a/src/imbi_automations/clients/github.py
+++ b/src/imbi_automations/clients/github.py
@@ -8,8 +8,10 @@ remote file checking.
 
 import logging
 import typing
+import urllib.parse
 
 import httpx
+import pydantic
 
 from imbi_automations import errors, models
 
@@ -79,8 +81,57 @@ class GitHub(http.BaseURLHTTPClient):
 
         """
         response = await self.get(f'/repositories/{repo_id}')
+        return self._parse_repository_response(response, f'ID {repo_id}')
+
+    async def get_repository_by_url(
+        self, url: pydantic.AnyUrl | str
+    ) -> models.GitHubRepository | None:
+        """Get a repository from an Imbi project link URL.
+
+        Parses the owner and repository name from a GitHub repository URL
+        (e.g. ``https://github.com/org/repo``) and resolves it via the
+        GitHub API.
+
+        Args:
+            url: GitHub repository URL from an Imbi project link
+
+        Returns:
+            GitHubRepository object or None if the URL cannot be parsed
+            or the repository is not found
+
+        Raises:
+            httpx.HTTPError: If API request fails (except 404)
+
+        """
+        path = urllib.parse.urlparse(str(url)).path
+        segments = [segment for segment in path.split('/') if segment]
+        if len(segments) < 2:
+            LOGGER.warning('Could not parse owner/repo from URL: %s', url)
+            return None
+        owner, repo = segments[0], segments[1].removesuffix('.git')
+        response = await self.get(f'/repos/{owner}/{repo}')
+        return self._parse_repository_response(response, f'{owner}/{repo}')
+
+    def _parse_repository_response(
+        self, response: httpx.Response, identifier: str
+    ) -> models.GitHubRepository | None:
+        """Parse a GitHub repository API response into a model.
+
+        Args:
+            response: GitHub API response from a repository lookup
+            identifier: Human-readable repository identifier for logging
+
+        Returns:
+            GitHubRepository object or None if not found
+
+        Raises:
+            errors.GitHubRateLimitError: If the API rate limit is exceeded
+            errors.GitHubNotFoundError: If access to the repository is denied
+            httpx.HTTPError: If API request fails (except 404)
+
+        """
         if response.status_code == http.HTTPStatus.NOT_FOUND:
-            LOGGER.debug('Repository not found for ID %s (404)', repo_id)
+            LOGGER.debug('Repository not found for %s (404)', identifier)
             return None
         elif response.status_code == http.HTTPStatus.FORBIDDEN:
             response_data = response.json() if response.content else {}
@@ -91,17 +142,17 @@ class GitHub(http.BaseURLHTTPClient):
                 raise errors.GitHubRateLimitError(message)
             else:
                 LOGGER.warning(
-                    'Access forbidden for repository ID %s (403): %s',
-                    repo_id,
+                    'Access forbidden for repository %s (403): %s',
+                    identifier,
                     message,
                 )
                 raise errors.GitHubNotFoundError(
-                    f'Access denied for repository ID {repo_id}'
+                    f'Access denied for repository {identifier}'
                 )
         elif not response.is_success:
             LOGGER.error(
-                'GitHub API error for repository ID %s (%s): %s',
-                repo_id,
+                'GitHub API error for repository %s (%s): %s',
+                identifier,
                 response.status_code,
                 response.text,
             )
@@ -111,7 +162,7 @@ class GitHub(http.BaseURLHTTPClient):
             return models.GitHubRepository(**response.json())
         except (httpx.HTTPError, ValueError, KeyError) as exc:
             LOGGER.error(
-                'Failed to parse repository data for ID %s: %s', repo_id, exc
+                'Failed to parse repository data for %s: %s', identifier, exc
             )
             raise
 

--- a/tests/clients/test_github.py
+++ b/tests/clients/test_github.py
@@ -233,6 +233,14 @@ class GitHubRepositoryTestCase(base.AsyncTestCase):
 
         self.assertIsNone(result)
 
+    async def test_get_repository_by_link_invalid_url(self) -> None:
+        """Test a URL that urlparse rejects returns None."""
+        result = await self.client.get_repository_by_url(
+            'https://[github.com/org/test-repo'
+        )
+
+        self.assertIsNone(result)
+
     async def test_get_repository_by_link_wrong_host(self) -> None:
         """Test a link URL on a different host returns None."""
         result = await self.client.get_repository_by_url(

--- a/tests/clients/test_github.py
+++ b/tests/clients/test_github.py
@@ -192,6 +192,47 @@ class GitHubRepositoryTestCase(base.AsyncTestCase):
         self.assertEqual(result.full_name, 'org/test-repo')
         self.assertEqual(result.default_branch, 'main')
 
+    async def test_get_repository_by_link(self) -> None:
+        """Test repository retrieval via project link URL fallback."""
+        project = create_test_project(
+            links={'github-repository': 'https://github.com/org/test-repo'}
+        )
+
+        repo_data = create_github_repo_response_data()
+
+        self.http_client_side_effect = httpx.Response(200, json=repo_data)
+
+        result = await self.client.get_repository(project)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.full_name, 'org/test-repo')
+
+    async def test_get_repository_by_link_strips_git_suffix(self) -> None:
+        """Test repository link URLs with a .git suffix resolve cleanly."""
+        captured: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured['path'] = request.url.path
+            return httpx.Response(200, json=create_github_repo_response_data())
+
+        client = github.GitHub(
+            self.config, transport=httpx.MockTransport(handler)
+        )
+        result = await client.get_repository_by_url(
+            'https://github.com/org/test-repo.git'
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(captured['path'], '/repos/org/test-repo')
+
+    async def test_get_repository_by_link_unparseable(self) -> None:
+        """Test an unparseable link URL returns None."""
+        result = await self.client.get_repository_by_url(
+            'https://github.com/org'
+        )
+
+        self.assertIsNone(result)
+
     async def test_get_repository_no_identifier_or_link(self) -> None:
         """Test retrieval returns None with no identifier or link."""
         project = create_test_project()  # No identifiers or links

--- a/tests/clients/test_github.py
+++ b/tests/clients/test_github.py
@@ -233,6 +233,14 @@ class GitHubRepositoryTestCase(base.AsyncTestCase):
 
         self.assertIsNone(result)
 
+    async def test_get_repository_by_link_wrong_host(self) -> None:
+        """Test a link URL on a different host returns None."""
+        result = await self.client.get_repository_by_url(
+            'https://gitlab.example.com/org/test-repo'
+        )
+
+        self.assertIsNone(result)
+
     async def test_get_repository_no_identifier_or_link(self) -> None:
         """Test retrieval returns None with no identifier or link."""
         project = create_test_project()  # No identifiers or links


### PR DESCRIPTION
## Summary
Implement the missing `GitHub.get_repository_by_url` method so projects without a GitHub identifier can still be resolved via their `github-repository` link.

## Problem
`GitHub.get_repository` falls back to a project's `github-repository` link when no GitHub identifier is present, calling `self.get_repository_by_url(link)`. That method has never existed — it was referenced but never defined in the September 2025 GitHub client refactor. The call fell through `HTTPClient.__getattr__` to the underlying `httpx.AsyncClient`, raising:

```
AttributeError: 'AsyncClient' object has no attribute 'get_repository_by_url'
```

This breaks any run targeting an Imbi project that lacks the GitHub identifier and relies on the link instead (e.g. resolving a project by its `github-repository` URL).

## Solution
- Add `get_repository_by_url`, which parses `owner`/`repo` from a GitHub repository URL (stripping any `.git` suffix) and resolves it via `GET /repos/{owner}/{repo}`. Unparseable URLs log a warning and return `None`.
- Factor the shared response handling out of `_get_repository_by_id` into `_parse_repository_response` (404 → `None`, 403 → rate-limit/forbidden, parse + error logging). No behavior change for the identifier path.

## Impact
Projects resolved via the `github-repository` link now work instead of crashing. No change for projects that use the GitHub identifier. Pure addition plus a non-behavioral refactor.

## Testing
- `uv run pytest` — full suite passes (789 passed).
- Added tests covering the link fallback path, `.git` suffix stripping (asserting the resolved `/repos/{owner}/{repo}` path), and unparseable URLs.
