### PR TITLE
Remove StructuredOutput permission deny rule

### DIFF
--- a/src/imbi_automations/claude.py
+++ b/src/imbi_automations/claude.py
@@ -897,7 +897,6 @@ class Claude(mixins.WorkflowLoggerMixin):
             'hooks': {},
             'outputStyle': 'json',
             'settingSources': ['project', 'local'],
-            'permissions': {'deny': ['StructuredOutput']},
         }
 
         # Add merged plugin configuration


### PR DESCRIPTION
## Summary
Drop the `StructuredOutput` entry from the generated `.claude/settings.json` deny list, which Claude Code no longer recognizes.

## Problem
Every `claude` action run logs:

```
Permission deny rule "StructuredOutput" matches no known tool — check for typos.
```

`StructuredOutput` was a built-in tool in Claude Code CLI 2.0.62. It is gone from the current built-in tool list and was not renamed, structured output now lives entirely in SDK options (`output_format` / `ClaudeAgentOptions`) rather than as a tool an agent can call.

The rule was also already inert. PR #54 added it to keep agents from calling the built-in tool instead of the SDK's `output_format`, but that same PR replaced `output_format` with the `submit_agent_response` MCP tool, so nothing has depended on the deny rule since.

## Solution
Remove the `permissions` key from `settings_config` in `claude.py`. Nothing else referenced the rule, so this is a one-line deletion.

## Impact
No behavior change beyond the warning disappearing from run logs. Agent response submission still goes through `submit_agent_response`.

## Testing
`uv run pytest tests/test_claude.py` passes (50 tests).
