### PR TITLE
Fix local glob conditions raising on documented URL form

### DIFF
--- a/src/imbi_automations/condition_checker.py
+++ b/src/imbi_automations/condition_checker.py
@@ -280,8 +280,10 @@ class ConditionChecker(mixins.WorkflowLoggerMixin):
             regex matches any file (Pattern)
 
         """
-        # Extract the path component from the ResourceUrl
-        file_str = str(resource_url).split('://', 1)[-1]
+        # Extract the path component from the ResourceUrl, dropping the
+        # leading slash of the scheme:///path form so the glob pattern is
+        # always relative (pathlib rejects absolute glob patterns)
+        file_str = str(resource_url).split('://', 1)[-1].lstrip('/')
 
         if isinstance(file_str, str):
             # Check if it's a glob pattern (contains *, ?, [, or **)
@@ -306,14 +308,15 @@ class ConditionChecker(mixins.WorkflowLoggerMixin):
                 for _ in range(len(parts) - pattern_idx):
                     base_path = base_path.parent
 
-                # Now apply the glob pattern
-                if file_str.startswith('**/'):
+                # Glob only the pattern components; base_path already holds
+                # the literal components before the first glob part
+                pattern = '/'.join(parts[pattern_idx:])
+                if pattern.startswith('**/'):
                     # Recursive glob
-                    pattern = file_str[3:]  # Remove **/ prefix
-                    matches = base_path.rglob(pattern)
+                    matches = base_path.rglob(pattern[3:])
                 else:
                     # Regular glob
-                    matches = base_path.glob(file_str)
+                    matches = base_path.glob(pattern)
 
                 # Return True if any files match the pattern
                 try:

--- a/tests/test_condition_checker.py
+++ b/tests/test_condition_checker.py
@@ -226,6 +226,54 @@ class ConditionCheckerTestCase(base.AsyncTestCase):
 
         self.assertFalse(result)  # .py files exist, so condition fails
 
+    def test_check_glob_pattern_triple_slash_form(self) -> None:
+        """Test file_exists glob with the documented scheme:///path form."""
+        condition = models.WorkflowCondition(
+            file_exists='repository:///**/*.py'
+        )
+
+        result = self.checker.check(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertTrue(result)
+
+    def test_check_glob_pattern_with_literal_prefix(self) -> None:
+        """Test file_exists glob preceded by literal path components."""
+        condition = models.WorkflowCondition(
+            file_exists='repository:///src/**'
+        )
+
+        result = self.checker.check(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertTrue(result)
+
+    def test_check_glob_pattern_with_literal_prefix_failure(self) -> None:
+        """Test file_exists glob with a literal prefix that doesn't exist."""
+        condition = models.WorkflowCondition(
+            file_exists='repository:///k8s/production/**'
+        )
+
+        result = self.checker.check(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertFalse(result)
+
+    def test_check_glob_pattern_with_literal_prefix_two_slash(self) -> None:
+        """Test file_exists glob with literal prefix, scheme://path form."""
+        condition = models.WorkflowCondition(
+            file_exists='repository://src/**/*.py'
+        )
+
+        result = self.checker.check(
+            self.context, models.WorkflowConditionType.all, [condition]
+        )
+
+        self.assertTrue(result)
+
     def test_check_condition_type_any_success(self) -> None:
         """Test condition_type 'any' with mixed conditions."""
         conditions = [


### PR DESCRIPTION
## Summary

Local `file_exists`/`file_not_exists` conditions with glob patterns were broken in both documented forms: the `scheme:///path` form raised `ValueError: Non-relative patterns are unsupported`, and globs preceded by literal path components silently returned `False`.

## Problem

`ConditionChecker._check_file_pattern_exists` extracts the path with `str(resource_url).split('://', 1)[-1]`. For the documented `repository:///k8s/production/**` form this keeps the leading slash, and `pathlib.Path.glob()` rejects absolute patterns — so every workflow using a local glob condition in the documented form errored at action execution:

```
ERROR - airflow error executing action "copy-service-release-workflow": Non-relative patterns are unsupported
```

Separately, `base_path` is computed by stripping the glob suffix components from the resolved path, but the glob was then applied with the *full* pattern string, re-appending the literal prefix. `repository://src/**` looked for `src/src/**` and silently returned `False`. The existing tests only used prefix-free two-slash patterns (`repository://**/*.py`), which dodge both bugs.

## Solution

- Strip the leading slash after splitting off the scheme, so the glob pattern is always relative.
- Glob only the pattern components (`parts[pattern_idx:]`) from `base_path`, which already holds the literal prefix.
- Add regression tests: three-slash form, literal-prefix globs (both URL forms), and a non-matching literal prefix.

790 tests pass; ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)