### PR TITLE
Implement the --github-repository CLI target

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -162,12 +162,19 @@ Processing 664 projects...
 
 ### --github-repository URL
 
-Process a single GitHub repository by URL.
+Process the Imbi project whose `github-repository` link points at the
+given repository. The workflow `[filter]` is skipped, as with `--project-id`.
 
 **Type:** URL string
 **Format:** `https://github.com/org/repo` or `org/repo`  
 
-**Use Case:** Target specific GitHub repository
+**Use Case:** Target a project by its repository when you don't know the
+Imbi project ID.
+
+**Matching:** The URL is compared against each project's link
+(configured via `imbi.github_link`) ignoring scheme, case, trailing slash,
+and a `.git` suffix. Bare `org/repo` resolves against `github.host`. The
+run fails if no project links to the repository.
 
 **Example:**
 ```bash
@@ -183,6 +190,10 @@ imbi-automations config.toml workflows/fix-actions \
 ```
 
 ### --github-organization ORG
+
+**Not yet implemented.** The flag is accepted but the run fails with a
+clear error. Use `--project-type` or `--all-projects` with a workflow
+`[filter]` instead.
 
 Process all repositories in a GitHub organization.
 
@@ -205,6 +216,9 @@ Completed: 30/32 successful
 ```
 
 ### --all-github-repositories
+
+**Not yet implemented.** The flag is accepted but the run fails with a
+clear error. Use `--all-projects` instead.
 
 Process all GitHub repositories across all organizations.
 

--- a/src/imbi_automations/clients/imbi.py
+++ b/src/imbi_automations/clients/imbi.py
@@ -12,16 +12,27 @@ import base64
 import datetime
 import json
 import logging
+import re
 import typing
 
 import async_lru
 import httpx
+import pydantic
 
 from imbi_automations import models
 
 from . import http
 
 LOGGER = logging.getLogger(__name__)
+
+URL_SCHEME_PATTERN = re.compile(r'^[a-z][a-z0-9+.-]*://', re.IGNORECASE)
+
+
+def normalize_repository_url(url: str | pydantic.AnyUrl) -> str:
+    """Strip scheme, trailing slash, and ``.git`` and lowercase a URL."""
+    stripped = URL_SCHEME_PATTERN.sub('', str(url).strip())
+    return stripped.rstrip('/').removesuffix('.git').lower()
+
 
 _TOKEN_SKEW = datetime.timedelta(seconds=30)
 
@@ -363,19 +374,21 @@ class Imbi(http.BaseURLHTTPClient):
     ) -> list[models.ImbiProject]:
         """Find projects whose links dict contains ``github_url``.
 
-        Imbi has no server-side search endpoint, so this lists every
-        project in the org and filters client-side. Cost is O(N) per
-        call; cache results in the workflow when scanning many URLs.
+        Comparison ignores scheme, case, trailing slashes, and a ``.git``
+        suffix. Imbi has no server-side search endpoint, so this lists
+        every project in the org and filters client-side. Cost is O(N)
+        per call; cache results in the workflow when scanning many URLs.
         """
-        normalized = github_url.rstrip('/')
+        normalized = normalize_repository_url(github_url)
         projects = await self.get_projects()
-        matches: list[models.ImbiProject] = []
-        for project in projects:
-            for url in project.links.values():
-                if str(url).rstrip('/') == normalized:
-                    matches.append(project)
-                    break
-        return matches
+        return [
+            project
+            for project in projects
+            if any(
+                normalize_repository_url(url) == normalized
+                for url in project.links.values()
+            )
+        ]
 
     # -- Project attribute writes ---------------------------------------
 

--- a/src/imbi_automations/controller.py
+++ b/src/imbi_automations/controller.py
@@ -12,6 +12,7 @@ import datetime
 import enum
 import logging
 import pathlib
+import re
 import shutil
 import tempfile
 
@@ -30,6 +31,32 @@ from imbi_automations import (
 )
 
 LOGGER = logging.getLogger(__name__)
+
+URL_SCHEME_PATTERN = re.compile(r'^[a-z][a-z0-9+.-]*://', re.IGNORECASE)
+
+
+def github_repository_url(value: str, default_host: str) -> str:
+    """Canonicalize a repository reference to ``https://host/owner/repo``.
+
+    Accepts ``https://host/owner/repo``, ``host/owner/repo``, and
+    ``owner/repo``. A trailing ``.git`` is dropped.
+
+    Raises:
+        ValueError: If ``value`` does not contain an owner and repository
+
+    """
+    stripped, has_scheme = URL_SCHEME_PATTERN.subn('', value.strip())
+    segments = [segment for segment in stripped.split('/') if segment]
+    if len(segments) >= 3:
+        host, owner, repo = segments[0], segments[1], segments[2]
+    elif len(segments) == 2 and not has_scheme:
+        host, (owner, repo) = default_host, segments
+    else:
+        raise ValueError(
+            f'Invalid GitHub repository {value!r}: expected '
+            'https://host/owner/repo or owner/repo'
+        )
+    return f'https://{host}/{owner}/{repo.removesuffix(".git")}'
 
 
 class AutomationIterator(enum.Enum):
@@ -436,11 +463,34 @@ class Automation(mixins.WorkflowLoggerMixin):
         client = clients.GitHub.get_instance(config=self.configuration)
         return await client.get_repository(project)
 
-    async def _process_github_repositories(self) -> bool: ...
+    async def _process_github_repositories(self) -> bool:
+        raise RuntimeError('--all-github-repositories is not implemented yet')
 
-    async def _process_github_organization(self) -> bool: ...
+    async def _process_github_organization(self) -> bool:
+        raise RuntimeError('--github-organization is not implemented yet')
 
-    async def _process_github_project(self) -> bool: ...
+    async def _process_github_project(self) -> bool:
+        default_host = (
+            self.configuration.github.host
+            if self.configuration.github
+            else 'github.com'
+        )
+        try:
+            url = github_repository_url(
+                self.args.github_repository, default_host
+            )
+        except ValueError as error:
+            self.logger.error('%s', error)
+            return False
+
+        client = clients.Imbi.get_instance(config=self.configuration.imbi)
+        projects = await client.search_projects_by_github_url(url)
+        if not projects:
+            self.logger.error('No Imbi project links to %s', url)
+            return False
+        return await self._process_imbi_projects_common(
+            projects, apply_filter=False
+        )
 
     async def _process_imbi_project(self) -> bool:
         client = clients.Imbi.get_instance(config=self.configuration.imbi)

--- a/tests/clients/test_imbi.py
+++ b/tests/clients/test_imbi.py
@@ -416,6 +416,30 @@ class ImbiClientReadsTestCase(base.AsyncTestCase):
         )
         self.assertEqual([p.slug for p in result], ['match'])
 
+    async def test_search_projects_by_github_url_normalizes(self) -> None:
+        client, _ = self._client(
+            [
+                _resp(
+                    http.HTTPStatus.OK,
+                    json_body=[
+                        project_payload(
+                            project_id='1',
+                            slug='match',
+                            links={
+                                'github-repository': (
+                                    'https://github.com/Org/Match.git'
+                                )
+                            },
+                        )
+                    ],
+                )
+            ]
+        )
+        result = await client.search_projects_by_github_url(
+            'http://github.com/org/match/'
+        )
+        self.assertEqual([p.slug for p in result], ['match'])
+
     async def test_get_project_schema(self) -> None:
         client, recorder = self._client(
             [

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -505,6 +505,158 @@ class ControllerSingleProjectTestCase(base.AsyncTestCase):
             mock_process.assert_not_called()
 
 
+class GitHubRepositoryUrlTestCase(base.AsyncTestCase):
+    """Test canonicalization of --github-repository values."""
+
+    def test_accepted_formats(self) -> None:
+        expected = 'https://github.com/org/repo'
+        for value in (
+            'https://github.com/org/repo',
+            'https://github.com/org/repo/',
+            'https://github.com/org/repo.git',
+            'github.com/org/repo',
+            'org/repo',
+            ' org/repo ',
+        ):
+            with self.subTest(value=value):
+                self.assertEqual(
+                    controller.github_repository_url(value, 'github.com'),
+                    expected,
+                )
+
+    def test_bare_owner_repo_uses_default_host(self) -> None:
+        self.assertEqual(
+            controller.github_repository_url('org/repo', 'ghe.example.com'),
+            'https://ghe.example.com/org/repo',
+        )
+
+    def test_explicit_host_wins_over_default(self) -> None:
+        self.assertEqual(
+            controller.github_repository_url(
+                'https://github.com/org/repo', 'ghe.example.com'
+            ),
+            'https://github.com/org/repo',
+        )
+
+    def test_invalid_value_raises(self) -> None:
+        for value in ('repo', '', 'https://github.com/org'):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                controller.github_repository_url(value, 'github.com')
+
+
+class ControllerGitHubProjectTestCase(base.AsyncTestCase):
+    """Test --github-repository target processing."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = models.Configuration(
+            github=models.GitHubConfiguration(token='test-token'),
+            imbi=models.ImbiConfiguration(
+                organization='test-org',
+                base_url='https://imbi.test.com',
+                api_key='ik_test',
+            ),
+        )
+        self.instance = clients.Imbi.get_instance(
+            config=self.config.imbi, transport=self.http_client_transport
+        )
+        self.workflow = models.Workflow(
+            path=pathlib.Path('/tmp/workflows/test'),
+            configuration=models.WorkflowConfiguration(
+                name='test-workflow', actions=[]
+            ),
+        )
+        self.projects = [
+            create_test_project(
+                id=1,
+                slug='match',
+                links={'github-repository': 'https://github.com/org/Match'},
+            ),
+            create_test_project(
+                id=2,
+                slug='other',
+                links={'github-repository': 'https://github.com/org/other'},
+            ),
+        ]
+        self.http_client_side_effect = httpx.Response(
+            200,
+            json=[
+                project.model_dump(mode='json') for project in self.projects
+            ],
+        )
+
+    def _automation(self, value: str) -> controller.Automation:
+        args = argparse.Namespace(
+            verbose=False,
+            max_concurrency=5,
+            exit_on_error=False,
+            github_repository=value,
+        )
+        return controller.Automation(args, self.config, self.workflow)
+
+    async def test_iterator(self) -> None:
+        automation = self._automation('org/repo')
+        automation.args.resume = None
+        automation.args.rerun_followup = None
+        automation.args.project_id = None
+        automation.args.project_type = None
+        automation.args.all_projects = False
+        self.assertEqual(
+            automation.iterator, controller.AutomationIterator.github_project
+        )
+
+    async def test_processes_matching_project(self) -> None:
+        automation = self._automation('org/match.git')
+        with mock.patch.object(
+            automation, '_process_workflow_from_imbi_project'
+        ) as mock_process:
+            mock_process.return_value = True
+            result = await automation._process_github_project()
+
+        self.assertTrue(result)
+        mock_process.assert_called_once()
+        self.assertEqual(mock_process.call_args.args[0].slug, 'match')
+
+    async def test_skips_workflow_filter(self) -> None:
+        automation = self._automation('https://github.com/org/match')
+        with (
+            mock.patch.object(automation, '_filter_projects') as mock_filter,
+            mock.patch.object(
+                automation, '_process_workflow_from_imbi_project'
+            ) as mock_process,
+        ):
+            mock_process.return_value = True
+            await automation._process_github_project()
+        mock_filter.assert_not_called()
+
+    async def test_no_matching_project(self) -> None:
+        automation = self._automation('org/missing')
+        with mock.patch.object(
+            automation, '_process_workflow_from_imbi_project'
+        ) as mock_process:
+            result = await automation._process_github_project()
+
+        self.assertFalse(result)
+        mock_process.assert_not_called()
+
+    async def test_invalid_value(self) -> None:
+        automation = self._automation('nonsense')
+        with mock.patch.object(
+            automation, '_process_workflow_from_imbi_project'
+        ) as mock_process:
+            result = await automation._process_github_project()
+
+        self.assertFalse(result)
+        mock_process.assert_not_called()
+
+    async def test_unimplemented_targets_raise(self) -> None:
+        automation = self._automation('org/repo')
+        with self.assertRaises(RuntimeError):
+            await automation._process_github_organization()
+        with self.assertRaises(RuntimeError):
+            await automation._process_github_repositories()
+
+
 class ControllerProjectTypeTestCase(base.AsyncTestCase):
     """Test project type iterator functionality."""
 


### PR DESCRIPTION
## Summary
Implement the `--github-repository` CLI target, which has been an empty stub since the flag was added.

## Problem
`--github-repository URL` is documented and accepted by argparse, but the controller method it routes to (`_process_github_project`) was `...`. The run returned `None`, did nothing, and exited with status 5 and no useful error. PR #138 fixed the GitHub client's link fallback (`get_repository_by_url`), which is easy to confuse with this flag, but the CLI target itself was never implemented. The `--github-organization` and `--all-github-repositories` targets have the same silent-stub behaviour.

## Solution
- `_process_github_project` canonicalizes the argument to `https://host/owner/repo`, finds the Imbi project whose `github-repository` link matches, and runs the workflow through the existing `_process_imbi_projects_common` path with the filter skipped, the same semantics as `--project-id`. No match or an unparseable value logs an error and fails the run.
- Accepted formats match the existing docs: `https://github.com/org/repo`, `github.com/org/repo`, and `org/repo`. Bare `org/repo` resolves against `github.host`. A trailing `.git` is dropped.
- `Imbi.search_projects_by_github_url` now ignores scheme, case, trailing slash, and `.git` when comparing, so formatting differences in the Imbi link still match.
- `--github-organization` and `--all-github-repositories` raise a `RuntimeError` with a clear "not implemented yet" message, which the CLI prints and exits 3, instead of silently returning `None`. Docs mark them as not yet implemented.

## Impact
`--github-repository` works. The other two GitHub targets fail loudly instead of quietly. No change to Imbi-keyed targets or to resume/rerun paths.

## Testing
- `uv run pytest`: 814 passed.
- Added tests for URL canonicalization (all accepted formats, host defaulting, invalid values), the controller path (match, no match, invalid value, filter skipped, iterator selection, unimplemented targets raise), and the client's normalized link matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
